### PR TITLE
Fix my own screwup

### DIFF
--- a/Source/LibationWinForms/GridView/GridEntry.cs
+++ b/Source/LibationWinForms/GridView/GridEntry.cs
@@ -109,7 +109,6 @@ namespace LibationWinForms.GridView
 			=> gridEntries.Series().FirstOrDefault(i => matchSeries.Any(s => s.Series.Name == i.Series));
 		public static IEnumerable<SeriesEntry> EmptySeries(this IEnumerable<GridEntry> gridEntries)
 			=> gridEntries.Series().Where(i => i.Children.Count == 0);
-		public static bool IsEpisodeChild(this LibraryBook lb) => lb.Book.ContentType == ContentType.Episode && lb.Book.SeriesLink is not null && lb.Book.SeriesLink.Any() && lb.Book.SeriesLink.First().Order != AudibleApi.Common.RelationshipToProduct.Parent;
-		public static bool IsEpisodeParent(this LibraryBook lb) => lb.Book.ContentType == ContentType.Episode && lb.Book.SeriesLink is not null && lb.Book.SeriesLink.Any() && lb.Book.SeriesLink.First().Order == AudibleApi.Common.RelationshipToProduct.Parent;
+		public static bool IsEpisodeChild(this LibraryBook lb) => lb.Book.ContentType == ContentType.Episode;
 	}
 }

--- a/Source/LibationWinForms/GridView/ProductsGrid.cs
+++ b/Source/LibationWinForms/GridView/ProductsGrid.cs
@@ -86,7 +86,8 @@ namespace LibationWinForms.GridView
 
 			var episodes = dbBooks.Where(b => b.IsEpisodeChild()).ToList();
 
-			foreach (var series in episodes.SelectMany(lb => lb.Book.SeriesLink).DistinctBy(s => s.Series))
+			var allSeries = episodes.SelectMany(lb => lb.Book.SeriesLink.Where(s => !s.Series.AudibleSeriesId.StartsWith("SERIES_"))).DistinctBy(s => s.Series).ToList();
+			foreach (var series in allSeries)
 			{
 				var seriesEntry = new SeriesEntry(series, episodes.Where(lb => lb.Book.SeriesLink.Any(s => s.Series == series.Series)));
 


### PR DESCRIPTION
I tried to do too much too fast with that last PR.  This one reverts most of it, but still fixes the null SeriesBook error that was causing the crash on display. https://github.com/rmcrackan/Libation/issues/263

With this update, he won't have the problem of all podcasts wanting to liberate again and failing validation.

His original problem was that an episode had a null series. This addresses that.  Parents are still discarded from the import as they were before my last PR.  For users who synced their DB with this version of Libation, they will still have duplicated Series, with the dup having the "SERIES_" prefix.  I added a hack in DisplayGrid so it's ignored, but it's still in the DB.

Adding parents to the DB is a wish list item that we can deal with at another time. For now, let's just solve the core problem.  This does that.

Really sorry about all this.