### PR TITLE
Address issues in 263

### DIFF
--- a/Source/ApplicationServices/DbContexts.cs
+++ b/Source/ApplicationServices/DbContexts.cs
@@ -12,10 +12,10 @@ namespace ApplicationServices
 			=> LibationContext.Create(SqliteStorage.ConnectionString);
 
 		/// <summary>Use for full library querying. No lazy loading</summary>
-		public static List<LibraryBook> GetLibrary_Flat_NoTracking()
+		public static List<LibraryBook> GetLibrary_Flat_NoTracking(bool includeParents = false)
 		{
 			using var context = GetContext();
-			return context.GetLibrary_Flat_NoTracking();
+			return context.GetLibrary_Flat_NoTracking(includeParents);
 		}
 	}
 }

--- a/Source/ApplicationServices/LibraryCommands.cs
+++ b/Source/ApplicationServices/LibraryCommands.cs
@@ -200,7 +200,7 @@ namespace ApplicationServices
             var libraryBookImporter = new LibraryBookImporter(context);
             var newCount = await Task.Run(() => libraryBookImporter.Import(importItems));
             logTime("importIntoDbAsync -- post Import()");
-            int qtyChanges = saveChanges(context);
+            int qtyChanges = SaveContext(context);
             logTime("importIntoDbAsync -- post SaveChanges");
 
 			// this is any changes at all to the database, not just new books
@@ -211,7 +211,7 @@ namespace ApplicationServices
             return newCount;
         }
 
-        private static int saveChanges(LibationContext context)
+        public static int SaveContext(LibationContext context)
 		{
 			try
 			{

--- a/Source/ApplicationServices/SearchEngineCommands.cs
+++ b/Source/ApplicationServices/SearchEngineCommands.cs
@@ -29,7 +29,7 @@ namespace ApplicationServices
 		}
 		#endregion
 
-		public static EventHandler SearchEngineUpdated;
+		public static event EventHandler SearchEngineUpdated;
 
 		#region Update
 		private static bool isUpdating;

--- a/Source/AudibleUtilities/AudibleUtilities.csproj
+++ b/Source/AudibleUtilities/AudibleUtilities.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AudibleApi" Version="3.0.2.1" />
+    <PackageReference Include="AudibleApi" Version="3.1.0.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Source/DataLayer/EfClasses/Book.cs
+++ b/Source/DataLayer/EfClasses/Book.cs
@@ -16,8 +16,14 @@ namespace DataLayer
         }
     }
 
-    // enum will be easier than bool to extend later
-    public enum ContentType { Unknown = 0, Product = 1, Episode = 2 }
+    // enum will be easier than bool to extend later. 
+    public enum ContentType 
+    { 
+        Unknown = 0,
+        Product = 1,
+        Episode = 2,
+        Parent = 4,
+    }
 
     public class Book
     {

--- a/Source/DataLayer/QueryObjects/BookQueries.cs
+++ b/Source/DataLayer/QueryObjects/BookQueries.cs
@@ -35,5 +35,15 @@ namespace DataLayer
                 .Include(b => b.SeriesLink).ThenInclude(sb => sb.Series)
                 .Include(b => b.ContributorsLink).ThenInclude(c => c.Contributor)
                 .Include(b => b.Category).ThenInclude(c => c.ParentCategory);
+
+        public static bool IsProduct(this Book book)
+            => book.ContentType is not ContentType.Episode and not ContentType.Parent;
+
+        public static bool IsEpisodeChild(this Book book)
+            => book.ContentType is ContentType.Episode;
+
+        public static bool IsEpisodeParent(this Book book)
+            => book.ContentType is ContentType.Parent;
+
     }
 }

--- a/Source/DataLayer/QueryObjects/LibraryBookQueries.cs
+++ b/Source/DataLayer/QueryObjects/LibraryBookQueries.cs
@@ -41,5 +41,23 @@ namespace DataLayer
                 .Include(le => le.Book).ThenInclude(b => b.SeriesLink).ThenInclude(sb => sb.Series)
                 .Include(le => le.Book).ThenInclude(b => b.ContributorsLink).ThenInclude(c => c.Contributor)
                 .Include(le => le.Book).ThenInclude(b => b.Category).ThenInclude(c => c.ParentCategory);
+
+#nullable enable
+        public static LibraryBook? FindSeriesParent(this IEnumerable<LibraryBook> libraryBooks, LibraryBook seriesEpisode)
+        {
+            if (seriesEpisode.Book.SeriesLink is null) return null;
+
+            //Parent books will always have exactly 1 SeriesBook due to how
+            //they are imported in ApiExtended.getChildEpisodesAsync()
+            return libraryBooks.FirstOrDefault(
+                lb =>
+                lb.Book.IsEpisodeParent() &&
+                seriesEpisode.Book.SeriesLink.Any(
+                    s => s.Series.AudibleSeriesId == lb.Book.SeriesLink.Single().Series.AudibleSeriesId));
+        }
+#nullable disable
+
+        public static IEnumerable<LibraryBook> FindChildren(this IEnumerable<LibraryBook> bookList, LibraryBook parent)
+            => bookList.Where(lb => lb.Book.SeriesLink?.Any(s => s.Series.AudibleSeriesId == parent.Book.AudibleProductId) == true).ToList();
     }
 }

--- a/Source/DataLayer/QueryObjects/LibraryBookQueries.cs
+++ b/Source/DataLayer/QueryObjects/LibraryBookQueries.cs
@@ -20,7 +20,8 @@ namespace DataLayer
                 .LibraryBooks
                 .AsNoTrackingWithIdentityResolution()
                 .GetLibrary()
-                .Where(lb => lb.Book.ContentType != ContentType.Parent || includeParents)
+                .AsEnumerable()
+                .Where(lb => !lb.Book.IsEpisodeParent() || includeParents)
                 .ToList();
 
         public static LibraryBook GetLibraryBook_Flat_NoTracking(this LibationContext context, string productId)

--- a/Source/DataLayer/QueryObjects/LibraryBookQueries.cs
+++ b/Source/DataLayer/QueryObjects/LibraryBookQueries.cs
@@ -59,6 +59,15 @@ namespace DataLayer
 #nullable disable
 
         public static IEnumerable<LibraryBook> FindChildren(this IEnumerable<LibraryBook> bookList, LibraryBook parent)
-            => bookList.Where(lb => lb.Book.SeriesLink?.Any(s => s.Series.AudibleSeriesId == parent.Book.AudibleProductId) == true).ToList();
+            => bookList
+            .Where(
+                lb => 
+                lb.Book.IsEpisodeChild() && 
+                lb.Book.SeriesLink?
+                    .Any(
+                        s => 
+                        s.Series.AudibleSeriesId == parent.Book.AudibleProductId
+                        ) == true
+                    ).ToList();
     }
 }

--- a/Source/DataLayer/QueryObjects/LibraryBookQueries.cs
+++ b/Source/DataLayer/QueryObjects/LibraryBookQueries.cs
@@ -15,11 +15,12 @@ namespace DataLayer
 		//		.GetLibrary()
 		//		.ToList();
 
-		public static List<LibraryBook> GetLibrary_Flat_NoTracking(this LibationContext context)
+		public static List<LibraryBook> GetLibrary_Flat_NoTracking(this LibationContext context, bool includeParents = false)
             => context
                 .LibraryBooks
                 .AsNoTrackingWithIdentityResolution()
                 .GetLibrary()
+                .Where(lb => lb.Book.ContentType != ContentType.Parent || includeParents)
                 .ToList();
 
         public static LibraryBook GetLibraryBook_Flat_NoTracking(this LibationContext context, string productId)

--- a/Source/DtoImporterService/BookImporter.cs
+++ b/Source/DtoImporterService/BookImporter.cs
@@ -75,7 +75,7 @@ namespace DtoImporterService
 		{
 			var item = importItem.DtoItem;
 
-			var contentType = item.IsEpisodes ? DataLayer.ContentType.Episode : DataLayer.ContentType.Product;
+			var contentType = GetContentType(item);
 
 			// absence of authors is very rare, but possible
 			if (!item.Authors?.Any() ?? true)
@@ -183,6 +183,16 @@ namespace DtoImporterService
 					book.UpsertSeries(series, seriesEntry.Sequence);
 				}
 			}
+		}
+
+		private static DataLayer.ContentType GetContentType(Item item)
+		{
+			if (item.IsEpisodes)
+				return DataLayer.ContentType.Episode;
+			else if (item.IsSeriesParent)
+				return DataLayer.ContentType.Parent;
+			else 
+				return DataLayer.ContentType.Product;			
 		}
 	}
 }

--- a/Source/FileLiberator/Processable.cs
+++ b/Source/FileLiberator/Processable.cs
@@ -29,7 +29,8 @@ namespace FileLiberator
         public IEnumerable<LibraryBook> GetValidLibraryBooks(IEnumerable<LibraryBook> library)
             => library.Where(libraryBook =>
                 Validate(libraryBook)
-                && (libraryBook.Book.ContentType != ContentType.Episode || LibationFileManager.Configuration.Instance.DownloadEpisodes)
+                && libraryBook.Book.ContentType != ContentType.Parent 
+                && (libraryBook.Book.ContentType != ContentType.Episode || Configuration.Instance.DownloadEpisodes)
                 );
 
         public async Task<StatusHandler> ProcessSingleAsync(LibraryBook libraryBook, bool validate)

--- a/Source/FileLiberator/Processable.cs
+++ b/Source/FileLiberator/Processable.cs
@@ -29,7 +29,7 @@ namespace FileLiberator
         public IEnumerable<LibraryBook> GetValidLibraryBooks(IEnumerable<LibraryBook> library)
             => library.Where(libraryBook =>
                 Validate(libraryBook)
-                && (libraryBook.Book.ContentType != ContentType.Episode || LibationFileManager.Configuration.Instance.DownloadEpisodes)
+                && (!libraryBook.Book.IsEpisodeChild() || Configuration.Instance.DownloadEpisodes)
                 );
 
         public async Task<StatusHandler> ProcessSingleAsync(LibraryBook libraryBook, bool validate)

--- a/Source/FileLiberator/Processable.cs
+++ b/Source/FileLiberator/Processable.cs
@@ -29,8 +29,7 @@ namespace FileLiberator
         public IEnumerable<LibraryBook> GetValidLibraryBooks(IEnumerable<LibraryBook> library)
             => library.Where(libraryBook =>
                 Validate(libraryBook)
-                && libraryBook.Book.ContentType != ContentType.Parent 
-                && (libraryBook.Book.ContentType != ContentType.Episode || Configuration.Instance.DownloadEpisodes)
+                && (libraryBook.Book.ContentType != ContentType.Episode || LibationFileManager.Configuration.Instance.DownloadEpisodes)
                 );
 
         public async Task<StatusHandler> ProcessSingleAsync(LibraryBook libraryBook, bool validate)

--- a/Source/LibationSearchEngine/SearchEngine.cs
+++ b/Source/LibationSearchEngine/SearchEngine.cs
@@ -121,12 +121,12 @@ namespace LibationSearchEngine
                     ["Liberated"] = lb => isLiberated(lb.Book),
                     ["LiberatedError"] = lb => liberatedError(lb.Book),
 
-                    ["Podcast"] = lb => lb.Book.ContentType == ContentType.Episode,
-                    ["Podcasts"] = lb => lb.Book.ContentType == ContentType.Episode,
-                    ["IsPodcast"] = lb => lb.Book.ContentType == ContentType.Episode,
-                    ["Episode"] = lb => lb.Book.ContentType == ContentType.Episode,
-                    ["Episodes"] = lb => lb.Book.ContentType == ContentType.Episode,
-                    ["IsEpisode"] = lb => lb.Book.ContentType == ContentType.Episode,
+                    ["Podcast"] = lb => lb.Book.IsEpisodeChild(),
+                    ["Podcasts"] = lb => lb.Book.IsEpisodeChild(),
+                    ["IsPodcast"] = lb => lb.Book.IsEpisodeChild(),
+                    ["Episode"] = lb => lb.Book.IsEpisodeChild(),
+                    ["Episodes"] = lb => lb.Book.IsEpisodeChild(),
+                    ["IsEpisode"] = lb => lb.Book.IsEpisodeChild(),
                 }
                 );
 

--- a/Source/LibationWinForms/Dialogs/RemoveBooksDialog.cs
+++ b/Source/LibationWinForms/Dialogs/RemoveBooksDialog.cs
@@ -39,6 +39,7 @@ namespace LibationWinForms.Dialogs
 			_dataGridView.BindingContextChanged += _dataGridView_BindingContextChanged;
 
 			var orderedGridEntries = _libraryBooks
+				.Where(lb => lb.Book.ContentType is not ContentType.Parent)
 				.Select(lb => new RemovableGridEntry(lb))
 				.OrderByDescending(ge => (DateTime)ge.GetMemberValue(nameof(ge.PurchaseDate)))
 				.ToList();

--- a/Source/LibationWinForms/Dialogs/RemoveBooksDialog.cs
+++ b/Source/LibationWinForms/Dialogs/RemoveBooksDialog.cs
@@ -39,7 +39,6 @@ namespace LibationWinForms.Dialogs
 			_dataGridView.BindingContextChanged += _dataGridView_BindingContextChanged;
 
 			var orderedGridEntries = _libraryBooks
-				.Where(lb => lb.Book.ContentType is not ContentType.Parent)
 				.Select(lb => new RemovableGridEntry(lb))
 				.OrderByDescending(ge => (DateTime)ge.GetMemberValue(nameof(ge.PurchaseDate)))
 				.ToList();

--- a/Source/LibationWinForms/GridView/GridEntry.cs
+++ b/Source/LibationWinForms/GridView/GridEntry.cs
@@ -17,7 +17,6 @@ namespace LibationWinForms.GridView
 		public string AudibleProductId => Book.AudibleProductId;
 		public LibraryBook LibraryBook { get; protected set; }
 		protected Book Book => LibraryBook.Book;
-		private Image _cover;
 
 		#region Model properties exposed to the view
 		public Image Cover
@@ -50,13 +49,13 @@ namespace LibationWinForms.GridView
 		#region Sorting
 
 		public GridEntry() => _memberValues = CreateMemberValueDictionary();
-		private Dictionary<string, Func<object>> _memberValues { get; set; }
-		protected abstract Dictionary<string, Func<object>> CreateMemberValueDictionary();
 
 		// These methods are implementation of Dinah.Core.DataBinding.IMemberComparable
 		// Used by GridEntryBindingList for all sorting
 		public virtual object GetMemberValue(string memberName) => _memberValues[memberName]();
 		public IComparer GetMemberComparer(Type memberType) => _memberTypeComparers[memberType];
+		protected abstract Dictionary<string, Func<object>> CreateMemberValueDictionary();
+		private Dictionary<string, Func<object>> _memberValues { get; set; }
 
 		// Instantiate comparers for every exposed member object type.
 		private static readonly Dictionary<Type, IComparer> _memberTypeComparers = new()
@@ -71,18 +70,19 @@ namespace LibationWinForms.GridView
 
 		#endregion
 
+		#region Cover Art
+
+		private Image _cover;
 		protected void LoadCover()
 		{
 			// Get cover art. If it's default, subscribe to PictureCached
-			{
-				(bool isDefault, byte[] picture) = PictureStorage.GetPicture(new PictureDefinition(Book.PictureId, PictureSize._80x80));
+			(bool isDefault, byte[] picture) = PictureStorage.GetPicture(new PictureDefinition(Book.PictureId, PictureSize._80x80));
 
-				if (isDefault)
-					PictureStorage.PictureCached += PictureStorage_PictureCached;
+			if (isDefault)
+				PictureStorage.PictureCached += PictureStorage_PictureCached;
 
-				// Mutable property. Set the field so PropertyChanged isn't fired.
-				_cover = ImageReader.ToImage(picture);
-			}
+			// Mutable property. Set the field so PropertyChanged isn't fired.
+			_cover = ImageReader.ToImage(picture);
 		}
 
 		private void PictureStorage_PictureCached(object sender, PictureCachedEventArgs e)
@@ -94,10 +94,12 @@ namespace LibationWinForms.GridView
 			}
 		}
 
+		#endregion
+
 		#region Static library display functions		
 
 		/// <summary>
-		/// This information should not change during <see cref="LibraryBookEntry"/> lifetime, so call only once.
+		/// This information should not change during <see cref="GridEntry"/> lifetime, so call only once.
 		/// </summary>
 		protected static string GetDescriptionDisplay(Book book)
 		{
@@ -116,7 +118,7 @@ namespace LibationWinForms.GridView
 
 
 		/// <summary>
-		/// This information should not change during <see cref="LibraryBookEntry"/> lifetime, so call only once.
+		/// This information should not change during <see cref="GridEntry"/> lifetime, so call only once.
 		/// Maximum of 5 text rows will fit in 80-pixel row height.
 		/// </summary>
 		protected static string GetMiscDisplay(LibraryBook libraryBook)

--- a/Source/LibationWinForms/GridView/GridEntry.cs
+++ b/Source/LibationWinForms/GridView/GridEntry.cs
@@ -1,4 +1,5 @@
 ﻿using DataLayer;
+using Dinah.Core;
 using Dinah.Core.DataBinding;
 using Dinah.Core.Drawing;
 using LibationFileManager;
@@ -10,11 +11,14 @@ using System.Linq;
 
 namespace LibationWinForms.GridView
 {
+	/// <summary>The View Model base for the DataGridView</summary>
 	public abstract class GridEntry : AsyncNotifyPropertyChanged, IMemberComparable
 	{
-		protected abstract Book Book { get; }
-
+		public string AudibleProductId => Book.AudibleProductId;
+		public LibraryBook LibraryBook { get; protected set; }
+		protected Book Book => LibraryBook.Book;
 		private Image _cover;
+
 		#region Model properties exposed to the view
 		public Image Cover
 		{
@@ -25,20 +29,20 @@ namespace LibationWinForms.GridView
 				NotifyPropertyChanged();
 			}
 		}
-		public new bool InvokeRequired => base.InvokeRequired;
+		public float SeriesIndex { get; protected set; }
+		public string ProductRating { get; protected set; }
+		public string PurchaseDate { get; protected set; }
+		public string MyRating { get; protected set; }
+		public string Series { get; protected set; }
+		public string Title { get; protected set; }
+		public string Length { get; protected set; }
+		public string Authors { get; protected set; }
+		public string Narrators { get; protected set; }
+		public string Category { get; protected set; }
+		public string Misc { get; protected set; }
+		public string Description { get; protected set; }
+		public string LongDescription { get; protected set; }
 		public abstract DateTime DateAdded { get; }
-		public abstract float SeriesIndex { get; }
-		public abstract string ProductRating { get; protected set; }
-		public abstract string PurchaseDate { get; protected set; }
-		public abstract string MyRating { get; protected set; }
-		public abstract string Series { get; protected set; }
-		public abstract string Title { get; protected set; }
-		public abstract string Length { get; protected set; }
-		public abstract string Authors { get; protected set; }
-		public abstract string Narrators { get; protected set; }
-		public abstract string Category { get; protected set; }
-		public abstract string Misc { get; protected set; }
-		public abstract string Description { get; protected set; }
 		public abstract string DisplayTags { get; }
 		public abstract LiberateButtonStatus Liberate { get; }
 		#endregion
@@ -53,6 +57,17 @@ namespace LibationWinForms.GridView
 		// Used by GridEntryBindingList for all sorting
 		public virtual object GetMemberValue(string memberName) => _memberValues[memberName]();
 		public IComparer GetMemberComparer(Type memberType) => _memberTypeComparers[memberType];
+
+		// Instantiate comparers for every exposed member object type.
+		private static readonly Dictionary<Type, IComparer> _memberTypeComparers = new()
+		{
+			{ typeof(string), new ObjectComparer<string>() },
+			{ typeof(int), new ObjectComparer<int>() },
+			{ typeof(float), new ObjectComparer<float>() },
+			{ typeof(bool), new ObjectComparer<bool>() },
+			{ typeof(DateTime), new ObjectComparer<DateTime>() },
+			{ typeof(LiberateButtonStatus), new ObjectComparer<LiberateButtonStatus>() },
+		};
 
 		#endregion
 
@@ -79,36 +94,61 @@ namespace LibationWinForms.GridView
 			}
 		}
 
-		// Instantiate comparers for every exposed member object type.
-		private static readonly Dictionary<Type, IComparer> _memberTypeComparers = new()
+		#region Static library display functions		
+
+		/// <summary>
+		/// This information should not change during <see cref="LibraryBookEntry"/> lifetime, so call only once.
+		/// </summary>
+		protected static string GetDescriptionDisplay(Book book)
 		{
-			{ typeof(string), new ObjectComparer<string>() },
-			{ typeof(int), new ObjectComparer<int>() },
-			{ typeof(float), new ObjectComparer<float>() },
-			{ typeof(bool), new ObjectComparer<bool>() },
-			{ typeof(DateTime), new ObjectComparer<DateTime>() },
-			{ typeof(LiberateButtonStatus), new ObjectComparer<LiberateButtonStatus>() },
-		};
+			var doc = new HtmlAgilityPack.HtmlDocument();
+			doc.LoadHtml(book?.Description?.Replace("</p> ", "\r\n\r\n</p>") ?? "");
+			return doc.DocumentNode.InnerText.Trim();
+		}
+
+		protected static string TrimTextToWord(string text, int maxLength)
+		{
+			return
+				text.Length <= maxLength ?
+				text :
+				text.Substring(0, maxLength - 3) + "...";
+		}
+
+
+		/// <summary>
+		/// This information should not change during <see cref="LibraryBookEntry"/> lifetime, so call only once.
+		/// Maximum of 5 text rows will fit in 80-pixel row height.
+		/// </summary>
+		protected static string GetMiscDisplay(LibraryBook libraryBook)
+		{
+			var details = new List<string>();
+
+			var locale = libraryBook.Book.Locale.DefaultIfNullOrWhiteSpace("[unknown]");
+			var acct = libraryBook.Account.DefaultIfNullOrWhiteSpace("[unknown]");
+
+			details.Add($"Account: {locale} - {acct}");
+
+			if (libraryBook.Book.HasPdf())
+				details.Add("Has PDF");
+			if (libraryBook.Book.IsAbridged)
+				details.Add("Abridged");
+			if (libraryBook.Book.DatePublished.HasValue)
+				details.Add($"Date pub'd: {libraryBook.Book.DatePublished.Value:MM/dd/yyyy}");
+			// this goes last since it's most likely to have a line-break
+			if (!string.IsNullOrWhiteSpace(libraryBook.Book.Publisher))
+				details.Add($"Pub: {libraryBook.Book.Publisher.Trim()}");
+
+			if (!details.Any())
+				return "[details not imported]";
+
+			return string.Join("\r\n", details);
+		}
+
+		#endregion
 
 		~GridEntry()
 		{
 			PictureStorage.PictureCached -= PictureStorage_PictureCached;
 		}
-	}
-
-	internal static class GridEntryExtensions
-	{
-#nullable enable
-		public static IEnumerable<SeriesEntry> Series(this IEnumerable<GridEntry> gridEntries)
-			=> gridEntries.OfType<SeriesEntry>();
-		public static IEnumerable<LibraryBookEntry> LibraryBooks(this IEnumerable<GridEntry> gridEntries)
-			=> gridEntries.OfType<LibraryBookEntry>();
-		public static LibraryBookEntry? FindBookByAsin(this IEnumerable<LibraryBookEntry> gridEntries, string audibleProductID)
-			=> gridEntries.FirstOrDefault(i => i.AudibleProductId == audibleProductID);
-		public static SeriesEntry? FindBookSeriesEntry(this IEnumerable<GridEntry> gridEntries, IEnumerable<SeriesBook> matchSeries)
-			=> gridEntries.Series().FirstOrDefault(i => matchSeries.Any(s => s.Series.Name == i.Series));
-		public static IEnumerable<SeriesEntry> EmptySeries(this IEnumerable<GridEntry> gridEntries)
-			=> gridEntries.Series().Where(i => i.Children.Count == 0);
-		public static bool IsEpisodeChild(this LibraryBook lb) => lb.Book.ContentType == ContentType.Episode;
 	}
 }

--- a/Source/LibationWinForms/GridView/GridEntry.cs
+++ b/Source/LibationWinForms/GridView/GridEntry.cs
@@ -6,6 +6,7 @@ using LibationFileManager;
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Drawing;
 using System.Linq;
 
@@ -14,11 +15,16 @@ namespace LibationWinForms.GridView
 	/// <summary>The View Model base for the DataGridView</summary>
 	public abstract class GridEntry : AsyncNotifyPropertyChanged, IMemberComparable
 	{
-		public string AudibleProductId => Book.AudibleProductId;
-		public LibraryBook LibraryBook { get; protected set; }
-		protected Book Book => LibraryBook.Book;
+		[Browsable(false)] public string AudibleProductId => Book.AudibleProductId;
+		[Browsable(false)] public LibraryBook LibraryBook { get; protected set; }
+		[Browsable(false)] public float SeriesIndex { get; protected set; }
+		[Browsable(false)] public string LongDescription { get; protected set; }
+		[Browsable(false)] public abstract DateTime DateAdded { get; }
+		[Browsable(false)] protected Book Book => LibraryBook.Book;
 
 		#region Model properties exposed to the view
+
+		public abstract LiberateButtonStatus Liberate { get; }
 		public Image Cover
 		{
 			get => _cover;
@@ -28,10 +34,7 @@ namespace LibationWinForms.GridView
 				NotifyPropertyChanged();
 			}
 		}
-		public float SeriesIndex { get; protected set; }
-		public string ProductRating { get; protected set; }
 		public string PurchaseDate { get; protected set; }
-		public string MyRating { get; protected set; }
 		public string Series { get; protected set; }
 		public string Title { get; protected set; }
 		public string Length { get; protected set; }
@@ -40,10 +43,10 @@ namespace LibationWinForms.GridView
 		public string Category { get; protected set; }
 		public string Misc { get; protected set; }
 		public string Description { get; protected set; }
-		public string LongDescription { get; protected set; }
-		public abstract DateTime DateAdded { get; }
+		public string ProductRating { get; protected set; }
+		public string MyRating { get; protected set; }
 		public abstract string DisplayTags { get; }
-		public abstract LiberateButtonStatus Liberate { get; }
+
 		#endregion
 
 		#region Sorting
@@ -98,9 +101,7 @@ namespace LibationWinForms.GridView
 
 		#region Static library display functions		
 
-		/// <summary>
-		/// This information should not change during <see cref="GridEntry"/> lifetime, so call only once.
-		/// </summary>
+		/// <summary>This information should not change during <see cref="GridEntry"/> lifetime, so call only once.</summary>
 		protected static string GetDescriptionDisplay(Book book)
 		{
 			var doc = new HtmlAgilityPack.HtmlDocument();

--- a/Source/LibationWinForms/GridView/GridEntryBindingList.cs
+++ b/Source/LibationWinForms/GridView/GridEntryBindingList.cs
@@ -73,10 +73,10 @@ namespace LibationWinForms.GridView
 			FilterString = filterString;
 			SearchResults = SearchEngineCommands.Search(filterString);
 
-			var booksFilteredIn = Items.LibraryBooks().Join(SearchResults.Docs, lbe => lbe.AudibleProductId, d => d.ProductId, (lbe, d) => (GridEntry)lbe);
+			var booksFilteredIn = Items.BookEntries().Join(SearchResults.Docs, lbe => lbe.AudibleProductId, d => d.ProductId, (lbe, d) => (GridEntry)lbe);
 
 			//Find all series containing children that match the search criteria
-			var seriesFilteredIn = Items.Series().Where(s => s.Children.Join(SearchResults.Docs, lbe => lbe.AudibleProductId, d => d.ProductId, (lbe, d) => lbe).Any());
+			var seriesFilteredIn = Items.SeriesEntries().Where(s => s.Children.Join(SearchResults.Docs, lbe => lbe.AudibleProductId, d => d.ProductId, (lbe, d) => lbe).Any());
 
 			var filteredOut = Items.Except(booksFilteredIn.Concat(seriesFilteredIn)).ToList();
 
@@ -89,19 +89,19 @@ namespace LibationWinForms.GridView
 
 		public void CollapseAll()
 		{
-			foreach (var series in Items.Series().ToList())
+			foreach (var series in Items.SeriesEntries().ToList())
 				CollapseItem(series);
 		}
 
 		public void ExpandAll()
 		{
-			foreach (var series in Items.Series().ToList())
+			foreach (var series in Items.SeriesEntries().ToList())
 				ExpandItem(series);
 		}
 
 		public void CollapseItem(SeriesEntry sEntry)
 		{
-			foreach (var episode in Items.LibraryBooks().Where(b => b.Parent == sEntry).ToList())
+			foreach (var episode in Items.BookEntries().Where(b => b.Parent == sEntry).ToList())
 			{
 				FilterRemoved.Add(episode);
 				base.Remove(episode);
@@ -114,7 +114,7 @@ namespace LibationWinForms.GridView
 		{
 			var sindex = Items.IndexOf(sEntry);
 
-			foreach (var episode in FilterRemoved.LibraryBooks().Where(b => b.Parent == sEntry).ToList())
+			foreach (var episode in FilterRemoved.BookEntries().Where(b => b.Parent == sEntry).ToList())
 			{
 				if (SearchResults is null || SearchResults.Docs.Any(d => d.ProductId == episode.AudibleProductId))
 				{
@@ -174,7 +174,7 @@ namespace LibationWinForms.GridView
 		{
 			var itemsList = (List<GridEntry>)Items;
 
-			var children = itemsList.LibraryBooks().Where(i => i.Parent is not null).ToList();
+			var children = itemsList.BookEntries().Where(i => i.Parent is not null).ToList();
 
 			var sortedItems = itemsList.Except(children).OrderBy(ge => ge, Comparer).ToList();
 

--- a/Source/LibationWinForms/GridView/LibraryBookEntry.cs
+++ b/Source/LibationWinForms/GridView/LibraryBookEntry.cs
@@ -11,7 +11,6 @@ namespace LibationWinForms.GridView
 	/// <summary>The View Model for a LibraryBook that is ContentType.Product or ContentType.Episode</summary>
 	public class LibraryBookEntry : GridEntry
 	{
-
 		[Browsable(false)] public override DateTime DateAdded => LibraryBook.DateAdded;
 		[Browsable(false)] public SeriesEntry Parent { get; init; }
 
@@ -60,22 +59,19 @@ namespace LibationWinForms.GridView
 		{
 			LibraryBook = libraryBook;
 
-			// Immutable properties
-			{
-				Title = Book.Title;
-				Series = Book.SeriesNames();
-				Length = Book.LengthInMinutes == 0 ? "" : $"{Book.LengthInMinutes / 60} hr {Book.LengthInMinutes % 60} min";
-				MyRating = Book.UserDefinedItem.Rating?.ToStarString()?.DefaultIfNullOrWhiteSpace("");
-				PurchaseDate = libraryBook.DateAdded.ToString("d");
-				ProductRating = Book.Rating?.ToStarString()?.DefaultIfNullOrWhiteSpace("");
-				Authors = Book.AuthorNames();
-				Narrators = Book.NarratorNames();
-				Category = string.Join(" > ", Book.CategoriesNames());
-				Misc = GetMiscDisplay(libraryBook);
-				LongDescription = GetDescriptionDisplay(Book);
-				Description = TrimTextToWord(LongDescription, 62);
-				SeriesIndex = Book.SeriesLink.FirstOrDefault()?.Index ?? 0;
-			}
+			Title = Book.Title;
+			Series = Book.SeriesNames();
+			Length = Book.LengthInMinutes == 0 ? "" : $"{Book.LengthInMinutes / 60} hr {Book.LengthInMinutes % 60} min";
+			MyRating = Book.UserDefinedItem.Rating?.ToStarString()?.DefaultIfNullOrWhiteSpace("");
+			PurchaseDate = libraryBook.DateAdded.ToString("d");
+			ProductRating = Book.Rating?.ToStarString()?.DefaultIfNullOrWhiteSpace("");
+			Authors = Book.AuthorNames();
+			Narrators = Book.NarratorNames();
+			Category = string.Join(" > ", Book.CategoriesNames());
+			Misc = GetMiscDisplay(libraryBook);
+			LongDescription = GetDescriptionDisplay(Book);
+			Description = TrimTextToWord(LongDescription, 62);
+			SeriesIndex = Book.SeriesLink.FirstOrDefault()?.Index ?? 0;
 
 			UserDefinedItem.ItemChanged += UserDefinedItem_ItemChanged;
 		}

--- a/Source/LibationWinForms/GridView/LibraryBookEntry.cs
+++ b/Source/LibationWinForms/GridView/LibraryBookEntry.cs
@@ -3,6 +3,7 @@ using DataLayer;
 using Dinah.Core;
 using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Linq;
 
 namespace LibationWinForms.GridView
@@ -10,14 +11,15 @@ namespace LibationWinForms.GridView
 	/// <summary>The View Model for a LibraryBook that is ContentType.Product or ContentType.Episode</summary>
 	public class LibraryBookEntry : GridEntry
 	{
+
+		[Browsable(false)] public override DateTime DateAdded => LibraryBook.DateAdded;
+		[Browsable(false)] public SeriesEntry Parent { get; init; }
+
 		#region Model properties exposed to the view
 
 		private DateTime lastStatusUpdate = default;
 		private LiberatedStatus _bookStatus;
 		private LiberatedStatus? _pdfStatus;
-
-		public override DateTime DateAdded => LibraryBook.DateAdded;
-		public override string DisplayTags => string.Join("\r\n", Book.UserDefinedItem.TagsEnumerated);
 
 		public override LiberateButtonStatus Liberate
 		{
@@ -33,10 +35,9 @@ namespace LibationWinForms.GridView
 				return new LiberateButtonStatus { BookStatus = _bookStatus, PdfStatus = _pdfStatus, IsSeries = false };
 			}
 		}
+		public override string DisplayTags => string.Join("\r\n", Book.UserDefinedItem.TagsEnumerated);
 
 		#endregion
-
-		public SeriesEntry Parent { get; init; }
 
 		public LibraryBookEntry(LibraryBook libraryBook)
 		{

--- a/Source/LibationWinForms/GridView/ProductsDisplay.Designer.cs
+++ b/Source/LibationWinForms/GridView/ProductsDisplay.Designer.cs
@@ -39,10 +39,10 @@
 			this.productsGrid.Name = "productsGrid";
 			this.productsGrid.Size = new System.Drawing.Size(1510, 380);
 			this.productsGrid.TabIndex = 0;
-			this.productsGrid.LiberateClicked += new LibationWinForms.GridView.ProductsGrid.LibraryBookEntryClickedEventHandler(this.productsGrid_LiberateClicked);
-			this.productsGrid.CoverClicked += new LibationWinForms.GridView.ProductsGrid.LibraryBookEntryClickedEventHandler(this.productsGrid_CoverClicked);
-			this.productsGrid.DetailsClicked += new LibationWinForms.GridView.ProductsGrid.LibraryBookEntryClickedEventHandler(this.productsGrid_DetailsClicked);
-			this.productsGrid.DescriptionClicked += new LibationWinForms.GridView.ProductsGrid.LibraryBookEntryRectangleClickedEventHandler(this.productsGrid_DescriptionClicked);
+			this.productsGrid.LiberateClicked += new LibationWinForms.GridView.LibraryBookEntryClickedEventHandler(this.productsGrid_LiberateClicked);
+			this.productsGrid.CoverClicked += new LibationWinForms.GridView.GridEntryClickedEventHandler(this.productsGrid_CoverClicked);
+			this.productsGrid.DetailsClicked += new LibationWinForms.GridView.LibraryBookEntryClickedEventHandler(this.productsGrid_DetailsClicked);
+			this.productsGrid.DescriptionClicked += new LibationWinForms.GridView.GridEntryRectangleClickedEventHandler(this.productsGrid_DescriptionClicked);
 			this.productsGrid.VisibleCountChanged += new System.EventHandler<int>(this.productsGrid_VisibleCountChanged);
 			// 
 			// ProductsDisplay

--- a/Source/LibationWinForms/GridView/ProductsDisplay.cs
+++ b/Source/LibationWinForms/GridView/ProductsDisplay.cs
@@ -87,7 +87,7 @@ namespace LibationWinForms.GridView
 			try
 			{
 				// don't return early if lib size == 0. this will not update correctly if all books are removed
-				var lib = DbContexts.GetLibrary_Flat_NoTracking();
+				var lib = DbContexts.GetLibrary_Flat_NoTracking(includeParents: true);
 
 				if (!hasBeenDisplayed)
 				{
@@ -114,7 +114,7 @@ namespace LibationWinForms.GridView
 
 		#endregion
 
-		internal List<LibraryBook> GetVisible() => productsGrid.GetVisible().Select(v => v.LibraryBook).ToList();
+		internal List<LibraryBook> GetVisible() => productsGrid.GetVisibleBooks().ToList();
 
 		private void productsGrid_VisibleCountChanged(object sender, int count)
 		{

--- a/Source/LibationWinForms/GridView/ProductsDisplay.cs
+++ b/Source/LibationWinForms/GridView/ProductsDisplay.cs
@@ -29,7 +29,7 @@ namespace LibationWinForms.GridView
 		#region Button controls		
 
 		private ImageDisplay imageDisplay;
-		private async void productsGrid_CoverClicked(LibraryBookEntry liveGridEntry)
+		private async void productsGrid_CoverClicked(GridEntry liveGridEntry)
 		{
 			var picDefinition = new PictureDefinition(liveGridEntry.LibraryBook.Book.PictureLarge ?? liveGridEntry.LibraryBook.Book.PictureId, PictureSize.Native);
 			var picDlTask = Task.Run(() => PictureStorage.GetPictureSynchronously(picDefinition));
@@ -52,7 +52,7 @@ namespace LibationWinForms.GridView
 			imageDisplay.CoverPicture = await picDlTask;
 		}
 
-		private void productsGrid_DescriptionClicked(LibraryBookEntry liveGridEntry, Rectangle cellRectangle)
+		private void productsGrid_DescriptionClicked(GridEntry liveGridEntry, Rectangle cellRectangle)
 		{
 			var displayWindow = new DescriptionDisplay
 			{
@@ -103,7 +103,6 @@ namespace LibationWinForms.GridView
 			{
 				Serilog.Log.Error(ex, "Error displaying library in {0}", nameof(ProductsDisplay));
 			}
-
 		}
 
 		#endregion

--- a/Source/LibationWinForms/GridView/ProductsGrid.cs
+++ b/Source/LibationWinForms/GridView/ProductsGrid.cs
@@ -25,9 +25,10 @@ namespace LibationWinForms.GridView
 		public new event EventHandler<ScrollEventArgs> Scroll;
 
 		private GridEntryBindingList bindingList;
-		internal IEnumerable<LibraryBookEntry> GetVisible()
+		internal IEnumerable<LibraryBook> GetVisibleBooks()
 			=> bindingList
-			.BookEntries();
+			.BookEntries()
+			.Select(lbe => lbe.LibraryBook);
 
 		public ProductsGrid()
 		{

--- a/Source/LibationWinForms/GridView/ProductsGrid.cs
+++ b/Source/LibationWinForms/GridView/ProductsGrid.cs
@@ -10,23 +10,24 @@ using System.Windows.Forms;
 
 namespace LibationWinForms.GridView
 {
+	public delegate void GridEntryClickedEventHandler(GridEntry liveGridEntry);
+	public delegate void LibraryBookEntryClickedEventHandler(LibraryBookEntry liveGridEntry);
+	public delegate void GridEntryRectangleClickedEventHandler(GridEntry liveGridEntry, Rectangle cellRectangle);
+
 	public partial class ProductsGrid : UserControl
 	{
-		public delegate void LibraryBookEntryClickedEventHandler(LibraryBookEntry liveGridEntry);
-		public delegate void LibraryBookEntryRectangleClickedEventHandler(LibraryBookEntry liveGridEntry, Rectangle cellRectangle);
-
 		/// <summary>Number of visible rows has changed</summary>
 		public event EventHandler<int> VisibleCountChanged;
 		public event LibraryBookEntryClickedEventHandler LiberateClicked;
-		public event LibraryBookEntryClickedEventHandler CoverClicked;
+		public event GridEntryClickedEventHandler CoverClicked;
 		public event LibraryBookEntryClickedEventHandler DetailsClicked;
-		public event LibraryBookEntryRectangleClickedEventHandler DescriptionClicked;
+		public event GridEntryRectangleClickedEventHandler DescriptionClicked;
 		public new event EventHandler<ScrollEventArgs> Scroll;
 
 		private GridEntryBindingList bindingList;
 		internal IEnumerable<LibraryBookEntry> GetVisible()
 			=> bindingList
-			.LibraryBooks();
+			.BookEntries();
 
 		public ProductsGrid()
 		{
@@ -61,16 +62,23 @@ namespace LibationWinForms.GridView
 				else if (e.ColumnIndex == coverGVColumn.Index)
 					CoverClicked?.Invoke(lbEntry);
 			}
-			else if (entry is SeriesEntry sEntry && e.ColumnIndex == liberateGVColumn.Index)
+			else if (entry is SeriesEntry sEntry)
 			{
-				if (sEntry.Liberate.Expanded)
-					bindingList.CollapseItem(sEntry);
-				else
-					bindingList.ExpandItem(sEntry);
+				if (e.ColumnIndex == liberateGVColumn.Index)
+				{
+					if (sEntry.Liberate.Expanded)
+						bindingList.CollapseItem(sEntry);
+					else
+						bindingList.ExpandItem(sEntry);
 
-				sEntry.NotifyPropertyChanged(nameof(sEntry.Liberate));
+					sEntry.NotifyPropertyChanged(nameof(sEntry.Liberate));
 
-				VisibleCountChanged?.Invoke(this, bindingList.LibraryBooks().Count());
+					VisibleCountChanged?.Invoke(this, bindingList.BookEntries().Count());
+				}
+				else if (e.ColumnIndex == descriptionGVColumn.Index)
+					DescriptionClicked?.Invoke(sEntry, gridEntryDataGridView.GetCellDisplayRectangle(e.ColumnIndex, e.RowIndex, false));
+				else if (e.ColumnIndex == coverGVColumn.Index)
+					CoverClicked?.Invoke(sEntry);
 			}
 		}
 
@@ -82,14 +90,18 @@ namespace LibationWinForms.GridView
 
 		internal void BindToGrid(List<LibraryBook> dbBooks)
 		{
-			var geList = dbBooks.Where(b => b.Book.ContentType is not ContentType.Episode).Select(b => new LibraryBookEntry(b)).Cast<GridEntry>().ToList();
+			var geList = dbBooks.Where(lb => lb.IsProduct()).Select(b => new LibraryBookEntry(b)).Cast<GridEntry>().ToList();
 
-			var episodes = dbBooks.Where(b => b.IsEpisodeChild()).ToList();
-
-			var allSeries = episodes.SelectMany(lb => lb.Book.SeriesLink.Where(s => !s.Series.AudibleSeriesId.StartsWith("SERIES_"))).DistinctBy(s => s.Series).ToList();
-			foreach (var series in allSeries)
+			var parents = dbBooks.Where(lb => lb.IsEpisodeParent());
+			var episodes = dbBooks.Where(lb => lb.IsEpisodeChild());
+						
+			foreach (var parent in parents)
 			{
-				var seriesEntry = new SeriesEntry(series, episodes.Where(lb => lb.Book.SeriesLink.Any(s => s.Series == series.Series)));
+				var seriesEpisodes = episodes.Where(lb => lb.Book.SeriesLink?.Any(s => s.Series.AudibleSeriesId == parent.Book.AudibleProductId) == true).ToList();
+
+				if (!seriesEpisodes.Any()) continue;
+
+				var seriesEntry = new SeriesEntry(parent, seriesEpisodes);
 
 				geList.Add(seriesEntry);
 				geList.AddRange(seriesEntry.Children);
@@ -98,79 +110,47 @@ namespace LibationWinForms.GridView
 			bindingList = new GridEntryBindingList(geList.OrderByDescending(e => e.DateAdded));
 			bindingList.CollapseAll();
 			syncBindingSource.DataSource = bindingList;
-			VisibleCountChanged?.Invoke(this, bindingList.LibraryBooks().Count());
-		}
+			VisibleCountChanged?.Invoke(this, bindingList.BookEntries().Count());
+		}	
 
 		internal void UpdateGrid(List<LibraryBook> dbBooks)
 		{
+			#region Add new or update existing grid entries
+
+			//Remove filter prior to adding/updating boooks
 			string existingFilter = syncBindingSource.Filter;
 			Filter(null);
 
 			bindingList.SuspendFilteringOnUpdate = true;
 
-			//Add absent books to grid, or update current books
+			//Add absent entries to grid, or update existing entry
 
-			var allItmes = bindingList.AllItems().LibraryBooks();
-			foreach (var libraryBook in dbBooks)
+			var allEntries = bindingList.AllItems().BookEntries();
+			var seriesEntries = bindingList.AllItems().SeriesEntries().ToList();
+
+			foreach (var libraryBook in dbBooks.OrderBy(e => e.DateAdded))
 			{
-				var existingItem = allItmes.FindBookByAsin(libraryBook.Book.AudibleProductId);
+				var existingEntry = allEntries.FindByAsin(libraryBook.Book.AudibleProductId);
 
-				// add new to top
-				if (existingItem is null)
-				{
-					if (libraryBook.IsEpisodeChild())
-					{
-						LibraryBookEntry lbe;
-						//Find the series that libraryBook belongs to, if it exists
-						var series = bindingList.AllItems().FindBookSeriesEntry(libraryBook.Book.SeriesLink);
-
-						if (series is null)
-						{
-							//Series doesn't exist yet, so create and add it
-							var newSeries = new SeriesEntry(libraryBook.Book.SeriesLink.First(), libraryBook);
-							lbe = newSeries.Children[0];
-							newSeries.Liberate.Expanded = true;
-							bindingList.Insert(0, newSeries);
-							series = newSeries;
-						}
-						else
-						{
-							lbe = new(libraryBook) { Parent = series };
-							series.Children.Add(lbe);
-						}
-						//Add episode beneath the parent
-						int seriesIndex = bindingList.IndexOf(series);
-						bindingList.Insert(seriesIndex + 1, lbe);
-
-						if (series.Liberate.Expanded)
-							bindingList.ExpandItem(series);
-						else
-							bindingList.CollapseItem(series);
-
-						series.NotifyPropertyChanged();
-					}
-					else if (libraryBook.Book.ContentType is not ContentType.Episode)
-						//Add the new product
-						bindingList.Insert(0, new LibraryBookEntry(libraryBook));
-				}
-				// update existing
-				else
-				{
-					existingItem.UpdateLibraryBook(libraryBook);
-				}
-			}
+				if (libraryBook.IsEpisodeChild()) 
+					AddOrUpdateEpisode(libraryBook, existingEntry, seriesEntries, dbBooks);
+				else if (libraryBook.IsProduct())
+					AddOrUpdateBook(libraryBook, existingEntry);
+			}	
 
 			bindingList.SuspendFilteringOnUpdate = false;
 
-			//Re-filter after updating existing / adding new books to capture any changes
+			//Re-apply filter after adding new/updating existing books to capture any changes
 			Filter(existingFilter);
+
+			#endregion
 
 			// remove deleted from grid.
 			// note: actual deletion from db must still occur via the RemoveBook feature. deleting from audible will not trigger this
 			var removedBooks =
 				bindingList
 				.AllItems()
-				.LibraryBooks()
+				.BookEntries()
 				.ExceptBy(dbBooks.Select(lb => lb.Book.AudibleProductId), ge => ge.AudibleProductId);
 
 			//Remove books in series from their parents' Children list
@@ -190,7 +170,69 @@ namespace LibationWinForms.GridView
 				//no need to re-filter for removed books
 				bindingList.Remove(removed);
 
-			VisibleCountChanged?.Invoke(this, bindingList.LibraryBooks().Count());
+			VisibleCountChanged?.Invoke(this, bindingList.BookEntries().Count());
+		}
+
+		private void AddOrUpdateBook(LibraryBook book, LibraryBookEntry existingBookEntry)
+		{
+			if (existingBookEntry is null)
+				// Add the new product to top
+				bindingList.Insert(0, new LibraryBookEntry(book));
+			else
+				// update existing
+				existingBookEntry.UpdateLibraryBook(book);
+		}
+
+		private void AddOrUpdateEpisode(LibraryBook episodeBook, LibraryBookEntry existingEpisodeEntry, List<SeriesEntry> seriesEntries, IEnumerable<LibraryBook> dbBooks)
+		{
+			if (existingEpisodeEntry is null)
+			{
+				LibraryBookEntry episodeEntry;
+				var seriesEntry = seriesEntries.FindSeriesParent(episodeBook);
+
+				if (seriesEntry is null)
+				{
+					//Series doesn't exist yet, so create and add it
+					var seriesBook = dbBooks.FindSeriesParent(episodeBook);
+
+					if (seriesBook is null)
+					{
+						var ex = new ApplicationException($"Episode's series parent not found in database.");
+						var seriesLinks = string.Join("\r\n", episodeBook.Book.SeriesLink?.Select(sb => $"{nameof(sb.Series.Name)}={sb.Series.Name}, {nameof(sb.Series.AudibleSeriesId)}={sb.Series.AudibleSeriesId}"));
+						Serilog.Log.Logger.Error(ex, "Episode={episodeBook}, Series: {seriesLinks}", episodeBook, seriesLinks);
+						throw ex;
+					}
+
+					seriesEntry = new SeriesEntry(seriesBook, episodeBook);
+					seriesEntries.Add(seriesEntry);
+
+					episodeEntry = seriesEntry.Children[0];
+					seriesEntry.Liberate.Expanded = true;
+					bindingList.Insert(0, seriesEntry);
+				}
+				else
+				{
+					//Series exists. Create and add episode child then update the SeriesEntry
+					episodeEntry = new(episodeBook) { Parent = seriesEntry };
+					seriesEntry.Children.Add(episodeEntry);
+					var seriesBook = dbBooks.Single(lb => lb.Book.AudibleProductId == seriesEntry.LibraryBook.Book.AudibleProductId);
+					seriesEntry.UpdateSeries(seriesBook);
+				}
+
+				//Add episode to the grid beneath the parent
+				int seriesIndex = bindingList.IndexOf(seriesEntry);
+				bindingList.Insert(seriesIndex + 1, episodeEntry);
+
+				if (seriesEntry.Liberate.Expanded)
+					bindingList.ExpandItem(seriesEntry);
+				else
+					bindingList.CollapseItem(seriesEntry);
+
+				seriesEntry.NotifyPropertyChanged();
+
+			}
+			else
+				existingEpisodeEntry.UpdateLibraryBook(episodeBook);
 		}
 
 		#endregion
@@ -207,7 +249,7 @@ namespace LibationWinForms.GridView
 				syncBindingSource.Filter = searchString;
 
 			if (visibleCount != bindingList.Count)
-				VisibleCountChanged?.Invoke(this, bindingList.LibraryBooks().Count());
+				VisibleCountChanged?.Invoke(this, bindingList.BookEntries().Count());
 
 		}
 

--- a/Source/LibationWinForms/GridView/ProductsGrid.cs
+++ b/Source/LibationWinForms/GridView/ProductsGrid.cs
@@ -91,13 +91,13 @@ namespace LibationWinForms.GridView
 
 		internal void BindToGrid(List<LibraryBook> dbBooks)
 		{
-			var geList = dbBooks.Where(lb => lb.IsProduct()).Select(b => new LibraryBookEntry(b)).Cast<GridEntry>().ToList();
+			var geList = dbBooks.Where(lb => lb.Book.IsProduct()).Select(b => new LibraryBookEntry(b)).Cast<GridEntry>().ToList();
 
-			var episodes = dbBooks.Where(lb => lb.IsEpisodeChild());
+			var episodes = dbBooks.Where(lb => lb.Book.IsEpisodeChild());
 						
-			foreach (var parent in dbBooks.Where(lb => lb.IsEpisodeParent()))
+			foreach (var parent in dbBooks.Where(lb => lb.Book.IsEpisodeParent()))
 			{
-				var seriesEpisodes = episodes.FindChildren(parent).ToList();
+				var seriesEpisodes = episodes.FindChildren(parent);
 
 				if (!seriesEpisodes.Any()) continue;
 
@@ -132,9 +132,9 @@ namespace LibationWinForms.GridView
 			{
 				var existingEntry = allEntries.FindByAsin(libraryBook.Book.AudibleProductId);
 
-				if (libraryBook.IsProduct())
+				if (libraryBook.Book.IsProduct())
 					AddOrUpdateBook(libraryBook, existingEntry);
-				else if(libraryBook.IsEpisodeChild()) 
+				else if(libraryBook.Book.IsEpisodeChild()) 
 					AddOrUpdateEpisode(libraryBook, existingEntry, seriesEntries, dbBooks);				 
 			}	
 

--- a/Source/LibationWinForms/GridView/QueryExtensions.cs
+++ b/Source/LibationWinForms/GridView/QueryExtensions.cs
@@ -8,9 +8,6 @@ namespace LibationWinForms.GridView
 #nullable enable
 	internal static class QueryExtensions
 	{
-		public static IEnumerable<LibraryBook> FindChildren(this IEnumerable<LibraryBook> bookList, LibraryBook parent)
-			=> bookList.Where(lb => lb.Book.SeriesLink?.Any(s => s.Series.AudibleSeriesId == parent.Book.AudibleProductId) == true);
-
 		public static IEnumerable<LibraryBookEntry> BookEntries(this IEnumerable<GridEntry> gridEntries)
 			=> gridEntries.OfType<LibraryBookEntry>();
 
@@ -23,15 +20,6 @@ namespace LibationWinForms.GridView
 		public static IEnumerable<SeriesEntry> EmptySeries(this IEnumerable<GridEntry> gridEntries)
 			=> gridEntries.SeriesEntries().Where(i => i.Children.Count == 0);
 
-		public static bool IsProduct(this LibraryBook lb)
-			=> lb.Book.ContentType is not ContentType.Episode and not ContentType.Parent;
-
-		public static bool IsEpisodeChild(this LibraryBook lb)
-			=> lb.Book.ContentType is ContentType.Episode;
-
-		public static bool IsEpisodeParent(this LibraryBook lb)
-			=> lb.Book.ContentType is ContentType.Parent;
-
 		public static SeriesEntry? FindSeriesParent(this IEnumerable<GridEntry> gridEntries, LibraryBook seriesEpisode)
 		{
 			if (seriesEpisode.Book.SeriesLink is null) return null;
@@ -42,19 +30,6 @@ namespace LibationWinForms.GridView
 				lb =>
 				seriesEpisode.Book.SeriesLink.Any(
 					s => s.Series.AudibleSeriesId == lb.LibraryBook.Book.SeriesLink.Single().Series.AudibleSeriesId));
-		}
-
-		public static LibraryBook? FindSeriesParent(this IEnumerable<LibraryBook> libraryBooks, LibraryBook seriesEpisode)
-		{
-			if (seriesEpisode.Book.SeriesLink is null) return null;
-
-			//Parent books will always have exactly 1 SeriesBook due to how
-			//they are imported in ApiExtended.getChildEpisodesAsync()
-			return libraryBooks.FirstOrDefault(
-				lb =>
-				lb.IsEpisodeParent() &&
-				seriesEpisode.Book.SeriesLink.Any(
-					s => s.Series.AudibleSeriesId == lb.Book.SeriesLink.Single().Series.AudibleSeriesId));
 		}
 	}
 #nullable disable

--- a/Source/LibationWinForms/GridView/QueryExtensions.cs
+++ b/Source/LibationWinForms/GridView/QueryExtensions.cs
@@ -8,6 +8,9 @@ namespace LibationWinForms.GridView
 #nullable enable
 	internal static class QueryExtensions
 	{
+		public static IEnumerable<LibraryBook> FindChildren(this IEnumerable<LibraryBook> bookList, LibraryBook parent)
+			=> bookList.Where(lb => lb.Book.SeriesLink?.Any(s => s.Series.AudibleSeriesId == parent.Book.AudibleProductId) == true);
+
 		public static IEnumerable<LibraryBookEntry> BookEntries(this IEnumerable<GridEntry> gridEntries)
 			=> gridEntries.OfType<LibraryBookEntry>();
 

--- a/Source/LibationWinForms/GridView/QueryExtensions.cs
+++ b/Source/LibationWinForms/GridView/QueryExtensions.cs
@@ -1,0 +1,58 @@
+﻿using DataLayer;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace LibationWinForms.GridView
+{
+#nullable enable
+	internal static class QueryExtensions
+	{
+		public static IEnumerable<LibraryBookEntry> BookEntries(this IEnumerable<GridEntry> gridEntries)
+			=> gridEntries.OfType<LibraryBookEntry>();
+
+		public static IEnumerable<SeriesEntry> SeriesEntries(this IEnumerable<GridEntry> gridEntries)
+			=> gridEntries.OfType<SeriesEntry>();
+
+		public static T? FindByAsin<T>(this IEnumerable<T> gridEntries, string audibleProductID) where T : GridEntry
+			=> gridEntries.FirstOrDefault(i => i.AudibleProductId == audibleProductID);
+
+		public static IEnumerable<SeriesEntry> EmptySeries(this IEnumerable<GridEntry> gridEntries)
+			=> gridEntries.SeriesEntries().Where(i => i.Children.Count == 0);
+
+		public static bool IsProduct(this LibraryBook lb)
+			=> lb.Book.ContentType is not ContentType.Episode and not ContentType.Parent;
+
+		public static bool IsEpisodeChild(this LibraryBook lb)
+			=> lb.Book.ContentType is ContentType.Episode;
+
+		public static bool IsEpisodeParent(this LibraryBook lb)
+			=> lb.Book.ContentType is ContentType.Parent;
+
+		public static SeriesEntry? FindSeriesParent(this IEnumerable<GridEntry> gridEntries, LibraryBook seriesEpisode)
+		{
+			if (seriesEpisode.Book.SeriesLink is null) return null;
+
+			//Parent books will always have exactly 1 SeriesBook due to how
+			//they are imported in ApiExtended.getChildEpisodesAsync()
+			return gridEntries.SeriesEntries().FirstOrDefault(
+				lb =>
+				seriesEpisode.Book.SeriesLink.Any(
+					s => s.Series.AudibleSeriesId == lb.LibraryBook.Book.SeriesLink.Single().Series.AudibleSeriesId));
+		}
+
+		public static LibraryBook? FindSeriesParent(this IEnumerable<LibraryBook> libraryBooks, LibraryBook seriesEpisode)
+		{
+			if (seriesEpisode.Book.SeriesLink is null) return null;
+
+			//Parent books will always have exactly 1 SeriesBook due to how
+			//they are imported in ApiExtended.getChildEpisodesAsync()
+			return libraryBooks.FirstOrDefault(
+				lb =>
+				lb.IsEpisodeParent() &&
+				seriesEpisode.Book.SeriesLink.Any(
+					s => s.Series.AudibleSeriesId == lb.Book.SeriesLink.Single().Series.AudibleSeriesId));
+		}
+	}
+#nullable disable
+}

--- a/Source/LibationWinForms/GridView/SeriesEntry.cs
+++ b/Source/LibationWinForms/GridView/SeriesEntry.cs
@@ -65,6 +65,8 @@ namespace LibationWinForms.GridView
 			NotifyPropertyChanged();
 		}
 
+		#region Data Sorting
+
 		/// <summary>Create getters for all member object values by name</summary>
 		protected override Dictionary<string, Func<object>> CreateMemberValueDictionary() => new()
 		{
@@ -83,5 +85,7 @@ namespace LibationWinForms.GridView
 			{ nameof(Liberate), () => Liberate },
 			{ nameof(DateAdded), () => DateAdded },
 		};
+
+		#endregion
 	}
 }

--- a/Source/LibationWinForms/GridView/SeriesEntry.cs
+++ b/Source/LibationWinForms/GridView/SeriesEntry.cs
@@ -14,52 +14,47 @@ namespace LibationWinForms.GridView
 		public override string DisplayTags { get; } = string.Empty;
 		public override LiberateButtonStatus Liberate { get; }
 
-		private SeriesEntry()
+		private SeriesEntry(LibraryBook parent)
 		{
 			Liberate = new LiberateButtonStatus { IsSeries = true };
 			SeriesIndex = -1;
+			LibraryBook = parent;
+			LoadCover();
 		}
 
-		public SeriesEntry(LibraryBook parent, IEnumerable<LibraryBook> children) : this()
+		public SeriesEntry(LibraryBook parent, IEnumerable<LibraryBook> children) : this(parent)
 		{
 			Children = children
 				.Select(c => new LibraryBookEntry(c) { Parent = this })
 				.OrderBy(c => c.SeriesIndex)
 				.ToList();
-
 			UpdateSeries(parent);
-			LoadCover();
 		}
 
-		public SeriesEntry(LibraryBook parent, LibraryBook child) : this()
+		public SeriesEntry(LibraryBook parent, LibraryBook child) : this(parent)
 		{
 			Children = new() { new LibraryBookEntry(child) { Parent = this } };
-
 			UpdateSeries(parent);
-			LoadCover();
 		}
 
-		public void UpdateSeries(LibraryBook libraryBook)
+		public void UpdateSeries(LibraryBook parent)
 		{
-			LibraryBook = libraryBook;
+			LibraryBook = parent;
 
-			// Immutable properties
-			{
-				Title = Book.Title;
-				Series = Book.SeriesNames();
-				MyRating = Book.UserDefinedItem.Rating?.ToStarString()?.DefaultIfNullOrWhiteSpace("");
-				PurchaseDate = Children.Min(c => c.LibraryBook.DateAdded).ToString("d");
-				ProductRating = Book.Rating?.ToStarString()?.DefaultIfNullOrWhiteSpace("");
-				Authors = Book.AuthorNames();
-				Narrators = Book.NarratorNames();
-				Category = string.Join(" > ", Book.CategoriesNames());
-				Misc = GetMiscDisplay(libraryBook);
-				LongDescription = GetDescriptionDisplay(Book);
-				Description = TrimTextToWord(LongDescription, 62);
+			Title = Book.Title;
+			Series = Book.SeriesNames();
+			MyRating = Book.UserDefinedItem.Rating?.ToStarString()?.DefaultIfNullOrWhiteSpace("");
+			PurchaseDate = Children.Min(c => c.LibraryBook.DateAdded).ToString("d");
+			ProductRating = Book.Rating?.ToStarString()?.DefaultIfNullOrWhiteSpace("");
+			Authors = Book.AuthorNames();
+			Narrators = Book.NarratorNames();
+			Category = string.Join(" > ", Book.CategoriesNames());
+			Misc = GetMiscDisplay(LibraryBook);
+			LongDescription = GetDescriptionDisplay(Book);
+			Description = TrimTextToWord(LongDescription, 62);
 
-				int bookLenMins = Children.Sum(c => c.LibraryBook.Book.LengthInMinutes);
-				Length = bookLenMins == 0 ? "" : $"{bookLenMins / 60} hr {bookLenMins % 60} min";
-			}
+			int bookLenMins = Children.Sum(c => c.LibraryBook.Book.LengthInMinutes);
+			Length = bookLenMins == 0 ? "" : $"{bookLenMins / 60} hr {bookLenMins % 60} min";
 
 			NotifyPropertyChanged();
 		}

--- a/Source/LibationWinForms/GridView/SeriesEntry.cs
+++ b/Source/LibationWinForms/GridView/SeriesEntry.cs
@@ -2,6 +2,7 @@
 using Dinah.Core;
 using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Linq;
 
 namespace LibationWinForms.GridView
@@ -9,10 +10,15 @@ namespace LibationWinForms.GridView
 	/// <summary>The View Model for a LibraryBook that is ContentType.Parent</summary>
 	public class SeriesEntry : GridEntry
 	{
-		public List<LibraryBookEntry> Children { get; }
-		public override DateTime DateAdded => Children.Max(c => c.DateAdded);
-		public override string DisplayTags { get; } = string.Empty;
+		[Browsable(false)] public List<LibraryBookEntry> Children { get; }
+		[Browsable(false)] public override DateTime DateAdded => Children.Max(c => c.DateAdded);
+
+		#region Model properties exposed to the view
+
 		public override LiberateButtonStatus Liberate { get; }
+		public override string DisplayTags { get; } = string.Empty;
+
+		#endregion
 
 		private SeriesEntry(LibraryBook parent)
 		{

--- a/Source/LibationWinForms/GridView/SeriesEntry.cs
+++ b/Source/LibationWinForms/GridView/SeriesEntry.cs
@@ -9,19 +9,18 @@ namespace LibationWinForms.GridView
 	/// <summary>The View Model for a LibraryBook that is ContentType.Parent</summary>
 	public class SeriesEntry : GridEntry
 	{
-		public List<LibraryBookEntry> Children { get; } = new();
+		public List<LibraryBookEntry> Children { get; }
 		public override DateTime DateAdded => Children.Max(c => c.DateAdded);
 		public override string DisplayTags { get; } = string.Empty;
 		public override LiberateButtonStatus Liberate { get; }
 
-		private SeriesEntry(LibraryBook parent)
+		private SeriesEntry()
 		{
-			LibraryBook = parent;
 			Liberate = new LiberateButtonStatus { IsSeries = true };
 			SeriesIndex = -1;
 		}
 
-		public SeriesEntry(LibraryBook parent, IEnumerable<LibraryBook> children) : this(parent)
+		public SeriesEntry(LibraryBook parent, IEnumerable<LibraryBook> children) : this()
 		{
 			Children = children
 				.Select(c => new LibraryBookEntry(c) { Parent = this })
@@ -32,7 +31,7 @@ namespace LibationWinForms.GridView
 			LoadCover();
 		}
 
-		public SeriesEntry(LibraryBook parent, LibraryBook child) : this(parent)
+		public SeriesEntry(LibraryBook parent, LibraryBook child) : this()
 		{
 			Children = new() { new LibraryBookEntry(child) { Parent = this } };
 

--- a/Source/LibationWinForms/ProcessQueue/ProcessQueueControl.cs
+++ b/Source/LibationWinForms/ProcessQueue/ProcessQueueControl.cs
@@ -80,6 +80,15 @@ namespace LibationWinForms.ProcessQueue
 		private bool isBookInQueue(DataLayer.LibraryBook libraryBook)
 			=> Queue.Any(b => b?.LibraryBook?.Book?.AudibleProductId == libraryBook.Book.AudibleProductId);
 
+		public void AddDownloadPdf(DataLayer.LibraryBook libraryBook)
+			=> AddDownloadPdf(new List<DataLayer.LibraryBook>() { libraryBook });
+
+		public void AddDownloadDecrypt(DataLayer.LibraryBook libraryBook)
+			=> AddDownloadDecrypt(new List<DataLayer.LibraryBook>() { libraryBook });
+
+		public void AddConvertMp3(DataLayer.LibraryBook libraryBook)
+			=> AddConvertMp3(new List<DataLayer.LibraryBook>() { libraryBook });
+
 		public void AddDownloadPdf(IEnumerable<DataLayer.LibraryBook> entries)
 		{
 			List<ProcessBook> procs = new();
@@ -132,40 +141,6 @@ namespace LibationWinForms.ProcessQueue
 			AddToQueue(procs);
 		}
 
-		public void AddDownloadPdf(DataLayer.LibraryBook libraryBook)
-		{
-			if (isBookInQueue(libraryBook))
-				return;
-
-			ProcessBook pbook = new(libraryBook, Logger);
-			pbook.PropertyChanged += Pbook_DataAvailable;
-			pbook.AddDownloadPdf();
-			AddToQueue(pbook);
-		}
-
-		public void AddDownloadDecrypt(DataLayer.LibraryBook libraryBook)
-		{
-			if (isBookInQueue(libraryBook))
-				return;
-
-			ProcessBook pbook = new(libraryBook, Logger);
-			pbook.PropertyChanged += Pbook_DataAvailable;
-			pbook.AddDownloadDecryptBook();
-			pbook.AddDownloadPdf();
-			AddToQueue(pbook);
-		}
-
-		public void AddConvertMp3(DataLayer.LibraryBook libraryBook)
-		{
-			if (isBookInQueue(libraryBook))
-				return;
-
-			ProcessBook pbook = new(libraryBook, Logger);
-			pbook.PropertyChanged += Pbook_DataAvailable;
-			pbook.AddConvertToMp3();
-			AddToQueue(pbook);
-		}
-
 		private void AddToQueue(IEnumerable<ProcessBook> pbook)
 		{
 			syncContext.Post(_ =>
@@ -177,21 +152,11 @@ namespace LibationWinForms.ProcessQueue
 			null);
 		}
 
-		private void AddToQueue(ProcessBook pbook)
-		{
-			syncContext.Post(_ =>
-			{
-				Queue.Enqueue(pbook);
-				if (!Running)
-					QueueRunner = QueueLoop();
-			}, 
-			null);			
-		}
 
-		DateTime StartintTime;
+		DateTime StartingTime;
 		private async Task QueueLoop()
 		{
-			StartintTime = DateTime.Now;
+			StartingTime = DateTime.Now;
 			counterTimer.Start();
 
 			while (Queue.MoveNext())
@@ -273,7 +238,7 @@ namespace LibationWinForms.ProcessQueue
 			}
 
 			if (Running)
-				runningTimeLbl.Text = timeToStr(DateTime.Now - StartintTime);
+				runningTimeLbl.Text = timeToStr(DateTime.Now - StartingTime);
 		}
 
 		private void clearLogBtn_Click(object sender, EventArgs e)

--- a/Source/LibationWinForms/ProcessQueue/ProcessQueueControl.cs
+++ b/Source/LibationWinForms/ProcessQueue/ProcessQueueControl.cs
@@ -77,27 +77,64 @@ namespace LibationWinForms.ProcessQueue
 			CompletedCount = 0;
 		}
 
+		private bool isBookInQueue(DataLayer.LibraryBook libraryBook)
+			=> Queue.Any(b => b?.LibraryBook?.Book?.AudibleProductId == libraryBook.Book.AudibleProductId);
+
 		public void AddDownloadPdf(IEnumerable<DataLayer.LibraryBook> entries)
 		{
+			List<ProcessBook> procs = new();
 			foreach (var entry in entries)
-				AddDownloadPdf(entry);
+			{
+				if (isBookInQueue(entry))
+					continue;
+
+				ProcessBook pbook = new(entry, Logger);
+				pbook.PropertyChanged += Pbook_DataAvailable;
+				pbook.AddDownloadPdf();
+				procs.Add(pbook);
+			}
+
+			AddToQueue(procs);
 		}
 
 		public void AddDownloadDecrypt(IEnumerable<DataLayer.LibraryBook> entries)
 		{
+			List<ProcessBook> procs = new();
 			foreach (var entry in entries)
-				AddDownloadDecrypt(entry);
+			{
+				if (isBookInQueue(entry))
+					continue;
+
+				ProcessBook pbook = new(entry, Logger);
+				pbook.PropertyChanged += Pbook_DataAvailable;
+				pbook.AddDownloadDecryptBook();
+				pbook.AddDownloadPdf();
+				procs.Add(pbook);
+			}
+
+			AddToQueue(procs);
 		}
 		
 		public void AddConvertMp3(IEnumerable<DataLayer.LibraryBook> entries)
 		{
+			List<ProcessBook> procs = new();
 			foreach (var entry in entries)
-				AddConvertMp3(entry);
+			{
+				if (isBookInQueue(entry))
+					continue;
+
+				ProcessBook pbook = new(entry, Logger);
+				pbook.PropertyChanged += Pbook_DataAvailable;
+				pbook.AddConvertToMp3();
+				procs.Add(pbook);
+			}
+
+			AddToQueue(procs);
 		}
 
 		public void AddDownloadPdf(DataLayer.LibraryBook libraryBook)
 		{
-			if (Queue.Any(b => b?.LibraryBook?.Book?.AudibleProductId == libraryBook.Book.AudibleProductId))
+			if (isBookInQueue(libraryBook))
 				return;
 
 			ProcessBook pbook = new(libraryBook, Logger);
@@ -108,7 +145,7 @@ namespace LibationWinForms.ProcessQueue
 
 		public void AddDownloadDecrypt(DataLayer.LibraryBook libraryBook)
 		{
-			if (Queue.Any(b => b?.LibraryBook?.Book?.AudibleProductId == libraryBook.Book.AudibleProductId))
+			if (isBookInQueue(libraryBook))
 				return;
 
 			ProcessBook pbook = new(libraryBook, Logger);
@@ -120,13 +157,24 @@ namespace LibationWinForms.ProcessQueue
 
 		public void AddConvertMp3(DataLayer.LibraryBook libraryBook)
 		{
-			if (Queue.Any(b => b?.LibraryBook?.Book?.AudibleProductId == libraryBook.Book.AudibleProductId))
+			if (isBookInQueue(libraryBook))
 				return;
 
 			ProcessBook pbook = new(libraryBook, Logger);
 			pbook.PropertyChanged += Pbook_DataAvailable;
 			pbook.AddConvertToMp3();
 			AddToQueue(pbook);
+		}
+
+		private void AddToQueue(IEnumerable<ProcessBook> pbook)
+		{
+			syncContext.Post(_ =>
+			{
+				Queue.Enqueue(pbook);
+				if (!Running)
+					QueueRunner = QueueLoop();
+			},
+			null);
 		}
 
 		private void AddToQueue(ProcessBook pbook)

--- a/Source/LibationWinForms/ProcessQueue/TrackedQueue[T].cs
+++ b/Source/LibationWinForms/ProcessQueue/TrackedQueue[T].cs
@@ -226,5 +226,14 @@ namespace LibationWinForms.ProcessQueue
 				QueuededCountChanged?.Invoke(this, _queued.Count);
 			}
 		}
+
+		public void Enqueue(IEnumerable<T> item)
+		{
+			lock (lockObject)
+			{
+				_queued.AddRange(item);
+				QueuededCountChanged?.Invoke(this, _queued.Count);
+			}
+		}
 	}
 }

--- a/Source/LibationWinForms/ProcessQueue/TrackedQueue[T].cs
+++ b/Source/LibationWinForms/ProcessQueue/TrackedQueue[T].cs
@@ -181,7 +181,7 @@ namespace LibationWinForms.ProcessQueue
 
 		public bool MoveNext()
 		{
-			int queuedCount, completedCount = 0;
+			int completedCount = 0, queuedCount = 0;
 			bool completedChanged = false;
 			try
 			{
@@ -208,8 +208,8 @@ namespace LibationWinForms.ProcessQueue
 			finally
 			{
 				if (completedChanged)
-					CompletedCountChanged?.Invoke(this, _completed.Count);
-				QueuededCountChanged?.Invoke(this, _queued.Count);
+					CompletedCountChanged?.Invoke(this, completedCount);
+				QueuededCountChanged?.Invoke(this, queuedCount);
 			}
 		}
 

--- a/Source/LibationWinForms/ProcessQueue/TrackedQueue[T].cs
+++ b/Source/LibationWinForms/ProcessQueue/TrackedQueue[T].cs
@@ -85,13 +85,18 @@ namespace LibationWinForms.ProcessQueue
 
 		public bool RemoveQueued(T item)
 		{
+			bool itemsRemoved;
+			int queuedCount;
+
 			lock (lockObject)
 			{
-				bool removed = _queued.Remove(item);
-				if (removed)
-					QueuededCountChanged?.Invoke(this, _queued.Count);
-				return removed;
+				itemsRemoved = _queued.Remove(item);
+				queuedCount = _queued.Count;
 			}
+
+			if (itemsRemoved)
+				QueuededCountChanged?.Invoke(this, queuedCount);
+			return itemsRemoved;
 		}
 
 		public void ClearCurrent()
@@ -102,31 +107,32 @@ namespace LibationWinForms.ProcessQueue
 		
 		public bool RemoveCompleted(T item)
 		{
+			bool itemsRemoved;
+			int completedCount;
+
 			lock (lockObject)
 			{
-				bool removed = _completed.Remove(item);
-				if (removed)
-					CompletedCountChanged?.Invoke(this, _completed.Count);
-				return removed;
+				itemsRemoved = _completed.Remove(item);
+				completedCount = _completed.Count;
 			}
+
+			if (itemsRemoved)
+				CompletedCountChanged?.Invoke(this, completedCount);
+			return itemsRemoved;
 		}
 
 		public void ClearQueue()
 		{
 			lock (lockObject)
-			{
 				_queued.Clear();
-				QueuededCountChanged?.Invoke(this, 0);
-			}
+			QueuededCountChanged?.Invoke(this, 0);
 		}
 
 		public void ClearCompleted()
 		{
 			lock (lockObject)
-			{
 				_completed.Clear();
-				CompletedCountChanged?.Invoke(this, 0);
-			}
+			CompletedCountChanged?.Invoke(this, 0);
 		}
 
 		public bool Any(Func<T, bool> predicate)
@@ -175,23 +181,35 @@ namespace LibationWinForms.ProcessQueue
 
 		public bool MoveNext()
 		{
-			lock (lockObject)
+			int queuedCount, completedCount = 0;
+			bool completedChanged = false;
+			try
 			{
-				if (Current != null)
+				lock (lockObject)
 				{
-					_completed.Add(Current);
-					CompletedCountChanged?.Invoke(this, _completed.Count);
-				}
-				if (_queued.Count == 0)
-				{
-					Current = null;
-					return false;
-				}
-				Current = _queued[0];
-				_queued.RemoveAt(0);
+					if (Current != null)
+					{
+						_completed.Add(Current);
+						completedCount = _completed.Count;
+						completedChanged = true;
+					}
+					if (_queued.Count == 0)
+					{
+						Current = null;
+						return false;
+					}
+					Current = _queued[0];
+					_queued.RemoveAt(0);
 
+					queuedCount = _queued.Count;
+					return true;
+				}
+			}
+			finally
+			{
+				if (completedChanged)
+					CompletedCountChanged?.Invoke(this, _completed.Count);
 				QueuededCountChanged?.Invoke(this, _queued.Count);
-				return true;
 			}
 		}
 
@@ -218,22 +236,15 @@ namespace LibationWinForms.ProcessQueue
 			}
 		}
 
-		public void Enqueue(T item)
-		{
-			lock (lockObject)
-			{
-				_queued.Add(item);
-				QueuededCountChanged?.Invoke(this, _queued.Count);
-			}
-		}
-
 		public void Enqueue(IEnumerable<T> item)
 		{
+			int queueCount;
 			lock (lockObject)
 			{
 				_queued.AddRange(item);
-				QueuededCountChanged?.Invoke(this, _queued.Count);
+				queueCount = _queued.Count;
 			}
+			QueuededCountChanged?.Invoke(this, queueCount);
 		}
 	}
 }


### PR DESCRIPTION
There's a lot to unpack here, so I'll just go buy bullets and hope I get everything.

1. Added a migration to remove books and series that have the "SERIES_" prefix from the db. The effect of this migration, along with new Parent content type (Items 2 and 4 below) is that when this version is launched, no episodes will appear in the grid.  All episodes are still in the db along with any `UserDefinedItem`, but they are not added to the grid because they don't have any parents.  This is solved after the first library sync, after which all episodes will be back in the grid and intact.
2. Added `Parent` to `ContentType` enum with value of 4.  Flags are not needed (as explained in 3.2), but I thought I'd preserve the options for flags in the future.
3. Edited `ApiExtended` to import episodes and series parents
   1. Using the new `Item.IsSeriesParent` [from my AudibleApi PR](https://github.com/rmcrackan/AudibleApi/pull/28), `getItemsAsync` retrieves individual episodes as well as the series parent.
   2. I was wrong about [the first part of what went wrong](https://github.com/rmcrackan/Libation/issues/265#issuecomment-1139205952). What ACTUALLY went wrong is that an individual **episode** of a podcast was added to the library and not the podcast **series**. When a series is added to the library, the Api's library endpoint returns just the series item and not any of the series' episodes.  But users are also allowed to just add individual episodes and not whole series to their library. When they do that, the library endpoint returns individual episodes. To handle these cases inside Libation, I added code in the `getChildEpisodesAsync` to retrieve the series parent from the catalog endpoint and add it to the library. So there is no need to make `ContentType` private, and no DB migration is required. As far as I can tell at this time, there are no orphan episodes in the Audible catalog.
   3. `GetLibrary_Flat_NoTracking()` now has an overload to include `ContentType.Parent` in the returned books. Default is to not include parents. The only place where we query the library with parents is in `ProductsDisplay.Display()`
4. Modified GridView classes to use new `ContentType.Parent`
   1. Modified `SeriesEntry` to use series-specific values for everything except `PurchaseDate` and `Length`.
   2. Refactored `SeriesEntry`, `LibraryBookEntry` and `GridEntry` for more code reuse.
   4. Clicking on a `SeriesEntry` cover and description now launch windows for full display like they already do for `LibraryBookEntry`
   5. Refactored `ProductsGrid.UpdateGrid` for clarity and safety, and to use the the new parent content type.
   6. Moved queries into QueryExtensions and added some new ones.
5. Sped-up adding multiple books to `ProcessQueueControl`. UI no longer hangs. This should also resolve an uncommon error that could happen while liberating a large batch if the first book in queue completed before the queue was finished populating.
