### PR TITLE
Added resumable download support to FFMpegAaxcProcessor.

### DIFF
--- a/AaxDecrypter/Chapters.cs
+++ b/AaxDecrypter/Chapters.cs
@@ -15,7 +15,7 @@ namespace AaxDecrypter
         public IEnumerable<Chapter> Chapters => _chapterList.AsEnumerable();
         public int Count => _chapterList.Count;
         public ChapterInfo() { }
-        public ChapterInfo(string audiobookFile) 
+        public ChapterInfo(string audiobookFile)
         {
             var info = new ProcessStartInfo
             {
@@ -27,7 +27,7 @@ namespace AaxDecrypter
             var chapterJObject = JObject.Parse(jString);
             var chapters = chapterJObject["chapters"]
                 .Select(c => new Chapter(
-                    c["tags"]?["title"]?.Value<string>(), 
+                    c["tags"]?["title"]?.Value<string>(),
                     c["start_time"].Value<double>(),
                     c["end_time"].Value<double>()
                     ));
@@ -44,7 +44,7 @@ namespace AaxDecrypter
             var ffmetaChapters = new StringBuilder();
 
             if (includeFFMetaHeader)
-                ffmetaChapters.AppendLine(";FFMETADATA1\n");
+                ffmetaChapters.AppendLine(";FFMETADATA1");
 
             foreach (var c in Chapters)
             {
@@ -66,10 +66,10 @@ namespace AaxDecrypter
 
             Title = title;
             StartOffset = TimeSpan.FromMilliseconds(startOffsetMs);
-            EndOffset = StartOffset +  TimeSpan.FromMilliseconds(lengthMs);
+            EndOffset = StartOffset + TimeSpan.FromMilliseconds(lengthMs);
         }
         public Chapter(string title, double startTimeSec, double endTimeSec)
-            :this(title, (long)(startTimeSec * 1000), (long)((endTimeSec - startTimeSec) * 1000))
+            : this(title, (long)(startTimeSec * 1000), (long)((endTimeSec - startTimeSec) * 1000))
         {
         }
 

--- a/AaxDecrypter/NetworkFileStream.cs
+++ b/AaxDecrypter/NetworkFileStream.cs
@@ -138,6 +138,17 @@ namespace AaxDecrypter
         }
 
         #endregion
+               
+        #region Downloader
+
+        /// <summary>
+        /// Update the <see cref="JsonFilePersister"/>.
+        /// </summary>
+        private void Update()
+        {
+            RequestHeaders = HttpRequest.Headers;
+            Updated?.Invoke(this, new EventArgs());
+        }
 
         /// <summary>
         /// Set a different <see cref="System.Uri"/> to the same file targeted by this instance of <see cref="NetworkFileStream"/>
@@ -160,18 +171,6 @@ namespace AaxDecrypter
             //If NetworkFileStream is resuming, Header will already contain a range.
             HttpRequest.Headers.Remove("Range");
             HttpRequest.AddRange(WritePosition);
-
-        }
-
-        #region Downloader
-
-        /// <summary>
-        /// Update the <see cref="JsonFilePersister"/>.
-        /// </summary>
-        private void Update()
-        {
-            RequestHeaders = HttpRequest.Headers;
-            Updated?.Invoke(this, new EventArgs());
         }
 
         /// <summary>
@@ -392,7 +391,7 @@ namespace AaxDecrypter
             long requiredPosition = Position + toRead;
 
             //read operation will block until file contains enough data
-            //to fulfil the request.
+            //to fulfil the request, or until cancelled.
             while (requiredPosition > WritePosition && !isCancelled)
                 Thread.Sleep(0);
 

--- a/AaxDecrypter/NetworkFileStream.cs
+++ b/AaxDecrypter/NetworkFileStream.cs
@@ -15,13 +15,20 @@ namespace AaxDecrypter
     /// </summary>
     public class SingleUriCookieContainer : CookieContainer
     {
-        public SingleUriCookieContainer(Uri uri)
-        {
-            Uri = uri;
+        private Uri baseAddress;
+        public Uri Uri
+        { 
+            get => baseAddress; 
+            set 
+            { 
+                baseAddress = new UriBuilder(value.Scheme, value.Host).Uri; 
+            } 
         }
-        public Uri Uri { get; }
 
-        public CookieCollection GetCookies() => base.GetCookies(Uri);
+        public CookieCollection GetCookies()
+        {
+            return base.GetCookies(Uri);
+        }
     }
 
     /// <summary>
@@ -43,7 +50,7 @@ namespace AaxDecrypter
         /// Http(s) address of the file to download.
         /// </summary>
         [JsonProperty(Required = Required.Always)]
-        public Uri Uri { get; }
+        public Uri Uri { get; private set; }
 
         /// <summary>
         /// All cookies set by caller or by the remote server.
@@ -73,7 +80,7 @@ namespace AaxDecrypter
 
         #region Private Properties
 
-        private HttpWebRequest HttpRequest { get; }
+        private HttpWebRequest HttpRequest { get; set; }
         private FileStream _writeFile { get; }
         private FileStream _readFile { get; }
         private Stream _networkStream { get; set; }
@@ -118,9 +125,35 @@ namespace AaxDecrypter
             Uri = uri;
             WritePosition = writePosition;
             RequestHeaders = requestHeaders ?? new WebHeaderCollection();
-            CookieContainer = cookies ?? new SingleUriCookieContainer(uri);
+            CookieContainer = cookies ?? new SingleUriCookieContainer { Uri = uri };
+            
+            _writeFile = new FileStream(SaveFilePath, FileMode.OpenOrCreate, FileAccess.Write, FileShare.ReadWrite)
+            {
+                Position = WritePosition
+            };
 
-            HttpRequest = WebRequest.CreateHttp(uri);
+            _readFile = new FileStream(SaveFilePath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
+
+            SetUriForSameFile(uri);
+        }
+
+        #endregion
+
+        /// <summary>
+        /// Set a different <see cref="System.Uri"/> to the same file targeted by this instance of <see cref="NetworkFileStream"/>
+        /// </summary>
+        /// <param name="uriToSameFile">New <see cref="System.Uri"/> host must match existing host.</param>
+        public void SetUriForSameFile(Uri uriToSameFile)
+        {
+            ArgumentValidator.EnsureNotNullOrWhiteSpace(uriToSameFile?.AbsoluteUri, nameof(uriToSameFile));
+
+            if (uriToSameFile.Host != Uri.Host)
+                throw new ArgumentException($"New uri to the same file must have the same host.\r\n Old Host :{Uri.Host}\r\nNew Host: {uriToSameFile.Host}");
+            if (hasBegunDownloading && !finishedDownloading)
+                throw new Exception("Cannot change Uri during a download operation.");
+
+            Uri = uriToSameFile;
+            HttpRequest = WebRequest.CreateHttp(Uri);
 
             HttpRequest.CookieContainer = CookieContainer;
             HttpRequest.Headers = RequestHeaders;
@@ -128,15 +161,7 @@ namespace AaxDecrypter
             HttpRequest.Headers.Remove("Range");
             HttpRequest.AddRange(WritePosition);
 
-            _writeFile = new FileStream(SaveFilePath, FileMode.OpenOrCreate, FileAccess.Write, FileShare.ReadWrite)
-            {
-                Position = WritePosition
-            };
-
-            _readFile = new FileStream(SaveFilePath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
         }
-
-        #endregion
 
         #region Downloader
 
@@ -152,7 +177,7 @@ namespace AaxDecrypter
         /// <summary>
         /// Begins downloading <see cref="Uri"/> to <see cref="SaveFilePath"/> in a background thread.
         /// </summary>
-        public async Task BeginDownloading()
+        private void BeginDownloading()
         {
             if (ContentLength != 0 && WritePosition == ContentLength)
             {
@@ -164,7 +189,7 @@ namespace AaxDecrypter
             if (ContentLength != 0 && WritePosition > ContentLength)
                 throw new Exception($"Specified write position (0x{WritePosition:X10}) is larger than the file size.");
 
-            var response = await HttpRequest.GetResponseAsync() as HttpWebResponse;
+            var response = HttpRequest.GetResponse() as HttpWebResponse;
 
             if (response.StatusCode != HttpStatusCode.PartialContent)
                 throw new Exception($"Server at {Uri.Host} responded with unexpected status code: {response.StatusCode}.");
@@ -249,8 +274,9 @@ namespace AaxDecrypter
             {
                 var jObj = JObject.Load(reader);
 
-                var result = new SingleUriCookieContainer(new Uri(jObj["Uri"].Value<string>()))
+                var result = new SingleUriCookieContainer()
                 {
+                    Uri = new Uri(jObj["Uri"].Value<string>()),
                     Capacity = jObj["Capacity"].Value<int>(),
                     MaxCookieSize = jObj["MaxCookieSize"].Value<int>(),
                     PerDomainCapacity = jObj["PerDomainCapacity"].Value<int>()
@@ -360,7 +386,7 @@ namespace AaxDecrypter
         public override int Read(byte[] buffer, int offset, int count)
         {
             if (!hasBegunDownloading)
-                throw new Exception($"Must call {nameof(BeginDownloading)} before attempting to read {nameof(NetworkFileStream)};");
+                BeginDownloading();
 
             long toRead = Math.Min(count, Length - Position);
             long requiredPosition = Position + toRead;

--- a/FileLiberator/DownloadDecryptBook.cs
+++ b/FileLiberator/DownloadDecryptBook.cs
@@ -38,7 +38,7 @@ namespace FileLiberator
                 if (AudibleFileStorage.Audio.Exists(libraryBook.Book.AudibleProductId))
                     return new StatusHandler { "Cannot find decrypt. Final audio file already exists" };
 
-                var outputAudioFilename = await aaxToM4bConverterDecryptAsync(AudibleFileStorage.DecryptInProgress, libraryBook);
+                var outputAudioFilename = await aaxToM4bConverterDecryptAsync(AudibleFileStorage.DownloadsInProgress, AudibleFileStorage.DecryptInProgress, libraryBook);
 
                 // decrypt failed
                 if (outputAudioFilename is null)
@@ -59,7 +59,7 @@ namespace FileLiberator
             }
         }
 
-        private async Task<string> aaxToM4bConverterDecryptAsync(string destinationDir, LibraryBook libraryBook)
+        private async Task<string> aaxToM4bConverterDecryptAsync(string cacheDir, string destinationDir, LibraryBook libraryBook)
         {
             DecryptBegin?.Invoke(this, $"Begin decrypting {libraryBook}");
 
@@ -92,7 +92,7 @@ namespace FileLiberator
                                 ));
                 }
 
-                aaxcDownloader = AaxcDownloadConverter.Create(destinationDir, aaxcDecryptDlLic);
+                aaxcDownloader = AaxcDownloadConverter.Create(cacheDir, destinationDir, aaxcDecryptDlLic);
 
                 aaxcDownloader.AppName = "Libation";                              
 


### PR DESCRIPTION
FFMpegAaxcProcessor now uses a resumable networkfilestream to decrypt the audiobook. It still decrypts on the fly, but the downloaded aaxc is cached in case the download errors out. This change also seems to have sped up the beginning of the decryption process.