### PR TITLE
Fixed rare bug that would hang if an error occured while downloading

### DIFF
--- a/Source/AaxDecrypter/AaxDecrypter.csproj
+++ b/Source/AaxDecrypter/AaxDecrypter.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AAXClean.Codecs" Version="0.2.9" />
+    <PackageReference Include="AAXClean.Codecs" Version="0.2.10" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Source/AaxDecrypter/NetworkFileStream.cs
+++ b/Source/AaxDecrypter/NetworkFileStream.cs
@@ -145,7 +145,14 @@ namespace AaxDecrypter
 		private void Update()
 		{
 			RequestHeaders = HttpRequest.Headers;
-			Updated?.Invoke(this, EventArgs.Empty);
+			try
+			{
+				Updated?.Invoke(this, EventArgs.Empty);
+			}
+			catch (Exception ex)
+			{
+				Serilog.Log.Error(ex, "An error was encountered while saving the download progress to JSON");
+			}
 		}
 
 		/// <summary>
@@ -245,9 +252,6 @@ namespace AaxDecrypter
 				WritePosition = downloadPosition;
 				Update();
 
-				downloadedPiece.Set();
-				downloadEnded.Set();
-
 				if (!IsCancelled && WritePosition < ContentLength)
 					throw new WebException($"Downloaded size (0x{WritePosition:X10}) is less than {nameof(ContentLength)} (0x{ContentLength:X10}).");
 
@@ -258,6 +262,11 @@ namespace AaxDecrypter
 			{
 				Serilog.Log.Error(ex, "An error was encountered while downloading {Uri}", Uri);
 				IsCancelled = true;
+			}
+			finally
+			{
+				downloadedPiece.Set();
+				downloadEnded.Set();
 			}
 		}
 
@@ -401,10 +410,11 @@ namespace AaxDecrypter
 		{
 			if (!hasBegunDownloading)
 				BeginDownloading();
-
+			
 			var toRead = Math.Min(count, Length - Position);
 			WaitToPosition(Position + toRead);
-			return _readFile.Read(buffer, offset, count);
+
+			return IsCancelled ? 0 : _readFile.Read(buffer, offset, count);
 		}
 
 		public override long Seek(long offset, SeekOrigin origin)

--- a/Source/AaxDecrypter/NetworkFileStream.cs
+++ b/Source/AaxDecrypter/NetworkFileStream.cs
@@ -412,7 +412,6 @@ namespace AaxDecrypter
 			
 			var toRead = Math.Min(count, Length - Position);
 			WaitToPosition(Position + toRead);
-
 			return _readFile.Read(buffer, offset, count);
 		}
 
@@ -435,11 +434,13 @@ namespace AaxDecrypter
 		/// <param name="requiredPosition">The minimum required flished data length in <see cref="SaveFilePath"/>.</param>
 		private void WaitToPosition(long requiredPosition)
 		{
-			while (requiredPosition > WritePosition
+			while (WritePosition < requiredPosition
 				&& hasBegunDownloading
 				&& !IsCancelled
-				&& !downloadEnded.WaitOne(0)
-				&& !downloadedPiece.WaitOne(100)) ;
+				&& !downloadEnded.WaitOne(0))
+			{
+				downloadedPiece.WaitOne(100);
+			}
 		}
 
 		public override void Close()

--- a/Source/FileManager/FileNamingTemplate.cs
+++ b/Source/FileManager/FileNamingTemplate.cs
@@ -18,7 +18,8 @@ namespace FileManager
 		/// <summary>Generate a valid path for this file or directory</summary>
 		public LongPath GetFilePath(bool returnFirstExisting = false)
 		{
-			string fileName = Template;
+
+			string fileName = Template.EndsWith(Path.DirectorySeparatorChar) ? Template[..^1] : Template;
 			List<string> pathParts = new();
 
 			var paramReplacements = ParameterReplacements.ToDictionary(r => $"<{formatKey(r.Key)}>", r => formatValue(r.Value));


### PR DESCRIPTION
This took HOURS to find.  Every now and then, a book in the queue would just stop downloading with the CPU core maxed.  Libation was still responsive until you tried to cancel the hung book, then it would lock up the whole process. This would happen if there was an error in the download loop and the file didn't finish downloading. AAXClean would keep calling Read until it got what it needed, but it never checked if Read returned 0 bytes to signal the end of the stream, so it would hang in an infinite loop.

One of the main causes for errors in the download loop turned out to be an IO while trying to write the JsonFilePersister file. I wrapped the Update event invocation in a try/catch block and just log the error.  There's no reason to stop downloading if one of the updates fails to write to disk.

I also discovered some bad logic in the routine that waits for data to be downloaded. ~God know what damage that caused, but it probably caused some silent errors in decrypted files. And it's been around for a long time...~

Never mind. I just realized that this would not have been a problem because the AAXClean bug that I just fixed would have actually counteracted the bad WaitToPosition logic. Phew!