### PR TITLE
Minor fix and changes for form size and location persistance.

### DIFF
--- a/ApplicationServices/LibraryCommands.cs
+++ b/ApplicationServices/LibraryCommands.cs
@@ -18,6 +18,8 @@ namespace ApplicationServices
 
 		public static async Task<List<LibraryBook>> FindInactiveBooks(Func<Account, ILoginCallback> loginCallbackFactoryFunc, List<LibraryBook> existingLibrary, params Account[] accounts)
 		{
+			logRestart();
+
 			//These are the minimum response groups required for the
 			//library scanner to pass all validation and filtering.
 			LibraryResponseGroups =
@@ -30,8 +32,12 @@ namespace ApplicationServices
 
 			try
 			{
+				logTime($"pre {nameof(scanAccountsAsync)} all");
 				var libraryItems = await scanAccountsAsync(loginCallbackFactoryFunc, accounts);
-				Log.Logger.Information($"GetAllLibraryItems: Total count {libraryItems.Count}");
+				logTime($"post {nameof(scanAccountsAsync)} all");
+
+				var totalCount = libraryItems.Count;
+				Log.Logger.Information($"GetAllLibraryItems: Total count {totalCount}");
 
 				var missingBookList = existingLibrary.Where(b => !libraryItems.Any(i => i.DtoItem.Asin == b.Book.AudibleProductId)).ToList();
 
@@ -57,12 +63,14 @@ namespace ApplicationServices
 			}
 			catch (Exception ex)
 			{
-				Log.Logger.Error(ex, "Error importing library");
+				Log.Logger.Error(ex, "Error scanning library");
 				throw;
 			}
 			finally
 			{
 				LibraryResponseGroups = LibraryOptions.ResponseGroupOptions.ALL_OPTIONS;
+				stop();
+				var putBreakPointHere = logOutput;
 			}
 		}
 

--- a/FileManager/Configuration.cs
+++ b/FileManager/Configuration.cs
@@ -46,6 +46,7 @@ namespace FileManager
 
         private PersistentDictionary persistentDictionary;
 
+        public T GetNonString<T>(string propertyName) => persistentDictionary.GetNonString<T>(propertyName);
         public object GetObject(string propertyName) => persistentDictionary.GetObject(propertyName);
         public void SetObject(string propertyName, object newValue) => persistentDictionary.SetNonString(propertyName, newValue);
 
@@ -67,39 +68,7 @@ namespace FileManager
             return attribute?.Description;
         }
 
-        public bool Exists(string propertyName) => persistentDictionary.Exists(propertyName);
-
-        #region MainForm: X, Y, Width, Height, MainFormIsMaximized
-        public int MainFormX
-        {
-            get => persistentDictionary.GetNonString<int>(nameof(MainFormX));
-            set => persistentDictionary.SetNonString(nameof(MainFormX), value);
-        }
-
-        public int MainFormY
-        {
-            get => persistentDictionary.GetNonString<int>(nameof(MainFormY));
-            set => persistentDictionary.SetNonString(nameof(MainFormY), value);
-        }
-
-        public int MainFormWidth
-        {
-            get => persistentDictionary.GetNonString<int>(nameof(MainFormWidth));
-            set => persistentDictionary.SetNonString(nameof(MainFormWidth), value);
-        }
-
-        public int MainFormHeight
-        {
-            get => persistentDictionary.GetNonString<int>(nameof(MainFormHeight));
-            set => persistentDictionary.SetNonString(nameof(MainFormHeight), value);
-        }
-
-        public bool MainFormIsMaximized
-        {
-            get => persistentDictionary.GetNonString<bool>(nameof(MainFormIsMaximized));
-            set => persistentDictionary.SetNonString(nameof(MainFormIsMaximized), value);
-        }
-        #endregion
+        public bool Exists(string propertyName) => persistentDictionary.Exists(propertyName);       
 
         [Description("Location for book storage. Includes destination of newly liberated books")]
         public string Books

--- a/FileManager/PersistentDictionary.cs
+++ b/FileManager/PersistentDictionary.cs
@@ -51,7 +51,8 @@ namespace FileManager
         {
             var obj = GetObject(propertyName);
             if (obj is null) return default;
-            if (obj is JToken jToken) return jToken.Value<T>();
+            if (obj is JValue jValue) return jValue.Value<T>();
+            if (obj is JObject jObject)  return jObject.ToObject<T>();
             return (T)obj;
         }
 

--- a/LibationWinForms/BookLiberation/AudioConvertForm.cs
+++ b/LibationWinForms/BookLiberation/AudioConvertForm.cs
@@ -1,10 +1,17 @@
 ﻿using DataLayer;
+using FileManager;
 using System;
 
 namespace LibationWinForms.BookLiberation
 {
 	class AudioConvertForm : AudioDecodeForm
 	{
+		public AudioConvertForm()
+		{
+			this.Load += (_, _) => this.RestoreSizeAndLocation(Configuration.Instance);
+			this.FormClosing += (_, _) => this.SaveSizeAndLocation(Configuration.Instance);
+		}
+
 		#region AudioDecodeForm overrides
 		public override string DecodeActionName => "Converting";
 		#endregion

--- a/LibationWinForms/BookLiberation/AudioDecryptForm.cs
+++ b/LibationWinForms/BookLiberation/AudioDecryptForm.cs
@@ -1,10 +1,17 @@
 ﻿using DataLayer;
+using FileManager;
 using System;
 
 namespace LibationWinForms.BookLiberation
 {
 	class AudioDecryptForm : AudioDecodeForm
 	{
+		public AudioDecryptForm()
+		{
+			this.Load += (_, _) => this.RestoreSizeAndLocation(Configuration.Instance);
+			this.FormClosing += (_, _) => this.SaveSizeAndLocation(Configuration.Instance);
+		}
+
 		#region AudioDecodeForm overrides
 		public override string DecodeActionName => "Decrypting";
 		#endregion

--- a/LibationWinForms/Dialogs/RemoveBooksDialog.Designer.cs
+++ b/LibationWinForms/Dialogs/RemoveBooksDialog.Designer.cs
@@ -29,147 +29,147 @@ namespace LibationWinForms.Dialogs
         /// </summary>
         private void InitializeComponent()
         {
-            this.components = new System.ComponentModel.Container();
-            System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle2 = new System.Windows.Forms.DataGridViewCellStyle();
-            this._dataGridView = new System.Windows.Forms.DataGridView();
-            this.removeDataGridViewCheckBoxColumn = new System.Windows.Forms.DataGridViewCheckBoxColumn();
-            this.coverDataGridViewImageColumn = new System.Windows.Forms.DataGridViewImageColumn();
-            this.titleDataGridViewTextBoxColumn = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            this.authorsDataGridViewTextBoxColumn = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            this.miscDataGridViewTextBoxColumn = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            this.purchaseDateGridViewTextBoxColumn = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            this.gridEntryBindingSource = new System.Windows.Forms.BindingSource(this.components);
-            this.btnRemoveBooks = new System.Windows.Forms.Button();
-            this.label1 = new System.Windows.Forms.Label();
-            ((System.ComponentModel.ISupportInitialize)(this._dataGridView)).BeginInit();
-            ((System.ComponentModel.ISupportInitialize)(this.gridEntryBindingSource)).BeginInit();
-            this.SuspendLayout();
-            // 
-            // _dataGridView
-            // 
-            this._dataGridView.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
+			this.components = new System.ComponentModel.Container();
+			System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle1 = new System.Windows.Forms.DataGridViewCellStyle();
+			this._dataGridView = new System.Windows.Forms.DataGridView();
+			this.removeDataGridViewCheckBoxColumn = new System.Windows.Forms.DataGridViewCheckBoxColumn();
+			this.coverDataGridViewImageColumn = new System.Windows.Forms.DataGridViewImageColumn();
+			this.titleDataGridViewTextBoxColumn = new System.Windows.Forms.DataGridViewTextBoxColumn();
+			this.authorsDataGridViewTextBoxColumn = new System.Windows.Forms.DataGridViewTextBoxColumn();
+			this.miscDataGridViewTextBoxColumn = new System.Windows.Forms.DataGridViewTextBoxColumn();
+			this.purchaseDateGridViewTextBoxColumn = new System.Windows.Forms.DataGridViewTextBoxColumn();
+			this.gridEntryBindingSource = new System.Windows.Forms.BindingSource(this.components);
+			this.btnRemoveBooks = new System.Windows.Forms.Button();
+			this.label1 = new System.Windows.Forms.Label();
+			((System.ComponentModel.ISupportInitialize)(this._dataGridView)).BeginInit();
+			((System.ComponentModel.ISupportInitialize)(this.gridEntryBindingSource)).BeginInit();
+			this.SuspendLayout();
+			// 
+			// _dataGridView
+			// 
+			this._dataGridView.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
             | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
-            this._dataGridView.AutoGenerateColumns = false;
-            this._dataGridView.ColumnHeadersHeightSizeMode = System.Windows.Forms.DataGridViewColumnHeadersHeightSizeMode.AutoSize;
-            this._dataGridView.Columns.AddRange(new System.Windows.Forms.DataGridViewColumn[] {
+			this._dataGridView.AutoGenerateColumns = false;
+			this._dataGridView.ColumnHeadersHeightSizeMode = System.Windows.Forms.DataGridViewColumnHeadersHeightSizeMode.AutoSize;
+			this._dataGridView.Columns.AddRange(new System.Windows.Forms.DataGridViewColumn[] {
             this.removeDataGridViewCheckBoxColumn,
             this.coverDataGridViewImageColumn,
             this.titleDataGridViewTextBoxColumn,
             this.authorsDataGridViewTextBoxColumn,
             this.miscDataGridViewTextBoxColumn,
             this.purchaseDateGridViewTextBoxColumn});
-            this._dataGridView.DataSource = this.gridEntryBindingSource;
-            dataGridViewCellStyle2.Alignment = System.Windows.Forms.DataGridViewContentAlignment.MiddleLeft;
-            dataGridViewCellStyle2.BackColor = System.Drawing.SystemColors.Window;
-            dataGridViewCellStyle2.Font = new System.Drawing.Font("Segoe UI", 9F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point);
-            dataGridViewCellStyle2.ForeColor = System.Drawing.SystemColors.ControlText;
-            dataGridViewCellStyle2.SelectionBackColor = System.Drawing.SystemColors.Highlight;
-            dataGridViewCellStyle2.SelectionForeColor = System.Drawing.SystemColors.HighlightText;
-            dataGridViewCellStyle2.WrapMode = System.Windows.Forms.DataGridViewTriState.True;
-            this._dataGridView.DefaultCellStyle = dataGridViewCellStyle2;
-            this._dataGridView.Location = new System.Drawing.Point(0, 0);
-            this._dataGridView.Name = "_dataGridView";
-            this._dataGridView.RowHeadersVisible = false;
-            this._dataGridView.RowTemplate.Height = 82;
-            this._dataGridView.Size = new System.Drawing.Size(800, 409);
-            this._dataGridView.TabIndex = 0;
-            // 
-            // removeDataGridViewCheckBoxColumn
-            // 
-            this.removeDataGridViewCheckBoxColumn.DataPropertyName = "Remove";
-            this.removeDataGridViewCheckBoxColumn.FalseValue = "False";
-            this.removeDataGridViewCheckBoxColumn.Frozen = true;
-            this.removeDataGridViewCheckBoxColumn.HeaderText = "Remove";
-            this.removeDataGridViewCheckBoxColumn.MinimumWidth = 60;
-            this.removeDataGridViewCheckBoxColumn.Name = "removeDataGridViewCheckBoxColumn";
-            this.removeDataGridViewCheckBoxColumn.Resizable = System.Windows.Forms.DataGridViewTriState.False;
-            this.removeDataGridViewCheckBoxColumn.SortMode = System.Windows.Forms.DataGridViewColumnSortMode.Automatic;
-            this.removeDataGridViewCheckBoxColumn.TrueValue = "True";
-            this.removeDataGridViewCheckBoxColumn.Width = 60;
-            // 
-            // coverDataGridViewImageColumn
-            // 
-            this.coverDataGridViewImageColumn.DataPropertyName = "Cover";
-            this.coverDataGridViewImageColumn.HeaderText = "Cover";
-            this.coverDataGridViewImageColumn.MinimumWidth = 80;
-            this.coverDataGridViewImageColumn.Name = "coverDataGridViewImageColumn";
-            this.coverDataGridViewImageColumn.ReadOnly = true;
-            this.coverDataGridViewImageColumn.Resizable = System.Windows.Forms.DataGridViewTriState.False;
-            this.coverDataGridViewImageColumn.Width = 80;
-            // 
-            // titleDataGridViewTextBoxColumn
-            // 
-            this.titleDataGridViewTextBoxColumn.DataPropertyName = "Title";
-            this.titleDataGridViewTextBoxColumn.HeaderText = "Title";
-            this.titleDataGridViewTextBoxColumn.Name = "titleDataGridViewTextBoxColumn";
-            this.titleDataGridViewTextBoxColumn.ReadOnly = true;
-            this.titleDataGridViewTextBoxColumn.Width = 200;
-            // 
-            // authorsDataGridViewTextBoxColumn
-            // 
-            this.authorsDataGridViewTextBoxColumn.DataPropertyName = "Authors";
-            this.authorsDataGridViewTextBoxColumn.HeaderText = "Authors";
-            this.authorsDataGridViewTextBoxColumn.Name = "authorsDataGridViewTextBoxColumn";
-            this.authorsDataGridViewTextBoxColumn.ReadOnly = true;
-            // 
-            // miscDataGridViewTextBoxColumn
-            // 
-            this.miscDataGridViewTextBoxColumn.DataPropertyName = "Misc";
-            this.miscDataGridViewTextBoxColumn.HeaderText = "Misc";
-            this.miscDataGridViewTextBoxColumn.Name = "miscDataGridViewTextBoxColumn";
-            this.miscDataGridViewTextBoxColumn.ReadOnly = true;
-            this.miscDataGridViewTextBoxColumn.Width = 150;
-            // 
-            // purchaseDateGridViewTextBoxColumn
-            // 
-            this.purchaseDateGridViewTextBoxColumn.DataPropertyName = "PurchaseDate";
-            this.purchaseDateGridViewTextBoxColumn.HeaderText = "Purchase Date";
-            this.purchaseDateGridViewTextBoxColumn.Name = "purchaseDateGridViewTextBoxColumn";
-            this.purchaseDateGridViewTextBoxColumn.ReadOnly = true;
-            this.purchaseDateGridViewTextBoxColumn.Resizable = System.Windows.Forms.DataGridViewTriState.False;
-            // 
-            // gridEntryBindingSource
-            // 
-            this.gridEntryBindingSource.AllowNew = false;
-            this.gridEntryBindingSource.DataSource = typeof(LibationWinForms.Dialogs.RemovableGridEntry);
-            // 
-            // btnRemoveBooks
-            // 
-            this.btnRemoveBooks.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
-            this.btnRemoveBooks.Location = new System.Drawing.Point(570, 419);
-            this.btnRemoveBooks.Name = "btnRemoveBooks";
-            this.btnRemoveBooks.Size = new System.Drawing.Size(218, 23);
-            this.btnRemoveBooks.TabIndex = 1;
-            this.btnRemoveBooks.Text = "Remove Selected Books from Libation";
-            this.btnRemoveBooks.UseVisualStyleBackColor = true;
-            this.btnRemoveBooks.Click += new System.EventHandler(this.btnRemoveBooks_Click);
-            // 
-            // label1
-            // 
-            this.label1.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
-            this.label1.AutoSize = true;
-            this.label1.Location = new System.Drawing.Point(12, 423);
-            this.label1.Name = "label1";
-            this.label1.Size = new System.Drawing.Size(178, 15);
-            this.label1.TabIndex = 2;
-            this.label1.Text = "{0} book{1} selected for removal.";
-            // 
-            // RemoveBooksDialog
-            // 
-            this.AutoScaleDimensions = new System.Drawing.SizeF(7F, 15F);
-            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.ClientSize = new System.Drawing.Size(800, 450);
-            this.Controls.Add(this.label1);
-            this.Controls.Add(this.btnRemoveBooks);
-            this.Controls.Add(this._dataGridView);
-            this.Name = "RemoveBooksDialog";
-            this.Text = "RemoveBooksDialog";
-            this.Shown += new System.EventHandler(this.RemoveBooksDialog_Shown);
-            ((System.ComponentModel.ISupportInitialize)(this._dataGridView)).EndInit();
-            ((System.ComponentModel.ISupportInitialize)(this.gridEntryBindingSource)).EndInit();
-            this.ResumeLayout(false);
-            this.PerformLayout();
+			this._dataGridView.DataSource = this.gridEntryBindingSource;
+			dataGridViewCellStyle1.Alignment = System.Windows.Forms.DataGridViewContentAlignment.MiddleLeft;
+			dataGridViewCellStyle1.BackColor = System.Drawing.SystemColors.Window;
+			dataGridViewCellStyle1.Font = new System.Drawing.Font("Segoe UI", 9F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point);
+			dataGridViewCellStyle1.ForeColor = System.Drawing.SystemColors.ControlText;
+			dataGridViewCellStyle1.SelectionBackColor = System.Drawing.SystemColors.Highlight;
+			dataGridViewCellStyle1.SelectionForeColor = System.Drawing.SystemColors.HighlightText;
+			dataGridViewCellStyle1.WrapMode = System.Windows.Forms.DataGridViewTriState.True;
+			this._dataGridView.DefaultCellStyle = dataGridViewCellStyle1;
+			this._dataGridView.Location = new System.Drawing.Point(0, 0);
+			this._dataGridView.Name = "_dataGridView";
+			this._dataGridView.RowHeadersVisible = false;
+			this._dataGridView.RowTemplate.Height = 82;
+			this._dataGridView.Size = new System.Drawing.Size(730, 409);
+			this._dataGridView.TabIndex = 0;
+			// 
+			// removeDataGridViewCheckBoxColumn
+			// 
+			this.removeDataGridViewCheckBoxColumn.DataPropertyName = "Remove";
+			this.removeDataGridViewCheckBoxColumn.FalseValue = "False";
+			this.removeDataGridViewCheckBoxColumn.Frozen = true;
+			this.removeDataGridViewCheckBoxColumn.HeaderText = "Remove";
+			this.removeDataGridViewCheckBoxColumn.MinimumWidth = 80;
+			this.removeDataGridViewCheckBoxColumn.Name = "removeDataGridViewCheckBoxColumn";
+			this.removeDataGridViewCheckBoxColumn.Resizable = System.Windows.Forms.DataGridViewTriState.False;
+			this.removeDataGridViewCheckBoxColumn.SortMode = System.Windows.Forms.DataGridViewColumnSortMode.Automatic;
+			this.removeDataGridViewCheckBoxColumn.TrueValue = "True";
+			this.removeDataGridViewCheckBoxColumn.Width = 80;
+			// 
+			// coverDataGridViewImageColumn
+			// 
+			this.coverDataGridViewImageColumn.DataPropertyName = "Cover";
+			this.coverDataGridViewImageColumn.HeaderText = "Cover";
+			this.coverDataGridViewImageColumn.MinimumWidth = 80;
+			this.coverDataGridViewImageColumn.Name = "coverDataGridViewImageColumn";
+			this.coverDataGridViewImageColumn.ReadOnly = true;
+			this.coverDataGridViewImageColumn.Resizable = System.Windows.Forms.DataGridViewTriState.False;
+			this.coverDataGridViewImageColumn.Width = 80;
+			// 
+			// titleDataGridViewTextBoxColumn
+			// 
+			this.titleDataGridViewTextBoxColumn.DataPropertyName = "Title";
+			this.titleDataGridViewTextBoxColumn.HeaderText = "Title";
+			this.titleDataGridViewTextBoxColumn.Name = "titleDataGridViewTextBoxColumn";
+			this.titleDataGridViewTextBoxColumn.ReadOnly = true;
+			this.titleDataGridViewTextBoxColumn.Width = 200;
+			// 
+			// authorsDataGridViewTextBoxColumn
+			// 
+			this.authorsDataGridViewTextBoxColumn.DataPropertyName = "Authors";
+			this.authorsDataGridViewTextBoxColumn.HeaderText = "Authors";
+			this.authorsDataGridViewTextBoxColumn.Name = "authorsDataGridViewTextBoxColumn";
+			this.authorsDataGridViewTextBoxColumn.ReadOnly = true;
+			// 
+			// miscDataGridViewTextBoxColumn
+			// 
+			this.miscDataGridViewTextBoxColumn.DataPropertyName = "Misc";
+			this.miscDataGridViewTextBoxColumn.HeaderText = "Misc";
+			this.miscDataGridViewTextBoxColumn.Name = "miscDataGridViewTextBoxColumn";
+			this.miscDataGridViewTextBoxColumn.ReadOnly = true;
+			this.miscDataGridViewTextBoxColumn.Width = 150;
+			// 
+			// purchaseDateGridViewTextBoxColumn
+			// 
+			this.purchaseDateGridViewTextBoxColumn.DataPropertyName = "PurchaseDate";
+			this.purchaseDateGridViewTextBoxColumn.HeaderText = "Purchase Date";
+			this.purchaseDateGridViewTextBoxColumn.Name = "purchaseDateGridViewTextBoxColumn";
+			this.purchaseDateGridViewTextBoxColumn.ReadOnly = true;
+			this.purchaseDateGridViewTextBoxColumn.Resizable = System.Windows.Forms.DataGridViewTriState.False;
+			// 
+			// gridEntryBindingSource
+			// 
+			this.gridEntryBindingSource.AllowNew = false;
+			this.gridEntryBindingSource.DataSource = typeof(LibationWinForms.Dialogs.RemovableGridEntry);
+			// 
+			// btnRemoveBooks
+			// 
+			this.btnRemoveBooks.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
+			this.btnRemoveBooks.Location = new System.Drawing.Point(500, 419);
+			this.btnRemoveBooks.Name = "btnRemoveBooks";
+			this.btnRemoveBooks.Size = new System.Drawing.Size(218, 23);
+			this.btnRemoveBooks.TabIndex = 1;
+			this.btnRemoveBooks.Text = "Remove Selected Books from Libation";
+			this.btnRemoveBooks.UseVisualStyleBackColor = true;
+			this.btnRemoveBooks.Click += new System.EventHandler(this.btnRemoveBooks_Click);
+			// 
+			// label1
+			// 
+			this.label1.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
+			this.label1.AutoSize = true;
+			this.label1.Location = new System.Drawing.Point(12, 423);
+			this.label1.Name = "label1";
+			this.label1.Size = new System.Drawing.Size(178, 15);
+			this.label1.TabIndex = 2;
+			this.label1.Text = "{0} book{1} selected for removal.";
+			// 
+			// RemoveBooksDialog
+			// 
+			this.AutoScaleDimensions = new System.Drawing.SizeF(7F, 15F);
+			this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+			this.ClientSize = new System.Drawing.Size(730, 450);
+			this.Controls.Add(this.label1);
+			this.Controls.Add(this.btnRemoveBooks);
+			this.Controls.Add(this._dataGridView);
+			this.Name = "RemoveBooksDialog";
+			this.Text = "RemoveBooksDialog";
+			this.Shown += new System.EventHandler(this.RemoveBooksDialog_Shown);
+			((System.ComponentModel.ISupportInitialize)(this._dataGridView)).EndInit();
+			((System.ComponentModel.ISupportInitialize)(this.gridEntryBindingSource)).EndInit();
+			this.ResumeLayout(false);
+			this.PerformLayout();
 
         }
 
@@ -179,11 +179,11 @@ namespace LibationWinForms.Dialogs
         private System.Windows.Forms.BindingSource gridEntryBindingSource;
         private System.Windows.Forms.Button btnRemoveBooks;
         private System.Windows.Forms.Label label1;
-        private System.Windows.Forms.DataGridViewCheckBoxColumn removeDataGridViewCheckBoxColumn;
-        private System.Windows.Forms.DataGridViewImageColumn coverDataGridViewImageColumn;
-        private System.Windows.Forms.DataGridViewTextBoxColumn titleDataGridViewTextBoxColumn;
-        private System.Windows.Forms.DataGridViewTextBoxColumn authorsDataGridViewTextBoxColumn;
-        private System.Windows.Forms.DataGridViewTextBoxColumn miscDataGridViewTextBoxColumn;
-        private System.Windows.Forms.DataGridViewTextBoxColumn purchaseDateGridViewTextBoxColumn;
-    }
+		private System.Windows.Forms.DataGridViewCheckBoxColumn removeDataGridViewCheckBoxColumn;
+		private System.Windows.Forms.DataGridViewImageColumn coverDataGridViewImageColumn;
+		private System.Windows.Forms.DataGridViewTextBoxColumn titleDataGridViewTextBoxColumn;
+		private System.Windows.Forms.DataGridViewTextBoxColumn authorsDataGridViewTextBoxColumn;
+		private System.Windows.Forms.DataGridViewTextBoxColumn miscDataGridViewTextBoxColumn;
+		private System.Windows.Forms.DataGridViewTextBoxColumn purchaseDateGridViewTextBoxColumn;
+	}
 }

--- a/LibationWinForms/Dialogs/RemoveBooksDialog.cs
+++ b/LibationWinForms/Dialogs/RemoveBooksDialog.cs
@@ -1,6 +1,7 @@
 ﻿using ApplicationServices;
 using DataLayer;
 using Dinah.Core.DataBinding;
+using FileManager;
 using InternalUtilities;
 using LibationWinForms.Login;
 using System;
@@ -28,6 +29,10 @@ namespace LibationWinForms.Dialogs
 			_accounts = accounts;
 
 			InitializeComponent();
+
+			this.Load += (_, _) => this.RestoreSizeAndLocation(Configuration.Instance);
+			this.FormClosing += (_, _) => this.SaveSizeAndLocation(Configuration.Instance);
+
 			_labelFormat = label1.Text;
 
 			_dataGridView.CellContentClick += (_, _) => _dataGridView.CommitEdit(DataGridViewDataErrorContexts.Commit);

--- a/LibationWinForms/Dialogs/RemoveBooksDialog.resx
+++ b/LibationWinForms/Dialogs/RemoveBooksDialog.resx
@@ -1,5 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<root> 
+﻿<root>
   <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
     <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
     <xsd:element name="root" msdata:IsDataSet="true">
@@ -58,4 +57,7 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=5.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
+  <metadata name="gridEntryBindingSource.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>17, 17</value>
+  </metadata>
 </root>

--- a/LibationWinForms/Form1.Designer.cs
+++ b/LibationWinForms/Form1.Designer.cs
@@ -353,7 +353,6 @@
 			this.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
 			this.Name = "Form1";
 			this.Text = "Libation: Liberate your Library";
-			this.FormClosing += new System.Windows.Forms.FormClosingEventHandler(this.Form1_FormClosing);
 			this.Load += new System.EventHandler(this.Form1_Load);
 			this.menuStrip1.ResumeLayout(false);
 			this.menuStrip1.PerformLayout();

--- a/LibationWinForms/Form1.cs
+++ b/LibationWinForms/Form1.cs
@@ -29,8 +29,9 @@ namespace LibationWinForms
 				return;
 
 			// independent UI updates
-			this.Load += restoreSizeAndLocation;
+			this.Load += (_, _) => this.RestoreSizeAndLocation(Configuration.Instance);
 			this.Load += RefreshImportMenu;
+			this.FormClosing += (_, _) => this.SaveSizeAndLocation(Configuration.Instance);
 			LibraryCommands.LibrarySizeChanged += reloadGridAndUpdateBottomNumbers;
 			LibraryCommands.BookUserDefinedItemCommitted += setBackupCounts;
 
@@ -51,81 +52,6 @@ namespace LibationWinForms
 
 			// also applies filter. ONLY call AFTER loading grid
 			loadInitialQuickFilterState();
-		}
-
-		private void Form1_FormClosing(object sender, FormClosingEventArgs e)
-		{
-			SaveSizeAndLocation();
-		}
-
-		private void restoreSizeAndLocation(object _ = null, object __ = null)
-		{
-			var config = Configuration.Instance;
-
-			var width = config.MainFormWidth;
-			var height = config.MainFormHeight;
-
-			// too small -- something must have gone wrong. use defaults
-			if (width < 25 || height < 25)
-			{
-				width = 1023;
-				height = 578;
-			}
-
-			// Fit to the current screen size in case the screen resolution changed since the size was last persisted
-			if (width > Screen.PrimaryScreen.WorkingArea.Width)
-				width = Screen.PrimaryScreen.WorkingArea.Width;
-			if (height > Screen.PrimaryScreen.WorkingArea.Height)
-				height = Screen.PrimaryScreen.WorkingArea.Height;
-
-			var x = config.MainFormX;
-			var y = config.MainFormY;
-
-			var rect = new System.Drawing.Rectangle(x, y, width, height);
-
-			// is proposed rect on a screen?
-			if (Screen.AllScreens.Any(screen => screen.WorkingArea.Contains(rect)))
-			{
-				this.StartPosition = FormStartPosition.Manual;
-				this.DesktopBounds = rect;
-			}
-			else
-			{
-				this.StartPosition = FormStartPosition.WindowsDefaultLocation;
-				this.Size = rect.Size;
-			}
-
-			// FINAL: for Maximized: start normal state, set size and location, THEN set max state
-			this.WindowState = config.MainFormIsMaximized ? FormWindowState.Maximized : FormWindowState.Normal;
-		}
-
-		private void SaveSizeAndLocation()
-		{
-			System.Drawing.Point location;
-			System.Drawing.Size size;
-
-			// save location and size if the state is normal
-			if (this.WindowState == FormWindowState.Normal)
-			{
-				location = this.Location;
-				size = this.Size;
-			}
-			else
-			{
-				// save the RestoreBounds if the form is minimized or maximized
-				location = this.RestoreBounds.Location;
-				size = this.RestoreBounds.Size;
-			}
-
-			var config = Configuration.Instance;
-
-			config.MainFormX = location.X;
-			config.MainFormY = location.Y;
-
-			config.MainFormWidth = size.Width;
-			config.MainFormHeight = size.Height;
-
-			config.MainFormIsMaximized = this.WindowState == FormWindowState.Maximized;
 		}
 
 		private void reloadGridAndUpdateBottomNumbers(object _ = null, object __ = null)

--- a/LibationWinForms/FormSaveExtension.cs
+++ b/LibationWinForms/FormSaveExtension.cs
@@ -1,0 +1,89 @@
+﻿using FileManager;
+using System.Drawing;
+using System.Linq;
+using System.Windows.Forms;
+
+namespace LibationWinForms
+{
+	public static class FormSaveExtension
+	{
+		public static void RestoreSizeAndLocation(this Form form, Configuration config)
+		{
+			FormSizeAndPosition savedState = config.GetNonString<FormSizeAndPosition>(form.Name);
+
+			if (savedState is null)
+				return;
+
+			// too small -- something must have gone wrong. use defaults
+			if (savedState.Width < 25 || savedState.Height < 25)
+			{
+				savedState.Width = form.Width;
+				savedState.Height = form.Height;
+			}
+
+			// Fit to the current screen size in case the screen resolution changed since the size was last persisted
+			if (savedState.Width > Screen.PrimaryScreen.WorkingArea.Width)
+				savedState.Width = Screen.PrimaryScreen.WorkingArea.Width;
+			if (savedState.Height > Screen.PrimaryScreen.WorkingArea.Height)
+				savedState.Height = Screen.PrimaryScreen.WorkingArea.Height;
+
+			var x = savedState.X;
+			var y = savedState.Y;
+
+			var rect = new Rectangle(x, y, savedState.Width, savedState.Height);
+
+			// is proposed rect on a screen?
+			if (Screen.AllScreens.Any(screen => screen.WorkingArea.Contains(rect)))
+			{
+				form.StartPosition = FormStartPosition.Manual;
+				form.DesktopBounds = rect;
+			}
+			else
+			{
+				form.StartPosition = FormStartPosition.WindowsDefaultLocation;
+				form.Size = rect.Size;
+			}
+
+			// FINAL: for Maximized: start normal state, set size and location, THEN set max state
+			form.WindowState = savedState.IsMaximized ? FormWindowState.Maximized : FormWindowState.Normal;
+		}
+
+		public static void SaveSizeAndLocation(this Form form, Configuration config)
+		{
+			Point location;
+			Size size;
+			var saveState = new FormSizeAndPosition();
+
+			// save location and size if the state is normal
+			if (form.WindowState == FormWindowState.Normal)
+			{
+				location = form.Location;
+				size = form.Size;
+			}
+			else
+			{
+				// save the RestoreBounds if the form is minimized or maximized
+				location = form.RestoreBounds.Location;
+				size = form.RestoreBounds.Size;
+			}
+
+			saveState.X = location.X;
+			saveState.Y = location.Y;
+
+			saveState.Width = size.Width;
+			saveState.Height = size.Height;
+
+			saveState.IsMaximized = form.WindowState == FormWindowState.Maximized;
+
+			config.SetObject(form.Name, saveState);
+		}
+	}
+	class FormSizeAndPosition
+	{
+		public int X;
+		public int Y;
+		public int Height;
+		public int Width;
+		public bool IsMaximized;
+	}
+}


### PR DESCRIPTION
- FindInactiveBooks now calls the new logRestart method.
- Adjusted RemoveBooksDialog's default form size and widened the Remove column so you can see the sort arrow.
-  Added Form extension methods RestoreSizeAndLocation and SaveSizeAndLocation.
- RemoveBooksDialog, AudioConvertForm  and AudioDecryptForm now save their sizes and positions.