### PR TITLE
Fix hang on grid update

### DIFF
--- a/Source/LibationWinForms/Form1.VisibleBooks.cs
+++ b/Source/LibationWinForms/Form1.VisibleBooks.cs
@@ -33,17 +33,11 @@ namespace LibationWinForms
 				{
 					liberateVisibleToolStripMenuItem.Format(notLiberated);
 					liberateVisibleToolStripMenuItem.Enabled = true;
-
-					liberateVisible2ToolStripMenuItem.Format(notLiberated);
-					liberateVisible2ToolStripMenuItem.Enabled = true;
 				}
 				else
 				{
 					liberateVisibleToolStripMenuItem.Text = "All visible books are liberated";
 					liberateVisibleToolStripMenuItem.Enabled = false;
-
-					liberateVisible2ToolStripMenuItem.Text = "All visible books are liberated";
-					liberateVisible2ToolStripMenuItem.Enabled = false;
 				}
 			});
 		}

--- a/Source/LibationWinForms/GridView/GridEntryBindingList.cs
+++ b/Source/LibationWinForms/GridView/GridEntryBindingList.cs
@@ -30,6 +30,9 @@ namespace LibationWinForms.GridView
 		public bool SupportsFiltering => true;
 		public string Filter { get => FilterString; set => ApplyFilter(value); }
 
+		/// <summary>When true, itms will not be checked filtered by search criteria on item changed<summary>
+		public bool SuspendFilteringOnUpdate { get; set; }
+
 		protected MemberComparer<GridEntry> Comparer { get; } = new();
 		protected override bool SupportsSortingCore => true;
 		protected override bool SupportsSearchingCore => true;
@@ -195,7 +198,7 @@ namespace LibationWinForms.GridView
 		{
 			if (e.ListChangedType == ListChangedType.ItemChanged)
 			{
-				if (Items[e.NewIndex] is LibraryBookEntry lbItem)
+				if (FilterString is not null && !SuspendFilteringOnUpdate && Items[e.NewIndex] is LibraryBookEntry lbItem)
 				{
 					SearchResults = SearchEngineCommands.Search(FilterString);
 					if (!SearchResults.Docs.Any(d => d.ProductId == lbItem.AudibleProductId))

--- a/Source/LibationWinForms/GridView/LibraryBookEntry.cs
+++ b/Source/LibationWinForms/GridView/LibraryBookEntry.cs
@@ -63,7 +63,11 @@ namespace LibationWinForms.GridView
 		}
 		#endregion
 
-		public LibraryBookEntry(LibraryBook libraryBook) => setLibraryBook(libraryBook);
+		public LibraryBookEntry(LibraryBook libraryBook)
+		{
+			setLibraryBook(libraryBook);
+			LoadCover();
+		}
 
 		public SeriesEntry Parent { get; init; }
 		public void UpdateLibraryBook(LibraryBook libraryBook)
@@ -78,9 +82,9 @@ namespace LibationWinForms.GridView
 
 		private void setLibraryBook(LibraryBook libraryBook)
 		{
-			LibraryBook = libraryBook;			
+			LibraryBook = libraryBook;
 
-			LoadCover();
+			UserDefinedItem.ItemChanged -= UserDefinedItem_ItemChanged;
 
 			// Immutable properties
 			{

--- a/Source/LibationWinForms/GridView/ProductsGrid.cs
+++ b/Source/LibationWinForms/GridView/ProductsGrid.cs
@@ -105,6 +105,8 @@ namespace LibationWinForms.GridView
 			string existingFilter = syncBindingSource.Filter;
 			Filter(null);
 
+			bindingList.SuspendFilteringOnUpdate = true;
+
 			//Add absent books to grid, or update current books
 
 			var allItmes = bindingList.AllItems().LibraryBooks();
@@ -156,6 +158,8 @@ namespace LibationWinForms.GridView
 					existingItem.UpdateLibraryBook(libraryBook);
 				}
 			}
+
+			bindingList.SuspendFilteringOnUpdate = false;
 
 			//Re-filter after updating existing / adding new books to capture any changes
 			Filter(existingFilter);


### PR DESCRIPTION
The problem was caused by my fix to the filtering issue you described in item 3 of https://github.com/rmcrackan/Libation/pull/255#issuecomment-1136038580

The fix was that when an item in the binding list changed,  re-filter the entire library and check the book that changed against the search results. However, when UpdateGrid runs, it updates almost every book in the library and triggers the item changed, so SearchEngineCommands.Search was re-run for every single book in the library.

The fix is to introduce the ```SuspendFilteringOnUpdate``` property to ```GridEntryBindingList```. Set it to true when we're updating the display, then back to false when we're finished.