### PR TITLE
Fixed race condition.

### DIFF
--- a/FileLiberator/DownloadDecryptBook.cs
+++ b/FileLiberator/DownloadDecryptBook.cs
@@ -170,6 +170,8 @@ namespace FileLiberator
                 File.Move(f.FullName, dest);
             }
 
+            AudibleFileStorage.Audio.Refresh();
+
             return destinationDir;
         }
 

--- a/FileManager/AudibleFileStorage.cs
+++ b/FileManager/AudibleFileStorage.cs
@@ -57,6 +57,11 @@ namespace FileManager
 			extAggr = extensions_noDots.Aggregate((a, b) => $"{a}|{b}");
         }
 
+        public void Refresh()
+        {
+            BookDirectoryFiles.RefreshFiles();
+        }
+
         /// <summary>
         /// Example for full books:
         /// Search recursively in _books directory. Full book exists if either are true


### PR DESCRIPTION
After moving files from the temp folder into the library, there was a chance that FileSystemWatcher wouldn't fire before Libation checked to see that the new file was there.