### PR TITLE
Added Mp3 support to AAXClean.

### DIFF
--- a/AaxDecrypter/AaxcDownloadConverter.cs
+++ b/AaxDecrypter/AaxcDownloadConverter.cs
@@ -177,7 +177,7 @@ namespace AaxDecrypter
         {
             OutputFormat format = OutputFormat.Mp4a;
 
-            DecryptProgressUpdate?.Invoke(this, int.MaxValue);
+            DecryptProgressUpdate?.Invoke(this, 0);
 
             if (File.Exists(outputFileName))
                 FileExt.SafeDelete(outputFileName);

--- a/AaxDecrypter/AaxcDownloadConverter.cs
+++ b/AaxDecrypter/AaxcDownloadConverter.cs
@@ -175,7 +175,7 @@ namespace AaxDecrypter
 
         public bool Step3_DownloadAndCombine()
         {
-            OutputFormat format = OutputFormat.Mp3;
+            OutputFormat format = OutputFormat.Mp4a;
 
             DecryptProgressUpdate?.Invoke(this, int.MaxValue);
 

--- a/LibationWinForms/BookLiberation/DecryptForm.cs
+++ b/LibationWinForms/BookLiberation/DecryptForm.cs
@@ -64,14 +64,8 @@ namespace LibationWinForms.BookLiberation
             if (percentage == 0)
                 remainingTimeLbl.UIThread(() => remainingTimeLbl.Text = "ETA:\r\n0 sec");
 
-            if (percentage == int.MaxValue)
-                progressBar1.UIThread(() => progressBar1.Style = ProgressBarStyle.Marquee);
             else
-                progressBar1.UIThread(() =>
-                {
-                    progressBar1.Value = percentage;
-                    progressBar1.Style = ProgressBarStyle.Blocks;
-                });
+                progressBar1.UIThread(() => progressBar1.Value = percentage);
         }
 
         public void UpdateRemainingTime(TimeSpan remaining)


### PR DESCRIPTION
AAXClean can now decrypt directly to mp3 or convert an existing m4b to mp3. Look at the readme and theese changes for usage pattern.

Mp3s are encoded in average bitrate mode, with the target bitrate equal to the input aaxc file's average bitrate. I have no plans to offer customized encoding options, but it wouldn't be that hard to do.

Right now MP3s are one big file. I do plan to add support for splitting the mp3 into single chapter files.