### PR TITLE
Fix for episodes with no series link

### DIFF
--- a/Source/AudibleUtilities/ApiExtended.cs
+++ b/Source/AudibleUtilities/ApiExtended.cs
@@ -137,6 +137,7 @@ namespace AudibleUtilities
 					//Add the parent to the library because it contains the series
 					//description, series rating, and series cover art which differ
 					//from the individual episodes' values.
+					item.Series = new Series[]{ new Series { Asin = item.Asin, Title = item.TitleWithSubtitle } };
 					items.Add(item);
 				}
 				else if (!item.IsEpisodes)

--- a/Source/AudibleUtilities/ApiExtended.cs
+++ b/Source/AudibleUtilities/ApiExtended.cs
@@ -181,10 +181,8 @@ namespace AudibleUtilities
 
 				var children = await getEpisodeChildrenAsync(parent);
 
-				// actual individual episode, not the parent of a series.
-				// for now I'm keeping it inside this method since it fits the work flow, incl. importEpisodes logic
 				if (!children.Any())
-					return new();
+					return children;
 
 				foreach (var child in children)
 				{

--- a/Source/AudibleUtilities/ApiExtended.cs
+++ b/Source/AudibleUtilities/ApiExtended.cs
@@ -131,16 +131,17 @@ namespace AudibleUtilities
 			{
 				if (item.IsEpisodes && importEpisodes)
 				{
-					//Get child episodes asynchronously and await all at the end
-					getChildEpisodesTasks.Add(getChildEpisodesAsync(concurrencySemaphore, item));
-
+					//Helps to distinguish product parrents which have no content
+					//from children which do have content.
+					item.Asin = $"SERIES_{item.Asin}";
 					//Add the parent to the library because it contains the series
 					//description, series rating, and series cover art which differ
 					//from the individual episodes' values.
-					item.Series = new Series[]{ new Series { Asin = item.Asin, Sequence = RelationshipToProduct.Parent, Title = item.TitleWithSubtitle } };
-					//Helps to distinguish product parrents which have no content
-					//from children which do have content.
-					item.Asin = $"PARENT_{item.Asin}";
+					item.Series = new Series[] { new Series { Asin = item.Asin, Sequence = RelationshipToProduct.Parent, Title = item.TitleWithSubtitle } };
+
+					//Get child episodes asynchronously and await all at the end
+					getChildEpisodesTasks.Add(getChildEpisodesAsync(concurrencySemaphore, item));
+
 					items.Add(item);
 				}
 				else if (!item.IsEpisodes)
@@ -190,6 +191,7 @@ namespace AudibleUtilities
 					//so the parent is its own child.
 					var parentJson = parent.ToJson(parent).ToString();
 					var child = Item.FromJson(parentJson);
+					child.Asin = child.Asin.Replace("SERIES_", "");
 					children.Add(child);
 				}
 

--- a/Source/AudibleUtilities/ApiExtended.cs
+++ b/Source/AudibleUtilities/ApiExtended.cs
@@ -133,6 +133,11 @@ namespace AudibleUtilities
 				{
 					//Get child episodes asynchronously and await all at the end
 					getChildEpisodesTasks.Add(getChildEpisodesAsync(concurrencySemaphore, item));
+
+					//Add the parent to the library because it contains the series
+					//description, series rating, and series cover art which differ
+					//from the individual episodes' values.
+					items.Add(item);
 				}
 				else if (!item.IsEpisodes)
 					items.Add(item);
@@ -178,7 +183,7 @@ namespace AudibleUtilities
 				// actual individual episode, not the parent of a series.
 				// for now I'm keeping it inside this method since it fits the work flow, incl. importEpisodes logic
 				if (!children.Any())
-					return new List<Item>() { parent };
+					return new();
 
 				foreach (var child in children)
 				{

--- a/Source/AudibleUtilities/ApiExtended.cs
+++ b/Source/AudibleUtilities/ApiExtended.cs
@@ -137,7 +137,7 @@ namespace AudibleUtilities
 					//Add the parent to the library because it contains the series
 					//description, series rating, and series cover art which differ
 					//from the individual episodes' values.
-					item.Series = new Series[]{ new Series { Asin = item.Asin, Title = item.TitleWithSubtitle } };
+					item.Series = new Series[]{ new Series { Asin = item.Asin, Sequence = RelationshipToProduct.Parent, Title = item.TitleWithSubtitle } };
 					items.Add(item);
 				}
 				else if (!item.IsEpisodes)

--- a/Source/LibationWinForms/GridView/GridEntry.cs
+++ b/Source/LibationWinForms/GridView/GridEntry.cs
@@ -109,7 +109,7 @@ namespace LibationWinForms.GridView
 			=> gridEntries.Series().FirstOrDefault(i => matchSeries.Any(s => s.Series.Name == i.Series));
 		public static IEnumerable<SeriesEntry> EmptySeries(this IEnumerable<GridEntry> gridEntries)
 			=> gridEntries.Series().Where(i => i.Children.Count == 0);
-		public static bool IsEpisodeChild(this LibraryBook lb) => lb.Book.ContentType == ContentType.Episode && lb.Book.SeriesLink is not null && lb.Book.SeriesLink.Any() && lb.Book.SeriesLink.First().Order is not null;
-		public static bool IsEpisodeParent(this LibraryBook lb) => lb.Book.ContentType == ContentType.Episode && lb.Book.SeriesLink is not null && lb.Book.SeriesLink.Any() && lb.Book.SeriesLink.First().Order is null;
+		public static bool IsEpisodeChild(this LibraryBook lb) => lb.Book.ContentType == ContentType.Episode && lb.Book.SeriesLink is not null && lb.Book.SeriesLink.Any() && lb.Book.SeriesLink.First().Order != AudibleApi.Common.RelationshipToProduct.Parent;
+		public static bool IsEpisodeParent(this LibraryBook lb) => lb.Book.ContentType == ContentType.Episode && lb.Book.SeriesLink is not null && lb.Book.SeriesLink.Any() && lb.Book.SeriesLink.First().Order == AudibleApi.Common.RelationshipToProduct.Parent;
 	}
 }

--- a/Source/LibationWinForms/GridView/GridEntry.cs
+++ b/Source/LibationWinForms/GridView/GridEntry.cs
@@ -109,6 +109,7 @@ namespace LibationWinForms.GridView
 			=> gridEntries.Series().FirstOrDefault(i => matchSeries.Any(s => s.Series.Name == i.Series));
 		public static IEnumerable<SeriesEntry> EmptySeries(this IEnumerable<GridEntry> gridEntries)
 			=> gridEntries.Series().Where(i => i.Children.Count == 0);
-		public static bool IsEpisodeWithSeries(this LibraryBook lb) => lb.Book.ContentType == ContentType.Episode && lb.Book.SeriesLink is not null && lb.Book.SeriesLink.Any();
+		public static bool IsEpisodeChild(this LibraryBook lb) => lb.Book.ContentType == ContentType.Episode && lb.Book.SeriesLink is not null && lb.Book.SeriesLink.Any() && lb.Book.SeriesLink.First().Order is not null;
+		public static bool IsEpisodeParent(this LibraryBook lb) => lb.Book.ContentType == ContentType.Episode && lb.Book.SeriesLink is not null && lb.Book.SeriesLink.Any() && lb.Book.SeriesLink.First().Order is null;
 	}
 }

--- a/Source/LibationWinForms/GridView/GridEntry.cs
+++ b/Source/LibationWinForms/GridView/GridEntry.cs
@@ -109,5 +109,6 @@ namespace LibationWinForms.GridView
 			=> gridEntries.Series().FirstOrDefault(i => matchSeries.Any(s => s.Series.Name == i.Series));
 		public static IEnumerable<SeriesEntry> EmptySeries(this IEnumerable<GridEntry> gridEntries)
 			=> gridEntries.Series().Where(i => i.Children.Count == 0);
+		public static bool IsEpisodeWithSeries(this LibraryBook lb) => lb.Book.ContentType == ContentType.Episode && lb.Book.SeriesLink is not null && lb.Book.SeriesLink.Any();
 	}
 }

--- a/Source/LibationWinForms/GridView/ProductsDisplay.cs
+++ b/Source/LibationWinForms/GridView/ProductsDisplay.cs
@@ -84,18 +84,25 @@ namespace LibationWinForms.GridView
 
 		public void Display()
 		{
-			// don't return early if lib size == 0. this will not update correctly if all books are removed
-			var lib = DbContexts.GetLibrary_Flat_NoTracking();
-
-			if (!hasBeenDisplayed)
+			try
 			{
-				// bind
-				productsGrid.BindToGrid(lib);
-				hasBeenDisplayed = true;
-				InitialLoaded?.Invoke(this, new());
+				// don't return early if lib size == 0. this will not update correctly if all books are removed
+				var lib = DbContexts.GetLibrary_Flat_NoTracking();
+
+				if (!hasBeenDisplayed)
+				{
+					// bind
+					productsGrid.BindToGrid(lib);
+					hasBeenDisplayed = true;
+					InitialLoaded?.Invoke(this, new());
+				}
+				else
+					productsGrid.UpdateGrid(lib);
 			}
-			else
-				productsGrid.UpdateGrid(lib);
+			catch (Exception ex)
+			{
+				Serilog.Log.Error(ex, "Error displaying library in {0}", nameof(ProductsDisplay));
+			}
 
 		}
 

--- a/Source/LibationWinForms/GridView/ProductsGrid.cs
+++ b/Source/LibationWinForms/GridView/ProductsGrid.cs
@@ -84,7 +84,7 @@ namespace LibationWinForms.GridView
 		{
 			var geList = dbBooks.Where(b => b.Book.ContentType is not ContentType.Episode).Select(b => new LibraryBookEntry(b)).Cast<GridEntry>().ToList();
 
-			var episodes = dbBooks.Where(b => b.IsEpisodeWithSeries()).ToList();
+			var episodes = dbBooks.Where(b => b.IsEpisodeChild()).ToList();
 
 			foreach (var series in episodes.Select(lb => lb.Book.SeriesLink.First()).DistinctBy(s => s.Series))
 			{
@@ -117,7 +117,7 @@ namespace LibationWinForms.GridView
 				// add new to top
 				if (existingItem is null)
 				{
-					if (libraryBook.IsEpisodeWithSeries())
+					if (libraryBook.IsEpisodeChild())
 					{
 						LibraryBookEntry lbe;
 						//Find the series that libraryBook belongs to, if it exists

--- a/Source/LibationWinForms/GridView/ProductsGrid.cs
+++ b/Source/LibationWinForms/GridView/ProductsGrid.cs
@@ -84,7 +84,7 @@ namespace LibationWinForms.GridView
 		{
 			var geList = dbBooks.Where(b => b.Book.ContentType is not ContentType.Episode).Select(b => new LibraryBookEntry(b)).Cast<GridEntry>().ToList();
 
-			var episodes = dbBooks.Where(b => b.Book.ContentType is ContentType.Episode).ToList();
+			var episodes = dbBooks.Where(b => b.IsEpisodeWithSeries()).ToList();
 
 			foreach (var series in episodes.Select(lb => lb.Book.SeriesLink.First()).DistinctBy(s => s.Series))
 			{
@@ -117,7 +117,7 @@ namespace LibationWinForms.GridView
 				// add new to top
 				if (existingItem is null)
 				{
-					if (libraryBook.Book.ContentType is ContentType.Episode)
+					if (libraryBook.IsEpisodeWithSeries())
 					{
 						LibraryBookEntry lbe;
 						//Find the series that libraryBook belongs to, if it exists
@@ -148,7 +148,7 @@ namespace LibationWinForms.GridView
 
 						series.NotifyPropertyChanged();
 					}
-					else
+					else if (libraryBook.Book.ContentType is not ContentType.Episode)
 						//Add the new product
 						bindingList.Insert(0, new LibraryBookEntry(libraryBook));
 				}

--- a/Source/LibationWinForms/GridView/ProductsGrid.cs
+++ b/Source/LibationWinForms/GridView/ProductsGrid.cs
@@ -86,9 +86,9 @@ namespace LibationWinForms.GridView
 
 			var episodes = dbBooks.Where(b => b.IsEpisodeChild()).ToList();
 
-			foreach (var series in episodes.Select(lb => lb.Book.SeriesLink.First()).DistinctBy(s => s.Series))
+			foreach (var series in episodes.SelectMany(lb => lb.Book.SeriesLink).DistinctBy(s => s.Series))
 			{
-				var seriesEntry = new SeriesEntry(series, episodes.Where(lb => lb.Book.SeriesLink.First().Series == series.Book.SeriesLink.First().Series));
+				var seriesEntry = new SeriesEntry(series, episodes.Where(lb => lb.Book.SeriesLink.Any(s => s.Series == series.Series)));
 
 				geList.Add(seriesEntry);
 				geList.AddRange(seriesEntry.Children);


### PR DESCRIPTION
This will fix error #263

The problem, as I explained in the issue thread, is that if a parent had 0 episode, the parent was added to the database and it had no series link. This can happen if a podcast has only 1 episode, eg https://www.audible.com/pd/Episode-1-Podcast/B08ZXVZ7KQ

In that case, the parent is it's own child. For this special case where a series has no children, Libation clones the parent and adds it as a child.

getItemsAsync will add all parents to the db as well as their children.  Parents' ASINs are changed to "SERIES_[ASIN]" to better distinguish it from items that actually contain content, and so that in the special case where a parent is its own child, the ASINs do not collide.

Then in products grid, instead of checking ContentType is ContentType.Episode, use the new IsEpisodeChild().  There's a corresponding IsEpisodeParent() which I plan to use in the future to get series-specific info as I described in the TODO note in #255
