### PR TITLE
Update Libation to work with new AAXClean.Codecs

### DIFF
--- a/AaxDecrypter/AaxDecrypter.csproj
+++ b/AaxDecrypter/AaxDecrypter.csproj
@@ -1,11 +1,12 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net6.0-windows</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AAXClean" Version="0.1.10" />
+    <PackageReference Include="AAXClean" Version="0.2.5" />
+    <PackageReference Include="AAXClean.Codecs" Version="0.1.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/AaxDecrypter/AaxcDownloadMultiConverter.cs
+++ b/AaxDecrypter/AaxcDownloadMultiConverter.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using AAXClean;
+using AAXClean.Codecs;
 using Dinah.Core.StepRunner;
 using FileManager;
 
@@ -117,7 +118,7 @@ That naming may not be desirable for everyone, but it's an easy change to instea
             AaxFile.ConvertToMultiMp3(splitChapters, newSplitCallback =>
             {
                 createOutputFileStream(++chapterCount, splitChapters, newSplitCallback);
-                newSplitCallback.LameConfig.ID3.Track = chapterCount.ToString();
+                ((NAudio.Lame.LameConfig)newSplitCallback.UserState).ID3.Track = chapterCount.ToString();
             });
         }
 

--- a/AaxDecrypter/AaxcDownloadSingleConverter.cs
+++ b/AaxDecrypter/AaxcDownloadSingleConverter.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.IO;
 using AAXClean;
+using AAXClean.Codecs;
 using Dinah.Core.StepRunner;
 using FileManager;
 

--- a/AppScaffolding/AppScaffolding.csproj
+++ b/AppScaffolding/AppScaffolding.csproj
@@ -2,8 +2,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
-    <Version>6.7.8.1</Version>
+    <TargetFramework>net6.0-windows</TargetFramework>
+    <Version>6.7.8.5</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/ApplicationServices/ApplicationServices.csproj
+++ b/ApplicationServices/ApplicationServices.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net6.0-windows</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/AudibleUtilities/AudibleUtilities.csproj
+++ b/AudibleUtilities/AudibleUtilities.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net6.0-windows</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/DataLayer/DataLayer.csproj
+++ b/DataLayer/DataLayer.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net6.0-windows</TargetFramework>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/DtoImporterService/DtoImporterService.csproj
+++ b/DtoImporterService/DtoImporterService.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net6.0-windows</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/FileLiberator/ConvertToMp3.cs
+++ b/FileLiberator/ConvertToMp3.cs
@@ -2,6 +2,7 @@
 using System.IO;
 using System.Threading.Tasks;
 using AAXClean;
+using AAXClean.Codecs;
 using DataLayer;
 using Dinah.Core;
 using Dinah.Core.ErrorHandling;

--- a/FileLiberator/FileLiberator.csproj
+++ b/FileLiberator/FileLiberator.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net6.0-windows</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/LibationCli/LibationCli.csproj
+++ b/LibationCli/LibationCli.csproj
@@ -3,7 +3,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net6.0-windows</TargetFramework>
 
     <PublishTrimmed>true</PublishTrimmed>
     <PublishReadyToRun>true</PublishReadyToRun>

--- a/LibationFileManager/LibationFileManager.csproj
+++ b/LibationFileManager/LibationFileManager.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net6.0-windows</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/LibationSearchEngine/LibationSearchEngine.csproj
+++ b/LibationSearchEngine/LibationSearchEngine.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net6.0-windows</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/_Tests/AudibleUtilities.Tests/AudibleUtilities.Tests.csproj
+++ b/_Tests/AudibleUtilities.Tests/AudibleUtilities.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net6.0-windows</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/_Tests/FileLiberator.Tests/FileLiberator.Tests.csproj
+++ b/_Tests/FileLiberator.Tests/FileLiberator.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net6.0-windows</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/_Tests/LibationFileManager.Tests/LibationFileManager.Tests.csproj
+++ b/_Tests/LibationFileManager.Tests/LibationFileManager.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net6.0-windows</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/_Tests/LibationSearchEngine.Tests/LibationSearchEngine.Tests.csproj
+++ b/_Tests/LibationSearchEngine.Tests/LibationSearchEngine.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net6.0-windows</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>


### PR DESCRIPTION
Pretty minor stuff, but I did have to mark almost every project as windows-only because AAXClean.Codecs is windows-only.  Technically, AAXClean was windows-only before, but it just wasn't designated as such.  AAXClean is now platform independent.