### PR TITLE
Added Convert all M4b to Mp3 action.

### DIFF
--- a/FileLiberator/ConvertToMp3.cs
+++ b/FileLiberator/ConvertToMp3.cs
@@ -1,0 +1,108 @@
+﻿using AAXClean;
+using DataLayer;
+using Dinah.Core.ErrorHandling;
+using Dinah.Core.IO;
+using FileManager;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace FileLiberator
+{
+    public class ConvertToMp3 : IDecryptable
+    {
+
+        private Mp4File m4bBook;
+
+        public event EventHandler<string> DecryptBegin;
+        public event EventHandler<string> TitleDiscovered;
+        public event EventHandler<string> AuthorsDiscovered;
+        public event EventHandler<string> NarratorsDiscovered;
+        public event EventHandler<byte[]> CoverImageFilepathDiscovered;
+        public event EventHandler<int> UpdateProgress;
+        public event EventHandler<TimeSpan> UpdateRemainingTime;
+        public event EventHandler<string> DecryptCompleted;
+        public event EventHandler<LibraryBook> Begin;
+        public event EventHandler<LibraryBook> Completed;
+
+
+        public event EventHandler<string> StatusUpdate;
+        public event EventHandler<Action<byte[]>> RequestCoverArt;
+
+        private string Mp3FileName(LibraryBook libraryBook)
+        {
+            string m4bPath = AudibleFileStorage.Audio.GetPath(libraryBook.Book.AudibleProductId);
+
+            return Path.Combine(Path.GetDirectoryName(m4bPath), Path.GetFileNameWithoutExtension(m4bPath) + ".mp3");
+        }
+        public void Cancel()
+        {
+            m4bBook?.Cancel();
+        }
+
+        public bool Validate(LibraryBook libraryBook) => 
+            AudibleFileStorage.Audio.GetPath(libraryBook.Book.AudibleProductId)?.ToLower()?.EndsWith(".m4b") == true &&
+            !File.Exists(Mp3FileName(libraryBook));
+
+        public async Task<StatusHandler> ProcessAsync(LibraryBook libraryBook)
+        {
+            Begin?.Invoke(this, libraryBook);
+
+            DecryptBegin?.Invoke(this, $"Begin converting {libraryBook} to mp3");
+
+            try
+            {
+                var m4bPath = AudibleFileStorage.Audio.GetPath(libraryBook.Book.AudibleProductId);
+
+                m4bBook = new Mp4File(m4bPath, FileAccess.Read);
+                m4bBook.ConversionProgressUpdate += M4bBook_ConversionProgressUpdate;
+
+                TitleDiscovered?.Invoke(this, m4bBook.AppleTags.Title);
+                AuthorsDiscovered?.Invoke(this, m4bBook.AppleTags.FirstAuthor);
+                NarratorsDiscovered?.Invoke(this, m4bBook.AppleTags.Narrator);
+                CoverImageFilepathDiscovered?.Invoke(this, m4bBook.AppleTags.Cover);
+
+
+                var mp3File = File.OpenWrite(Path.GetTempFileName());
+
+                var result = await Task.Run(() => m4bBook.ConvertToMp3(mp3File));
+                m4bBook.InputStream.Close();
+                mp3File.Close();
+
+                var mp3Path = Mp3FileName(libraryBook);
+
+                FileExt.SafeMove(mp3File.Name, mp3Path);
+
+                var statusHandler = new StatusHandler();
+
+                if (result == ConversionResult.Failed)
+                    statusHandler.AddError("Conversion failed");
+
+                return statusHandler;
+            }
+            finally
+            {
+                DecryptCompleted?.Invoke(this, $"Completed converting to mp3: {libraryBook.Book.Title}");
+                Completed?.Invoke(this, libraryBook);
+            }
+        }
+
+        private void M4bBook_ConversionProgressUpdate(object sender, ConversionProgressEventArgs e)
+        {
+            var duration = m4bBook.Duration;
+            double remainingSecsToProcess = (duration - e.ProcessPosition).TotalSeconds;
+            double estTimeRemaining = remainingSecsToProcess / e.ProcessSpeed;
+
+            if (double.IsNormal(estTimeRemaining))
+                UpdateRemainingTime?.Invoke(this, TimeSpan.FromSeconds(estTimeRemaining));
+
+            double progressPercent = 100 * e.ProcessPosition.TotalSeconds / duration.TotalSeconds;
+
+            UpdateProgress?.Invoke(this, (int)progressPercent);
+        }
+
+    }
+}

--- a/FileLiberator/ConvertToMp3.cs
+++ b/FileLiberator/ConvertToMp3.cs
@@ -4,19 +4,14 @@ using Dinah.Core.ErrorHandling;
 using Dinah.Core.IO;
 using FileManager;
 using System;
-using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Text;
 using System.Threading.Tasks;
 
 namespace FileLiberator
 {
     public class ConvertToMp3 : IDecryptable
     {
-
-        private Mp4File m4bBook;
-
         public event EventHandler<string> DecryptBegin;
         public event EventHandler<string> TitleDiscovered;
         public event EventHandler<string> AuthorsDiscovered;
@@ -28,13 +23,17 @@ namespace FileLiberator
         public event EventHandler<LibraryBook> Begin;
         public event EventHandler<LibraryBook> Completed;
 
-
         public event EventHandler<string> StatusUpdate;
         public event EventHandler<Action<byte[]>> RequestCoverArt;
+
+        private Mp4File m4bBook;
 
         private string Mp3FileName(LibraryBook libraryBook)
         {
             string m4bPath = AudibleFileStorage.Audio.GetPath(libraryBook.Book.AudibleProductId);
+
+            if (m4bPath is null) 
+                return string.Empty;
 
             return Path.Combine(Path.GetDirectoryName(m4bPath), Path.GetFileNameWithoutExtension(m4bPath) + ".mp3");
         }
@@ -64,7 +63,6 @@ namespace FileLiberator
                 AuthorsDiscovered?.Invoke(this, m4bBook.AppleTags.FirstAuthor);
                 NarratorsDiscovered?.Invoke(this, m4bBook.AppleTags.Narrator);
                 CoverImageFilepathDiscovered?.Invoke(this, m4bBook.AppleTags.Cover);
-
 
                 var mp3File = File.OpenWrite(Path.GetTempFileName());
 

--- a/LibationWinForms/BookLiberation/DecryptForm.cs
+++ b/LibationWinForms/BookLiberation/DecryptForm.cs
@@ -13,9 +13,9 @@ namespace LibationWinForms.BookLiberation
         private string authorNames;
         private string narratorNames;
 
-        public void SetTitle(string title)
+        public void SetTitle(string actionName, string title)
         {
-            this.UIThread(() => this.Text = "Decrypting " + title);
+            this.UIThread(() => this.Text = actionName + " " + title);
             this.title = title;
             updateBookInfo();
         }

--- a/LibationWinForms/BookLiberation/ProcessorAutomationController.cs
+++ b/LibationWinForms/BookLiberation/ProcessorAutomationController.cs
@@ -104,6 +104,7 @@ namespace LibationWinForms.BookLiberation
             convertBook.Begin -= decryptBookBegin;
             convertBook.StatusUpdate -= statusUpdate;
             convertBook.Completed -= decryptBookCompleted;
+            convertBook.Completed -= updateLiberatedStatus;
         }
 
         private static BackupBook getWiredUpBackupBook(EventHandler<LibraryBook> completedAction)

--- a/LibationWinForms/BookLiberation/ProcessorAutomationController.cs
+++ b/LibationWinForms/BookLiberation/ProcessorAutomationController.cs
@@ -80,6 +80,32 @@ namespace LibationWinForms.BookLiberation
             unsubscribeEvents();
         }
 
+        public static async Task ConvertAllBooksAsync()
+        {
+            Serilog.Log.Logger.Information("Begin " + nameof(ConvertAllBooksAsync));
+
+            var convertBook = new ConvertToMp3();
+            convertBook.Begin += (_, l) => wireUpEvents(convertBook, l, "Converting");
+            convertBook.Completed += updateLiberatedStatus;
+
+            var automatedBackupsForm = new AutomatedBackupsForm();
+
+            var logMe = LogMe.RegisterForm(automatedBackupsForm);
+
+            void statusUpdate(object _, string str) => logMe.Info("- " + str);
+            void decryptBookBegin(object _, LibraryBook libraryBook) => logMe.Info($"Convert Step, Begin: {libraryBook.Book}");
+            void decryptBookCompleted(object _, LibraryBook libraryBook) => logMe.Info($"Convert Step, Completed: {libraryBook.Book}{Environment.NewLine}");
+            convertBook.Begin += decryptBookBegin;
+            convertBook.StatusUpdate += statusUpdate;
+            convertBook.Completed += decryptBookCompleted;
+
+            await new BackupLoop(logMe, convertBook, automatedBackupsForm).RunBackupAsync();
+
+            convertBook.Begin -= decryptBookBegin;
+            convertBook.StatusUpdate -= statusUpdate;
+            convertBook.Completed -= decryptBookCompleted;
+        }
+
         private static BackupBook getWiredUpBackupBook(EventHandler<LibraryBook> completedAction)
         {
             var backupBook = new BackupBook();
@@ -258,14 +284,14 @@ namespace LibationWinForms.BookLiberation
         }
 
         // subscribed to Begin event because a new form should be created+processed+closed on each iteration
-        private static void wireUpEvents(IDecryptable decryptBook, LibraryBook libraryBook)
+        private static void wireUpEvents(IDecryptable decryptBook, LibraryBook libraryBook, string actionName = "Decrypting")
         {
             #region create form
             var decryptDialog = new DecryptForm();
             #endregion
 
             #region Set initially displayed book properties from library info.
-            decryptDialog.SetTitle(libraryBook.Book.Title);
+            decryptDialog.SetTitle(actionName, libraryBook.Book.Title);
             decryptDialog.SetAuthorNames(string.Join(", ", libraryBook.Book.Authors));
             decryptDialog.SetNarratorNames(string.Join(", ", libraryBook.Book.NarratorNames));
             decryptDialog.SetCoverImage(
@@ -278,7 +304,7 @@ namespace LibationWinForms.BookLiberation
             #region define how model actions will affect form behavior
             void decryptBegin(object _, string __) => decryptDialog.Show();
 
-            void titleDiscovered(object _, string title) => decryptDialog.SetTitle(title);
+            void titleDiscovered(object _, string title) => decryptDialog.SetTitle(actionName, title);
             void authorsDiscovered(object _, string authors) => decryptDialog.SetAuthorNames(authors);
             void narratorsDiscovered(object _, string narrators) => decryptDialog.SetNarratorNames(narrators);
             void coverImageFilepathDiscovered(object _, byte[] coverBytes) => decryptDialog.SetCoverImage(Dinah.Core.Drawing.ImageReader.ToImage(coverBytes));

--- a/LibationWinForms/BookLiberation/ProcessorAutomationController.cs
+++ b/LibationWinForms/BookLiberation/ProcessorAutomationController.cs
@@ -93,17 +93,17 @@ namespace LibationWinForms.BookLiberation
             var logMe = LogMe.RegisterForm(automatedBackupsForm);
 
             void statusUpdate(object _, string str) => logMe.Info("- " + str);
-            void decryptBookBegin(object _, LibraryBook libraryBook) => logMe.Info($"Convert Step, Begin: {libraryBook.Book}");
-            void decryptBookCompleted(object _, LibraryBook libraryBook) => logMe.Info($"Convert Step, Completed: {libraryBook.Book}{Environment.NewLine}");
-            convertBook.Begin += decryptBookBegin;
+            void convertBookBegin(object _, LibraryBook libraryBook) => logMe.Info($"Convert Step, Begin: {libraryBook.Book}");
+            void convertBookCompleted(object _, LibraryBook libraryBook) => logMe.Info($"Convert Step, Completed: {libraryBook.Book}{Environment.NewLine}");
+            convertBook.Begin += convertBookBegin;
             convertBook.StatusUpdate += statusUpdate;
-            convertBook.Completed += decryptBookCompleted;
+            convertBook.Completed += convertBookCompleted;
 
             await new BackupLoop(logMe, convertBook, automatedBackupsForm).RunBackupAsync();
 
-            convertBook.Begin -= decryptBookBegin;
+            convertBook.Begin -= convertBookBegin;
             convertBook.StatusUpdate -= statusUpdate;
-            convertBook.Completed -= decryptBookCompleted;
+            convertBook.Completed -= convertBookCompleted;
             convertBook.Completed -= updateLiberatedStatus;
         }
 

--- a/LibationWinForms/Form1.Designer.cs
+++ b/LibationWinForms/Form1.Designer.cs
@@ -28,302 +28,311 @@
 		/// </summary>
 		private void InitializeComponent()
 		{
-			System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(Form1));
-			this.gridPanel = new System.Windows.Forms.Panel();
-			this.filterHelpBtn = new System.Windows.Forms.Button();
-			this.filterBtn = new System.Windows.Forms.Button();
-			this.filterSearchTb = new System.Windows.Forms.TextBox();
-			this.menuStrip1 = new System.Windows.Forms.MenuStrip();
-			this.importToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.noAccountsYetAddAccountToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.scanLibraryToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.scanLibraryOfAllAccountsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.scanLibraryOfSomeAccountsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.liberateToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.beginBookBackupsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.beginPdfBackupsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.exportToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.exportLibraryToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.quickFiltersToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.firstFilterIsDefaultToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.editQuickFiltersToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.toolStripSeparator1 = new System.Windows.Forms.ToolStripSeparator();
-			this.settingsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.accountsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.basicSettingsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-			this.statusStrip1 = new System.Windows.Forms.StatusStrip();
-			this.visibleCountLbl = new System.Windows.Forms.ToolStripStatusLabel();
-			this.springLbl = new System.Windows.Forms.ToolStripStatusLabel();
-			this.backupsCountsLbl = new System.Windows.Forms.ToolStripStatusLabel();
-			this.pdfsCountsLbl = new System.Windows.Forms.ToolStripStatusLabel();
-			this.addFilterBtn = new System.Windows.Forms.Button();
-			this.menuStrip1.SuspendLayout();
-			this.statusStrip1.SuspendLayout();
-			this.SuspendLayout();
-			// 
-			// gridPanel
-			// 
-			this.gridPanel.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
+            System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(Form1));
+            this.gridPanel = new System.Windows.Forms.Panel();
+            this.filterHelpBtn = new System.Windows.Forms.Button();
+            this.filterBtn = new System.Windows.Forms.Button();
+            this.filterSearchTb = new System.Windows.Forms.TextBox();
+            this.menuStrip1 = new System.Windows.Forms.MenuStrip();
+            this.importToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.noAccountsYetAddAccountToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.scanLibraryToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.scanLibraryOfAllAccountsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.scanLibraryOfSomeAccountsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.liberateToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.beginBookBackupsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.beginPdfBackupsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.exportToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.exportLibraryToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.quickFiltersToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.firstFilterIsDefaultToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.editQuickFiltersToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.toolStripSeparator1 = new System.Windows.Forms.ToolStripSeparator();
+            this.settingsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.accountsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.basicSettingsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.statusStrip1 = new System.Windows.Forms.StatusStrip();
+            this.visibleCountLbl = new System.Windows.Forms.ToolStripStatusLabel();
+            this.springLbl = new System.Windows.Forms.ToolStripStatusLabel();
+            this.backupsCountsLbl = new System.Windows.Forms.ToolStripStatusLabel();
+            this.pdfsCountsLbl = new System.Windows.Forms.ToolStripStatusLabel();
+            this.addFilterBtn = new System.Windows.Forms.Button();
+            this.convertAllM4bToMp3ToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.menuStrip1.SuspendLayout();
+            this.statusStrip1.SuspendLayout();
+            this.SuspendLayout();
+            // 
+            // gridPanel
+            // 
+            this.gridPanel.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
             | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
-			this.gridPanel.Location = new System.Drawing.Point(14, 65);
-			this.gridPanel.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
-			this.gridPanel.Name = "gridPanel";
-			this.gridPanel.Size = new System.Drawing.Size(979, 445);
-			this.gridPanel.TabIndex = 5;
-			// 
-			// filterHelpBtn
-			// 
-			this.filterHelpBtn.Location = new System.Drawing.Point(14, 31);
-			this.filterHelpBtn.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
-			this.filterHelpBtn.Name = "filterHelpBtn";
-			this.filterHelpBtn.Size = new System.Drawing.Size(26, 27);
-			this.filterHelpBtn.TabIndex = 3;
-			this.filterHelpBtn.Text = "?";
-			this.filterHelpBtn.UseVisualStyleBackColor = true;
-			this.filterHelpBtn.Click += new System.EventHandler(this.filterHelpBtn_Click);
-			// 
-			// filterBtn
-			// 
-			this.filterBtn.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
-			this.filterBtn.Location = new System.Drawing.Point(905, 31);
-			this.filterBtn.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
-			this.filterBtn.Name = "filterBtn";
-			this.filterBtn.Size = new System.Drawing.Size(88, 27);
-			this.filterBtn.TabIndex = 2;
-			this.filterBtn.Text = "Filter";
-			this.filterBtn.UseVisualStyleBackColor = true;
-			this.filterBtn.Click += new System.EventHandler(this.filterBtn_Click);
-			// 
-			// filterSearchTb
-			// 
-			this.filterSearchTb.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            this.gridPanel.Location = new System.Drawing.Point(14, 65);
+            this.gridPanel.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            this.gridPanel.Name = "gridPanel";
+            this.gridPanel.Size = new System.Drawing.Size(979, 445);
+            this.gridPanel.TabIndex = 5;
+            // 
+            // filterHelpBtn
+            // 
+            this.filterHelpBtn.Location = new System.Drawing.Point(14, 31);
+            this.filterHelpBtn.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            this.filterHelpBtn.Name = "filterHelpBtn";
+            this.filterHelpBtn.Size = new System.Drawing.Size(26, 27);
+            this.filterHelpBtn.TabIndex = 3;
+            this.filterHelpBtn.Text = "?";
+            this.filterHelpBtn.UseVisualStyleBackColor = true;
+            this.filterHelpBtn.Click += new System.EventHandler(this.filterHelpBtn_Click);
+            // 
+            // filterBtn
+            // 
+            this.filterBtn.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
+            this.filterBtn.Location = new System.Drawing.Point(905, 31);
+            this.filterBtn.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            this.filterBtn.Name = "filterBtn";
+            this.filterBtn.Size = new System.Drawing.Size(88, 27);
+            this.filterBtn.TabIndex = 2;
+            this.filterBtn.Text = "Filter";
+            this.filterBtn.UseVisualStyleBackColor = true;
+            this.filterBtn.Click += new System.EventHandler(this.filterBtn_Click);
+            // 
+            // filterSearchTb
+            // 
+            this.filterSearchTb.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
-			this.filterSearchTb.Location = new System.Drawing.Point(217, 33);
-			this.filterSearchTb.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
-			this.filterSearchTb.Name = "filterSearchTb";
-			this.filterSearchTb.Size = new System.Drawing.Size(681, 23);
-			this.filterSearchTb.TabIndex = 1;
-			this.filterSearchTb.KeyPress += new System.Windows.Forms.KeyPressEventHandler(this.filterSearchTb_KeyPress);
-			// 
-			// menuStrip1
-			// 
-			this.menuStrip1.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.filterSearchTb.Location = new System.Drawing.Point(217, 33);
+            this.filterSearchTb.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            this.filterSearchTb.Name = "filterSearchTb";
+            this.filterSearchTb.Size = new System.Drawing.Size(681, 23);
+            this.filterSearchTb.TabIndex = 1;
+            this.filterSearchTb.KeyPress += new System.Windows.Forms.KeyPressEventHandler(this.filterSearchTb_KeyPress);
+            // 
+            // menuStrip1
+            // 
+            this.menuStrip1.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.importToolStripMenuItem,
             this.liberateToolStripMenuItem,
             this.exportToolStripMenuItem,
             this.quickFiltersToolStripMenuItem,
             this.settingsToolStripMenuItem});
-			this.menuStrip1.Location = new System.Drawing.Point(0, 0);
-			this.menuStrip1.Name = "menuStrip1";
-			this.menuStrip1.Padding = new System.Windows.Forms.Padding(7, 2, 0, 2);
-			this.menuStrip1.Size = new System.Drawing.Size(1007, 24);
-			this.menuStrip1.TabIndex = 0;
-			this.menuStrip1.Text = "menuStrip1";
-			// 
-			// importToolStripMenuItem
-			// 
-			this.importToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.menuStrip1.Location = new System.Drawing.Point(0, 0);
+            this.menuStrip1.Name = "menuStrip1";
+            this.menuStrip1.Padding = new System.Windows.Forms.Padding(7, 2, 0, 2);
+            this.menuStrip1.Size = new System.Drawing.Size(1007, 24);
+            this.menuStrip1.TabIndex = 0;
+            this.menuStrip1.Text = "menuStrip1";
+            // 
+            // importToolStripMenuItem
+            // 
+            this.importToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.noAccountsYetAddAccountToolStripMenuItem,
             this.scanLibraryToolStripMenuItem,
             this.scanLibraryOfAllAccountsToolStripMenuItem,
             this.scanLibraryOfSomeAccountsToolStripMenuItem});
-			this.importToolStripMenuItem.Name = "importToolStripMenuItem";
-			this.importToolStripMenuItem.Size = new System.Drawing.Size(55, 20);
-			this.importToolStripMenuItem.Text = "&Import";
-			// 
-			// noAccountsYetAddAccountToolStripMenuItem
-			// 
-			this.noAccountsYetAddAccountToolStripMenuItem.Name = "noAccountsYetAddAccountToolStripMenuItem";
-			this.noAccountsYetAddAccountToolStripMenuItem.Size = new System.Drawing.Size(247, 22);
-			this.noAccountsYetAddAccountToolStripMenuItem.Text = "No accounts yet. A&dd Account...";
-			this.noAccountsYetAddAccountToolStripMenuItem.Click += new System.EventHandler(this.noAccountsYetAddAccountToolStripMenuItem_Click);
-			// 
-			// scanLibraryToolStripMenuItem
-			// 
-			this.scanLibraryToolStripMenuItem.Name = "scanLibraryToolStripMenuItem";
-			this.scanLibraryToolStripMenuItem.Size = new System.Drawing.Size(247, 22);
-			this.scanLibraryToolStripMenuItem.Text = "Scan &Library";
-			this.scanLibraryToolStripMenuItem.Click += new System.EventHandler(this.scanLibraryToolStripMenuItem_Click);
-			// 
-			// scanLibraryOfAllAccountsToolStripMenuItem
-			// 
-			this.scanLibraryOfAllAccountsToolStripMenuItem.Name = "scanLibraryOfAllAccountsToolStripMenuItem";
-			this.scanLibraryOfAllAccountsToolStripMenuItem.Size = new System.Drawing.Size(247, 22);
-			this.scanLibraryOfAllAccountsToolStripMenuItem.Text = "Scan Library of &All Accounts";
-			this.scanLibraryOfAllAccountsToolStripMenuItem.Click += new System.EventHandler(this.scanLibraryOfAllAccountsToolStripMenuItem_Click);
-			// 
-			// scanLibraryOfSomeAccountsToolStripMenuItem
-			// 
-			this.scanLibraryOfSomeAccountsToolStripMenuItem.Name = "scanLibraryOfSomeAccountsToolStripMenuItem";
-			this.scanLibraryOfSomeAccountsToolStripMenuItem.Size = new System.Drawing.Size(247, 22);
-			this.scanLibraryOfSomeAccountsToolStripMenuItem.Text = "Scan Library of &Some Accounts...";
-			this.scanLibraryOfSomeAccountsToolStripMenuItem.Click += new System.EventHandler(this.scanLibraryOfSomeAccountsToolStripMenuItem_Click);
-			// 
-			// liberateToolStripMenuItem
-			// 
-			this.liberateToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.importToolStripMenuItem.Name = "importToolStripMenuItem";
+            this.importToolStripMenuItem.Size = new System.Drawing.Size(55, 20);
+            this.importToolStripMenuItem.Text = "&Import";
+            // 
+            // noAccountsYetAddAccountToolStripMenuItem
+            // 
+            this.noAccountsYetAddAccountToolStripMenuItem.Name = "noAccountsYetAddAccountToolStripMenuItem";
+            this.noAccountsYetAddAccountToolStripMenuItem.Size = new System.Drawing.Size(247, 22);
+            this.noAccountsYetAddAccountToolStripMenuItem.Text = "No accounts yet. A&dd Account...";
+            this.noAccountsYetAddAccountToolStripMenuItem.Click += new System.EventHandler(this.noAccountsYetAddAccountToolStripMenuItem_Click);
+            // 
+            // scanLibraryToolStripMenuItem
+            // 
+            this.scanLibraryToolStripMenuItem.Name = "scanLibraryToolStripMenuItem";
+            this.scanLibraryToolStripMenuItem.Size = new System.Drawing.Size(247, 22);
+            this.scanLibraryToolStripMenuItem.Text = "Scan &Library";
+            this.scanLibraryToolStripMenuItem.Click += new System.EventHandler(this.scanLibraryToolStripMenuItem_Click);
+            // 
+            // scanLibraryOfAllAccountsToolStripMenuItem
+            // 
+            this.scanLibraryOfAllAccountsToolStripMenuItem.Name = "scanLibraryOfAllAccountsToolStripMenuItem";
+            this.scanLibraryOfAllAccountsToolStripMenuItem.Size = new System.Drawing.Size(247, 22);
+            this.scanLibraryOfAllAccountsToolStripMenuItem.Text = "Scan Library of &All Accounts";
+            this.scanLibraryOfAllAccountsToolStripMenuItem.Click += new System.EventHandler(this.scanLibraryOfAllAccountsToolStripMenuItem_Click);
+            // 
+            // scanLibraryOfSomeAccountsToolStripMenuItem
+            // 
+            this.scanLibraryOfSomeAccountsToolStripMenuItem.Name = "scanLibraryOfSomeAccountsToolStripMenuItem";
+            this.scanLibraryOfSomeAccountsToolStripMenuItem.Size = new System.Drawing.Size(247, 22);
+            this.scanLibraryOfSomeAccountsToolStripMenuItem.Text = "Scan Library of &Some Accounts...";
+            this.scanLibraryOfSomeAccountsToolStripMenuItem.Click += new System.EventHandler(this.scanLibraryOfSomeAccountsToolStripMenuItem_Click);
+            // 
+            // liberateToolStripMenuItem
+            // 
+            this.liberateToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.beginBookBackupsToolStripMenuItem,
-            this.beginPdfBackupsToolStripMenuItem});
-			this.liberateToolStripMenuItem.Name = "liberateToolStripMenuItem";
-			this.liberateToolStripMenuItem.Size = new System.Drawing.Size(61, 20);
-			this.liberateToolStripMenuItem.Text = "&Liberate";
-			// 
-			// beginBookBackupsToolStripMenuItem
-			// 
-			this.beginBookBackupsToolStripMenuItem.Name = "beginBookBackupsToolStripMenuItem";
-			this.beginBookBackupsToolStripMenuItem.Size = new System.Drawing.Size(248, 22);
-			this.beginBookBackupsToolStripMenuItem.Text = "Begin &Book and PDF Backups: {0}";
-			this.beginBookBackupsToolStripMenuItem.Click += new System.EventHandler(this.beginBookBackupsToolStripMenuItem_Click);
-			// 
-			// beginPdfBackupsToolStripMenuItem
-			// 
-			this.beginPdfBackupsToolStripMenuItem.Name = "beginPdfBackupsToolStripMenuItem";
-			this.beginPdfBackupsToolStripMenuItem.Size = new System.Drawing.Size(248, 22);
-			this.beginPdfBackupsToolStripMenuItem.Text = "Begin &PDF Only Backups: {0}";
-			this.beginPdfBackupsToolStripMenuItem.Click += new System.EventHandler(this.beginPdfBackupsToolStripMenuItem_Click);
-			// 
-			// exportToolStripMenuItem
-			// 
-			this.exportToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.beginPdfBackupsToolStripMenuItem,
+            this.convertAllM4bToMp3ToolStripMenuItem});
+            this.liberateToolStripMenuItem.Name = "liberateToolStripMenuItem";
+            this.liberateToolStripMenuItem.Size = new System.Drawing.Size(61, 20);
+            this.liberateToolStripMenuItem.Text = "&Liberate";
+            // 
+            // beginBookBackupsToolStripMenuItem
+            // 
+            this.beginBookBackupsToolStripMenuItem.Name = "beginBookBackupsToolStripMenuItem";
+            this.beginBookBackupsToolStripMenuItem.Size = new System.Drawing.Size(248, 22);
+            this.beginBookBackupsToolStripMenuItem.Text = "Begin &Book and PDF Backups: {0}";
+            this.beginBookBackupsToolStripMenuItem.Click += new System.EventHandler(this.beginBookBackupsToolStripMenuItem_Click);
+            // 
+            // beginPdfBackupsToolStripMenuItem
+            // 
+            this.beginPdfBackupsToolStripMenuItem.Name = "beginPdfBackupsToolStripMenuItem";
+            this.beginPdfBackupsToolStripMenuItem.Size = new System.Drawing.Size(248, 22);
+            this.beginPdfBackupsToolStripMenuItem.Text = "Begin &PDF Only Backups: {0}";
+            this.beginPdfBackupsToolStripMenuItem.Click += new System.EventHandler(this.beginPdfBackupsToolStripMenuItem_Click);
+            // 
+            // exportToolStripMenuItem
+            // 
+            this.exportToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.exportLibraryToolStripMenuItem});
-			this.exportToolStripMenuItem.Name = "exportToolStripMenuItem";
-			this.exportToolStripMenuItem.Size = new System.Drawing.Size(53, 20);
-			this.exportToolStripMenuItem.Text = "E&xport";
-			// 
-			// exportLibraryToolStripMenuItem
-			// 
-			this.exportLibraryToolStripMenuItem.Name = "exportLibraryToolStripMenuItem";
-			this.exportLibraryToolStripMenuItem.Size = new System.Drawing.Size(156, 22);
-			this.exportLibraryToolStripMenuItem.Text = "E&xport Library...";
-			this.exportLibraryToolStripMenuItem.Click += new System.EventHandler(this.exportLibraryToolStripMenuItem_Click);
-			// 
-			// quickFiltersToolStripMenuItem
-			// 
-			this.quickFiltersToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.exportToolStripMenuItem.Name = "exportToolStripMenuItem";
+            this.exportToolStripMenuItem.Size = new System.Drawing.Size(53, 20);
+            this.exportToolStripMenuItem.Text = "E&xport";
+            // 
+            // exportLibraryToolStripMenuItem
+            // 
+            this.exportLibraryToolStripMenuItem.Name = "exportLibraryToolStripMenuItem";
+            this.exportLibraryToolStripMenuItem.Size = new System.Drawing.Size(156, 22);
+            this.exportLibraryToolStripMenuItem.Text = "E&xport Library...";
+            this.exportLibraryToolStripMenuItem.Click += new System.EventHandler(this.exportLibraryToolStripMenuItem_Click);
+            // 
+            // quickFiltersToolStripMenuItem
+            // 
+            this.quickFiltersToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.firstFilterIsDefaultToolStripMenuItem,
             this.editQuickFiltersToolStripMenuItem,
             this.toolStripSeparator1});
-			this.quickFiltersToolStripMenuItem.Name = "quickFiltersToolStripMenuItem";
-			this.quickFiltersToolStripMenuItem.Size = new System.Drawing.Size(84, 20);
-			this.quickFiltersToolStripMenuItem.Text = "Quick &Filters";
-			// 
-			// firstFilterIsDefaultToolStripMenuItem
-			// 
-			this.firstFilterIsDefaultToolStripMenuItem.Name = "firstFilterIsDefaultToolStripMenuItem";
-			this.firstFilterIsDefaultToolStripMenuItem.Size = new System.Drawing.Size(256, 22);
-			this.firstFilterIsDefaultToolStripMenuItem.Text = "Start Libation with 1st filter &Default";
-			this.firstFilterIsDefaultToolStripMenuItem.Click += new System.EventHandler(this.FirstFilterIsDefaultToolStripMenuItem_Click);
-			// 
-			// editQuickFiltersToolStripMenuItem
-			// 
-			this.editQuickFiltersToolStripMenuItem.Name = "editQuickFiltersToolStripMenuItem";
-			this.editQuickFiltersToolStripMenuItem.Size = new System.Drawing.Size(256, 22);
-			this.editQuickFiltersToolStripMenuItem.Text = "&Edit quick filters...";
-			this.editQuickFiltersToolStripMenuItem.Click += new System.EventHandler(this.EditQuickFiltersToolStripMenuItem_Click);
-			// 
-			// toolStripSeparator1
-			// 
-			this.toolStripSeparator1.Name = "toolStripSeparator1";
-			this.toolStripSeparator1.Size = new System.Drawing.Size(253, 6);
-			// 
-			// settingsToolStripMenuItem
-			// 
-			this.settingsToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.quickFiltersToolStripMenuItem.Name = "quickFiltersToolStripMenuItem";
+            this.quickFiltersToolStripMenuItem.Size = new System.Drawing.Size(84, 20);
+            this.quickFiltersToolStripMenuItem.Text = "Quick &Filters";
+            // 
+            // firstFilterIsDefaultToolStripMenuItem
+            // 
+            this.firstFilterIsDefaultToolStripMenuItem.Name = "firstFilterIsDefaultToolStripMenuItem";
+            this.firstFilterIsDefaultToolStripMenuItem.Size = new System.Drawing.Size(256, 22);
+            this.firstFilterIsDefaultToolStripMenuItem.Text = "Start Libation with 1st filter &Default";
+            this.firstFilterIsDefaultToolStripMenuItem.Click += new System.EventHandler(this.FirstFilterIsDefaultToolStripMenuItem_Click);
+            // 
+            // editQuickFiltersToolStripMenuItem
+            // 
+            this.editQuickFiltersToolStripMenuItem.Name = "editQuickFiltersToolStripMenuItem";
+            this.editQuickFiltersToolStripMenuItem.Size = new System.Drawing.Size(256, 22);
+            this.editQuickFiltersToolStripMenuItem.Text = "&Edit quick filters...";
+            this.editQuickFiltersToolStripMenuItem.Click += new System.EventHandler(this.EditQuickFiltersToolStripMenuItem_Click);
+            // 
+            // toolStripSeparator1
+            // 
+            this.toolStripSeparator1.Name = "toolStripSeparator1";
+            this.toolStripSeparator1.Size = new System.Drawing.Size(253, 6);
+            // 
+            // settingsToolStripMenuItem
+            // 
+            this.settingsToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.accountsToolStripMenuItem,
             this.basicSettingsToolStripMenuItem});
-			this.settingsToolStripMenuItem.Name = "settingsToolStripMenuItem";
-			this.settingsToolStripMenuItem.Size = new System.Drawing.Size(61, 20);
-			this.settingsToolStripMenuItem.Text = "&Settings";
-			// 
-			// accountsToolStripMenuItem
-			// 
-			this.accountsToolStripMenuItem.Name = "accountsToolStripMenuItem";
-			this.accountsToolStripMenuItem.Size = new System.Drawing.Size(133, 22);
-			this.accountsToolStripMenuItem.Text = "&Accounts...";
-			this.accountsToolStripMenuItem.Click += new System.EventHandler(this.accountsToolStripMenuItem_Click);
-			// 
-			// basicSettingsToolStripMenuItem
-			// 
-			this.basicSettingsToolStripMenuItem.Name = "basicSettingsToolStripMenuItem";
-			this.basicSettingsToolStripMenuItem.Size = new System.Drawing.Size(133, 22);
-			this.basicSettingsToolStripMenuItem.Text = "&Settings...";
-			this.basicSettingsToolStripMenuItem.Click += new System.EventHandler(this.basicSettingsToolStripMenuItem_Click);
-			// 
-			// statusStrip1
-			// 
-			this.statusStrip1.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.settingsToolStripMenuItem.Name = "settingsToolStripMenuItem";
+            this.settingsToolStripMenuItem.Size = new System.Drawing.Size(61, 20);
+            this.settingsToolStripMenuItem.Text = "&Settings";
+            // 
+            // accountsToolStripMenuItem
+            // 
+            this.accountsToolStripMenuItem.Name = "accountsToolStripMenuItem";
+            this.accountsToolStripMenuItem.Size = new System.Drawing.Size(133, 22);
+            this.accountsToolStripMenuItem.Text = "&Accounts...";
+            this.accountsToolStripMenuItem.Click += new System.EventHandler(this.accountsToolStripMenuItem_Click);
+            // 
+            // basicSettingsToolStripMenuItem
+            // 
+            this.basicSettingsToolStripMenuItem.Name = "basicSettingsToolStripMenuItem";
+            this.basicSettingsToolStripMenuItem.Size = new System.Drawing.Size(133, 22);
+            this.basicSettingsToolStripMenuItem.Text = "&Settings...";
+            this.basicSettingsToolStripMenuItem.Click += new System.EventHandler(this.basicSettingsToolStripMenuItem_Click);
+            // 
+            // statusStrip1
+            // 
+            this.statusStrip1.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.visibleCountLbl,
             this.springLbl,
             this.backupsCountsLbl,
             this.pdfsCountsLbl});
-			this.statusStrip1.Location = new System.Drawing.Point(0, 517);
-			this.statusStrip1.Name = "statusStrip1";
-			this.statusStrip1.Padding = new System.Windows.Forms.Padding(1, 0, 16, 0);
-			this.statusStrip1.Size = new System.Drawing.Size(1007, 22);
-			this.statusStrip1.TabIndex = 6;
-			this.statusStrip1.Text = "statusStrip1";
-			// 
-			// visibleCountLbl
-			// 
-			this.visibleCountLbl.Name = "visibleCountLbl";
-			this.visibleCountLbl.Size = new System.Drawing.Size(61, 17);
-			this.visibleCountLbl.Text = "Visible: {0}";
-			// 
-			// springLbl
-			// 
-			this.springLbl.Name = "springLbl";
-			this.springLbl.Size = new System.Drawing.Size(375, 17);
-			this.springLbl.Spring = true;
-			// 
-			// backupsCountsLbl
-			// 
-			this.backupsCountsLbl.Name = "backupsCountsLbl";
-			this.backupsCountsLbl.Size = new System.Drawing.Size(336, 17);
-			this.backupsCountsLbl.Text = "BACKUPS: No progress: {0}  Encrypted: {1}  Fully backed up: {2}";
-			// 
-			// pdfsCountsLbl
-			// 
-			this.pdfsCountsLbl.Name = "pdfsCountsLbl";
-			this.pdfsCountsLbl.Size = new System.Drawing.Size(218, 17);
-			this.pdfsCountsLbl.Text = "|  PDFs: NOT d/l\'ed: {0}  Downloaded: {1}";
-			// 
-			// addFilterBtn
-			// 
-			this.addFilterBtn.Location = new System.Drawing.Point(47, 31);
-			this.addFilterBtn.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
-			this.addFilterBtn.Name = "addFilterBtn";
-			this.addFilterBtn.Size = new System.Drawing.Size(163, 27);
-			this.addFilterBtn.TabIndex = 4;
-			this.addFilterBtn.Text = "Add To Quick Filters";
-			this.addFilterBtn.UseVisualStyleBackColor = true;
-			this.addFilterBtn.Click += new System.EventHandler(this.AddFilterBtn_Click);
-			// 
-			// Form1
-			// 
-			this.AutoScaleDimensions = new System.Drawing.SizeF(7F, 15F);
-			this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-			this.ClientSize = new System.Drawing.Size(1007, 539);
-			this.Controls.Add(this.filterBtn);
-			this.Controls.Add(this.addFilterBtn);
-			this.Controls.Add(this.filterSearchTb);
-			this.Controls.Add(this.filterHelpBtn);
-			this.Controls.Add(this.statusStrip1);
-			this.Controls.Add(this.gridPanel);
-			this.Controls.Add(this.menuStrip1);
-			this.Icon = ((System.Drawing.Icon)(resources.GetObject("$this.Icon")));
-			this.MainMenuStrip = this.menuStrip1;
-			this.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
-			this.Name = "Form1";
-			this.Text = "Libation: Liberate your Library";
-			this.FormClosing += new System.Windows.Forms.FormClosingEventHandler(this.Form1_FormClosing);
-			this.Load += new System.EventHandler(this.Form1_Load);
-			this.menuStrip1.ResumeLayout(false);
-			this.menuStrip1.PerformLayout();
-			this.statusStrip1.ResumeLayout(false);
-			this.statusStrip1.PerformLayout();
-			this.ResumeLayout(false);
-			this.PerformLayout();
+            this.statusStrip1.Location = new System.Drawing.Point(0, 517);
+            this.statusStrip1.Name = "statusStrip1";
+            this.statusStrip1.Padding = new System.Windows.Forms.Padding(1, 0, 16, 0);
+            this.statusStrip1.Size = new System.Drawing.Size(1007, 22);
+            this.statusStrip1.TabIndex = 6;
+            this.statusStrip1.Text = "statusStrip1";
+            // 
+            // visibleCountLbl
+            // 
+            this.visibleCountLbl.Name = "visibleCountLbl";
+            this.visibleCountLbl.Size = new System.Drawing.Size(61, 17);
+            this.visibleCountLbl.Text = "Visible: {0}";
+            // 
+            // springLbl
+            // 
+            this.springLbl.Name = "springLbl";
+            this.springLbl.Size = new System.Drawing.Size(375, 17);
+            this.springLbl.Spring = true;
+            // 
+            // backupsCountsLbl
+            // 
+            this.backupsCountsLbl.Name = "backupsCountsLbl";
+            this.backupsCountsLbl.Size = new System.Drawing.Size(336, 17);
+            this.backupsCountsLbl.Text = "BACKUPS: No progress: {0}  Encrypted: {1}  Fully backed up: {2}";
+            // 
+            // pdfsCountsLbl
+            // 
+            this.pdfsCountsLbl.Name = "pdfsCountsLbl";
+            this.pdfsCountsLbl.Size = new System.Drawing.Size(218, 17);
+            this.pdfsCountsLbl.Text = "|  PDFs: NOT d/l\'ed: {0}  Downloaded: {1}";
+            // 
+            // addFilterBtn
+            // 
+            this.addFilterBtn.Location = new System.Drawing.Point(47, 31);
+            this.addFilterBtn.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            this.addFilterBtn.Name = "addFilterBtn";
+            this.addFilterBtn.Size = new System.Drawing.Size(163, 27);
+            this.addFilterBtn.TabIndex = 4;
+            this.addFilterBtn.Text = "Add To Quick Filters";
+            this.addFilterBtn.UseVisualStyleBackColor = true;
+            this.addFilterBtn.Click += new System.EventHandler(this.AddFilterBtn_Click);
+            // 
+            // convertAllM4bToMp3ToolStripMenuItem
+            // 
+            this.convertAllM4bToMp3ToolStripMenuItem.Name = "convertAllM4bToMp3ToolStripMenuItem";
+            this.convertAllM4bToMp3ToolStripMenuItem.Size = new System.Drawing.Size(248, 22);
+            this.convertAllM4bToMp3ToolStripMenuItem.Text = "Convert all M4b to Mp3";
+            this.convertAllM4bToMp3ToolStripMenuItem.Click += new System.EventHandler(this.convertAllM4bToMp3ToolStripMenuItem_Click);
+            // 
+            // Form1
+            // 
+            this.AutoScaleDimensions = new System.Drawing.SizeF(7F, 15F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.ClientSize = new System.Drawing.Size(1007, 539);
+            this.Controls.Add(this.filterBtn);
+            this.Controls.Add(this.addFilterBtn);
+            this.Controls.Add(this.filterSearchTb);
+            this.Controls.Add(this.filterHelpBtn);
+            this.Controls.Add(this.statusStrip1);
+            this.Controls.Add(this.gridPanel);
+            this.Controls.Add(this.menuStrip1);
+            this.Icon = ((System.Drawing.Icon)(resources.GetObject("$this.Icon")));
+            this.MainMenuStrip = this.menuStrip1;
+            this.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            this.Name = "Form1";
+            this.Text = "Libation: Liberate your Library";
+            this.FormClosing += new System.Windows.Forms.FormClosingEventHandler(this.Form1_FormClosing);
+            this.Load += new System.EventHandler(this.Form1_Load);
+            this.menuStrip1.ResumeLayout(false);
+            this.menuStrip1.PerformLayout();
+            this.statusStrip1.ResumeLayout(false);
+            this.statusStrip1.PerformLayout();
+            this.ResumeLayout(false);
+            this.PerformLayout();
 
 		}
 
@@ -357,5 +366,6 @@
 		private System.Windows.Forms.ToolStripMenuItem noAccountsYetAddAccountToolStripMenuItem;
 		private System.Windows.Forms.ToolStripMenuItem exportToolStripMenuItem;
 		private System.Windows.Forms.ToolStripMenuItem exportLibraryToolStripMenuItem;
-	}
+        private System.Windows.Forms.ToolStripMenuItem convertAllM4bToMp3ToolStripMenuItem;
+    }
 }

--- a/LibationWinForms/Form1.cs
+++ b/LibationWinForms/Form1.cs
@@ -390,6 +390,9 @@ namespace LibationWinForms
         private async void beginPdfBackupsToolStripMenuItem_Click(object sender, EventArgs e)
             => await BookLiberation.ProcessorAutomationController.BackupAllPdfsAsync(updateGridRow);
 
+        private async void convertAllM4bToMp3ToolStripMenuItem_Click(object sender, EventArgs e)
+            => await BookLiberation.ProcessorAutomationController.ConvertAllBooksAsync();
+
         private void updateGridRow(object _, LibraryBook libraryBook) => currProductsGrid.RefreshRow(libraryBook.Book.AudibleProductId);
         #endregion
 
@@ -483,6 +486,6 @@ namespace LibationWinForms
         private void accountsToolStripMenuItem_Click(object sender, EventArgs e) => new AccountsDialog(this).ShowDialog();
 
         private void basicSettingsToolStripMenuItem_Click(object sender, EventArgs e) => new SettingsDialog().ShowDialog();
-		#endregion
-	}
+        #endregion
+    }
 }


### PR DESCRIPTION
The "Liberate" tool strip menu now contains "Convert all M4b to Mp3". It uses the existing decryption infrastructure and is a minor change.  The only issue is how it integrates with the storage system, which is in flux right now.  Until you get that sorted, you may want to remove the tool menu entry in release builds.

One more thing, while making this I discovered that the m4b files made by AAXClean had an error in them.  It's nothing major and almost certainly wouldn't cause users any problems, but technically the files were incorrect. Depending how how fragilethe media player/editor is, it could cause a player crash at the end of the file. This error was introduced in [this commit](https://github.com/Mbucari/AAXClean/commit/11b4ff67ff2983d515539943f3d05096d21e680a) and was fixed [here](https://github.com/Mbucari/AAXClean/commit/bfaa450529ce97d62a1fbd3c0953a9a55a35b442).