### PR TITLE
Fix splitting audiobooks on chapters

### DIFF
--- a/FileLiberator/Processable.cs
+++ b/FileLiberator/Processable.cs
@@ -24,13 +24,13 @@ namespace FileLiberator
         public abstract Task<StatusHandler> ProcessAsync(LibraryBook libraryBook);
 
         // when used in foreach: stateful. deferred execution
-        protected IEnumerable<LibraryBook> GetValidLibraryBooks(IEnumerable<LibraryBook> library)
+        public IEnumerable<LibraryBook> GetValidLibraryBooks(IEnumerable<LibraryBook> library)
             => library.Where(libraryBook =>
                 Validate(libraryBook)
                 && (libraryBook.Book.ContentType != ContentType.Episode || FileManager.Configuration.Instance.DownloadEpisodes)
                 );
 
-        protected async Task<StatusHandler> ProcessSingleAsync(LibraryBook libraryBook, bool validate)
+        public async Task<StatusHandler> ProcessSingleAsync(LibraryBook libraryBook, bool validate)
         {
             if (validate && !Validate(libraryBook))
                 return new StatusHandler { "Validation failed" };
@@ -50,7 +50,7 @@ namespace FileLiberator
             return status;
         }
 
-        protected async Task<StatusHandler> TryProcessAsync(LibraryBook libraryBook)
+        public async Task<StatusHandler> TryProcessAsync(LibraryBook libraryBook)
             => Validate(libraryBook)
             ? await ProcessAsync(libraryBook)
             : new StatusHandler();

--- a/LibationWinForms/Dialogs/SettingsDialog.cs
+++ b/LibationWinForms/Dialogs/SettingsDialog.cs
@@ -84,10 +84,12 @@ namespace LibationWinForms.Dialogs
 		{
 			convertLosslessRb.Enabled = allowLibationFixupCbox.Checked;
 			convertLossyRb.Enabled = allowLibationFixupCbox.Checked;
+			splitFilesByChapterCbox.Enabled = allowLibationFixupCbox.Checked;
 
 			if (!allowLibationFixupCbox.Checked)
 			{
 				convertLosslessRb.Checked = true;
+				splitFilesByChapterCbox.Checked = false;
 			}
 		}
 


### PR DESCRIPTION
Fixed issue described in #127 re chapters of zero length. A new split file will only be created if it is at least 15 seconds long.

Also made change to settings dialog so that SplitFilesByChapter can only be enabled if AllowLibationFixup is also enabled.