### PR TITLE
Added support for downloaded chapter titles.

### DIFF
--- a/AaxDecrypter/UNTESTED/AAXChapters.cs
+++ b/AaxDecrypter/UNTESTED/AAXChapters.cs
@@ -1,0 +1,40 @@
+﻿using System.Diagnostics;
+using System.Globalization;
+using System.Linq;
+using Dinah.Core.Diagnostics;
+
+namespace AaxDecrypter
+{
+    public class AAXChapters : Chapters
+    {
+        public AAXChapters(string file)
+        {
+            var info = new ProcessStartInfo
+            {
+                FileName = DecryptSupportLibraries.ffprobePath,
+                Arguments = "-loglevel panic -show_chapters -print_format xml \"" + file + "\""
+            };
+            var xml = info.RunHidden().Output;
+
+            var xmlDocument = new System.Xml.XmlDocument();
+            xmlDocument.LoadXml(xml);
+            var chaptersXml = xmlDocument.SelectNodes("/ffprobe/chapters/chapter")
+                .Cast<System.Xml.XmlNode>()
+                .Where(n => n.Name == "chapter");
+
+            foreach (var cnode in chaptersXml)
+            {
+                double startTime = double.Parse(cnode.Attributes["start_time"].Value.Replace(",", "."), CultureInfo.InvariantCulture);
+                double endTime = double.Parse(cnode.Attributes["end_time"].Value.Replace(",", "."), CultureInfo.InvariantCulture);
+
+                string chapterTitle = cnode.ChildNodes
+                    .Cast<System.Xml.XmlNode>()
+                    .Where(childnode => childnode.Attributes["key"].Value == "title")
+                    .Select(childnode => childnode.Attributes["value"].Value)
+                    .FirstOrDefault();
+
+                AddChapter(new Chapter(startTime, endTime, chapterTitle));
+            }
+        }
+    }
+}

--- a/AaxDecrypter/UNTESTED/AaxToM4bConverter.cs
+++ b/AaxDecrypter/UNTESTED/AaxToM4bConverter.cs
@@ -98,7 +98,7 @@ namespace AaxDecrypter
         {
             tags = new Tags(inputFileName);
             encodingInfo = new EncodingInfo(inputFileName);
-            chapters = new Chapters(inputFileName, tags.duration.TotalSeconds);
+            chapters = new AAXChapters(inputFileName);
 
             var defaultFilename = Path.Combine(
                 Path.GetDirectoryName(inputFileName),
@@ -278,9 +278,9 @@ namespace AaxDecrypter
         public bool Step3_Chapterize()
         {
             var str1 = "";
-            if (chapters.FirstChapterStart != 0.0)
+            if (chapters.FirstChapter.StartTime != 0.0)
             {
-                str1 = " -ss " + chapters.FirstChapterStart.ToString("0.000", CultureInfo.InvariantCulture) + " -t " + (chapters.LastChapterStart - 1.0).ToString("0.000", CultureInfo.InvariantCulture) + " ";
+                str1 = " -ss " + chapters.FirstChapter.StartTime.ToString("0.000", CultureInfo.InvariantCulture) + " -t " + chapters.LastChapter.EndTime.ToString("0.000", CultureInfo.InvariantCulture) + " ";
             }
 
             var ffmpegTags = tags.GenerateFfmpegTags();

--- a/AaxDecrypter/UNTESTED/AaxToM4bConverter.cs
+++ b/AaxDecrypter/UNTESTED/AaxToM4bConverter.cs
@@ -62,9 +62,10 @@ namespace AaxDecrypter
         public Tags tags { get; private set; }
         public EncodingInfo encodingInfo { get; private set; }
 
-        public static async Task<AaxToM4bConverter> CreateAsync(string inputFile, string decryptKey)
+        public static async Task<AaxToM4bConverter> CreateAsync(string inputFile, string decryptKey, Chapters chapters = null)
         {
             var converter = new AaxToM4bConverter(inputFile, decryptKey);
+            converter.chapters = chapters ?? new AAXChapters(inputFile);
             await converter.prelimProcessing();
             converter.printPrelim();
 
@@ -98,7 +99,6 @@ namespace AaxDecrypter
         {
             tags = new Tags(inputFileName);
             encodingInfo = new EncodingInfo(inputFileName);
-            chapters = new AAXChapters(inputFileName);
 
             var defaultFilename = Path.Combine(
                 Path.GetDirectoryName(inputFileName),

--- a/AaxDecrypter/UNTESTED/Chapter.cs
+++ b/AaxDecrypter/UNTESTED/Chapter.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace AaxDecrypter
+{
+    public class Chapter
+    {
+        public Chapter(double startTime, double endTime, string title)
+        {
+            StartTime = startTime;
+            EndTime = endTime;
+            Title = title;
+        }
+        /// <summary>
+        /// Chapter start time, in seconds.
+        /// </summary>
+        public double StartTime { get; private set; }
+        /// <summary>
+        /// Chapter end time, in seconds.
+        /// </summary>
+        public double EndTime { get; private set; }
+        public string Title { get; private set; }
+    }
+}

--- a/AaxDecrypter/UNTESTED/Chapters.cs
+++ b/AaxDecrypter/UNTESTED/Chapters.cs
@@ -17,6 +17,10 @@ namespace AaxDecrypter
         {
             _chapterList.Add(chapter);
         }
+        protected void AddChapters(IEnumerable<Chapter> chapters)
+        {
+            _chapterList.AddRange(chapters);
+        }
         public string GenerateFfmpegChapters()
         {
             var stringBuilder = new StringBuilder();

--- a/AaxDecrypter/UNTESTED/Cue.cs
+++ b/AaxDecrypter/UNTESTED/Cue.cs
@@ -14,20 +14,15 @@ namespace AaxDecrypter
 
             stringBuilder.AppendLine(GetFileLine(filePath, "MP3"));
 
-            var beginningTimes = chapters.GetBeginningTimes().ToList();
-            for (var i = 0; i < beginningTimes.Count; i++)
+            var trackCount = 0;
+            foreach (Chapter c in chapters.ChapterList)
             {
-                var chapter = i + 1;
+                trackCount++;
+                var startTime = TimeSpan.FromSeconds(c.StartTime);
 
-                var timeSpan = beginningTimes[i];
-                var minutes = Math.Floor(timeSpan.TotalMinutes).ToString();
-                var seconds = timeSpan.Seconds.ToString("D2");
-                var milliseconds = (timeSpan.Milliseconds / 10).ToString("D2");
-                var time = minutes + ":" + seconds + ":" + milliseconds;
-
-                stringBuilder.AppendLine($"TRACK {chapter} AUDIO");
-                stringBuilder.AppendLine($"  TITLE \"Chapter {chapter:D2}\"");
-                stringBuilder.AppendLine($"  INDEX 01 {time}");
+                stringBuilder.AppendLine($"TRACK {trackCount} AUDIO");
+                stringBuilder.AppendLine($"  TITLE \"{c.Title}\"");
+                stringBuilder.AppendLine($"  INDEX 01 {(int)startTime.TotalMinutes}:{startTime:ss\\:ff}");
             }
 
             return stringBuilder.ToString();

--- a/FileLiberator/UNTESTED/DownloadedChapters.cs
+++ b/FileLiberator/UNTESTED/DownloadedChapters.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Globalization;
+using System.Linq;
+using System.Text;
+using AaxDecrypter;
+using AudibleApiDTOs;
+using Dinah.Core.Diagnostics;
+
+
+namespace FileLiberator
+{
+    public class DownloadedChapters : Chapters
+    {
+        public DownloadedChapters(ChapterInfo chapterInfo)
+        {
+            AddChapters(chapterInfo.Chapters
+                .Select(c => new AaxDecrypter.Chapter(c.StartOffsetMs / 1000d, (c.StartOffsetMs + c.LengthMs) / 1000d, c.Title)));
+        }
+    }
+}

--- a/LibationLauncher/LibationLauncher.csproj
+++ b/LibationLauncher/LibationLauncher.csproj
@@ -13,7 +13,7 @@
     <!-- <PublishSingleFile>true</PublishSingleFile> -->
     <RuntimeIdentifier>win-x64</RuntimeIdentifier>
 
-    <Version>4.2.4.8</Version>
+    <Version>4.2.4.9</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/LibationLauncher/LibationLauncher.csproj
+++ b/LibationLauncher/LibationLauncher.csproj
@@ -13,7 +13,7 @@
     <!-- <PublishSingleFile>true</PublishSingleFile> -->
     <RuntimeIdentifier>win-x64</RuntimeIdentifier>
 
-    <Version>4.2.4.1</Version>
+    <Version>4.2.4.3</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/LibationLauncher/LibationLauncher.csproj
+++ b/LibationLauncher/LibationLauncher.csproj
@@ -13,7 +13,7 @@
     <!-- <PublishSingleFile>true</PublishSingleFile> -->
     <RuntimeIdentifier>win-x64</RuntimeIdentifier>
 
-    <Version>4.2.4.3</Version>
+    <Version>4.2.4.8</Version>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Added support for custom chapters to AaxToM4bConverter.

Chapters is now a base class, and the old Chapters functionality is in AAXChapters which is derived from Chapters. Refactored Chapters so it contains a Chapter list. Chapter has chapter title, start time, and end time.

Added new Chapters derived class, DownloadedChapters, to be used with MetadataDtoV10.ContentMetadata.ChapterInfo (added in my earlier AudibleApi pull request).

Added call to Api in DecryptBook to download chapter metadata and pass DownloadedChapters to AaxToM4bConverter. If call fails, null is passed and AaxToM4bConverter will retrieve chapters from aax file (existing functionality).

Refactored Cue and added support for chapter titles.