### PR TITLE
Option to combine Opening/End Credits chapters and other changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -184,7 +184,7 @@ publish/
 *.azurePubxml
 # Note: Comment the next line if you want to checkin your web deploy settings,
 # but database connection strings (with potential passwords) will be unencrypted
-*.pubxml
+#*.pubxml
 *.publishproj
 
 # Microsoft Azure Web App publish settings. Comment the next line if you want to

--- a/Source/.config/dotnet-tools.json
+++ b/Source/.config/dotnet-tools.json
@@ -1,0 +1,12 @@
+{
+  "version": 1,
+  "isRoot": true,
+  "tools": {
+    "frogvall.dotnetbumpversion": {
+      "version": "3.0.1",
+      "commands": [
+        "bump-version"
+      ]
+    }
+  }
+}

--- a/Source/AaxDecrypter/AaxDecrypter.csproj
+++ b/Source/AaxDecrypter/AaxDecrypter.csproj
@@ -2,7 +2,6 @@
 
   <PropertyGroup>
     <TargetFramework>net6.0-windows</TargetFramework>
-	  <PublishTrimmed>true</PublishTrimmed>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Source/AaxDecrypter/AaxDecrypter.csproj
+++ b/Source/AaxDecrypter/AaxDecrypter.csproj
@@ -2,13 +2,23 @@
 
   <PropertyGroup>
     <TargetFramework>net6.0-windows</TargetFramework>
+	  <PublishTrimmed>true</PublishTrimmed>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="AAXClean.Codecs" Version="0.2.10" />
   </ItemGroup>
 
-  <ItemGroup>
+	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
+		<DebugType>embedded</DebugType>
+	</PropertyGroup>
+
+	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
+		<DebugType>embedded</DebugType>
+	</PropertyGroup>
+
+
+	<ItemGroup>
     <ProjectReference Include="..\FileManager\FileManager.csproj" />
   </ItemGroup>
 

--- a/Source/AppScaffolding/.msbump
+++ b/Source/AppScaffolding/.msbump
@@ -1,4 +1,0 @@
-{
-  "//": "https://github.com/BalassaMarton/MSBump",
-  BumpRevision: true
-}

--- a/Source/AppScaffolding/AppScaffolding.csproj
+++ b/Source/AppScaffolding/AppScaffolding.csproj
@@ -2,7 +2,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net6.0-windows</TargetFramework>
-    <EnablePreviewFeatures>True</EnablePreviewFeatures>
     <Version>8.1.4.31</Version>
   </PropertyGroup>
   <ItemGroup>

--- a/Source/AppScaffolding/AppScaffolding.csproj
+++ b/Source/AppScaffolding/AppScaffolding.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>net6.0-windows</TargetFramework>
     <EnablePreviewFeatures>True</EnablePreviewFeatures>
-    <Version>8.1.4.16</Version>
+    <Version>8.1.4.30</Version>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Octokit" Version="0.51.0" />
@@ -19,6 +19,6 @@
     <DebugType>embedded</DebugType>
   </PropertyGroup>
   <Target Name="PreBuild" BeforeTargets="PreBuildEvent">
-    <Exec Command="dotnet bump-version revision AppScaffolding.csproj" />
+    <Exec Command="if $(Configuration) == Debug (&#xD;&#xA;dotnet bump-version revision AppScaffolding.csproj&#xD;&#xA;)" />
   </Target>
 </Project>

--- a/Source/AppScaffolding/AppScaffolding.csproj
+++ b/Source/AppScaffolding/AppScaffolding.csproj
@@ -19,4 +19,12 @@
     <ProjectReference Include="..\AudibleUtilities\AudibleUtilities.csproj" />
   </ItemGroup>
 
+	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
+		<DebugType>embedded</DebugType>
+	</PropertyGroup>
+
+	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
+		<DebugType>embedded</DebugType>
+	</PropertyGroup>
+
 </Project>

--- a/Source/AppScaffolding/AppScaffolding.csproj
+++ b/Source/AppScaffolding/AppScaffolding.csproj
@@ -1,30 +1,24 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <TargetFramework>net6.0-windows</TargetFramework>
-    <Version>8.1.4.1</Version>
+    <EnablePreviewFeatures>True</EnablePreviewFeatures>
+    <Version>8.1.4.16</Version>
   </PropertyGroup>
-
   <ItemGroup>
-    <PackageReference Include="MSBump" Version="2.3.2">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
     <PackageReference Include="Octokit" Version="0.51.0" />
   </ItemGroup>
-
   <ItemGroup>
     <ProjectReference Include="..\ApplicationServices\ApplicationServices.csproj" />
     <ProjectReference Include="..\AudibleUtilities\AudibleUtilities.csproj" />
   </ItemGroup>
-
-	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
-		<DebugType>embedded</DebugType>
-	</PropertyGroup>
-
-	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
-		<DebugType>embedded</DebugType>
-	</PropertyGroup>
-
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
+    <DebugType>embedded</DebugType>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
+    <DebugType>embedded</DebugType>
+  </PropertyGroup>
+  <Target Name="PreBuild" BeforeTargets="PreBuildEvent">
+    <Exec Command="dotnet bump-version revision AppScaffolding.csproj" />
+  </Target>
 </Project>

--- a/Source/AppScaffolding/AppScaffolding.csproj
+++ b/Source/AppScaffolding/AppScaffolding.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>net6.0-windows</TargetFramework>
     <EnablePreviewFeatures>True</EnablePreviewFeatures>
-    <Version>8.1.4.30</Version>
+    <Version>8.1.4.31</Version>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Octokit" Version="0.51.0" />

--- a/Source/AppScaffolding/UNSAFE_MigrationHelper.cs
+++ b/Source/AppScaffolding/UNSAFE_MigrationHelper.cs
@@ -25,7 +25,7 @@ namespace AppScaffolding
 			: value;
 
 		#region appsettings.json
-		private static string APPSETTINGS_JSON { get; } = Path.Combine(Path.GetDirectoryName(System.Reflection.Assembly.GetEntryAssembly().Location), "appsettings.json");
+		private static string APPSETTINGS_JSON { get; } = Path.Combine(Path.GetDirectoryName(System.Diagnostics.Process.GetCurrentProcess().MainModule.FileName), "appsettings.json");
 
 		public static bool APPSETTINGS_Json_Exists => File.Exists(APPSETTINGS_JSON);
 

--- a/Source/ApplicationServices/ApplicationServices.csproj
+++ b/Source/ApplicationServices/ApplicationServices.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net6.0-windows</TargetFramework>
+	  <EnablePreviewFeatures>True</EnablePreviewFeatures>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Source/ApplicationServices/ApplicationServices.csproj
+++ b/Source/ApplicationServices/ApplicationServices.csproj
@@ -2,7 +2,6 @@
 
   <PropertyGroup>
     <TargetFramework>net6.0-windows</TargetFramework>
-	  <EnablePreviewFeatures>True</EnablePreviewFeatures>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Source/ApplicationServices/ApplicationServices.csproj
+++ b/Source/ApplicationServices/ApplicationServices.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>net6.0-windows</TargetFramework>
@@ -13,5 +13,13 @@
     <ProjectReference Include="..\DtoImporterService\DtoImporterService.csproj" />
     <ProjectReference Include="..\LibationSearchEngine\LibationSearchEngine.csproj" />
   </ItemGroup>
+
+	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
+		<DebugType>embedded</DebugType>
+	</PropertyGroup>
+
+	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
+		<DebugType>embedded</DebugType>
+	</PropertyGroup>
 
 </Project>

--- a/Source/AudibleUtilities/ApiExtended.cs
+++ b/Source/AudibleUtilities/ApiExtended.cs
@@ -155,7 +155,7 @@ namespace AudibleUtilities
 			//System.IO.File.WriteAllText(library_json, AudibleApi.Common.Converter.ToJson(items));
 #endif
 			var validators = new List<IValidator>();
-			validators.AddRange(getValidators());
+			validators.AddRange(Validators.GetValidators());
 			foreach (var v in validators)
 			{
 				var exceptions = v.Validate(items);
@@ -329,15 +329,5 @@ namespace AudibleUtilities
 			return results;
 		}
 		#endregion
-
-		private static List<IValidator> getValidators()
-		{
-			var type = typeof(IValidator);
-			var types = AppDomain.CurrentDomain.GetAssemblies()
-				.SelectMany(s => s.GetTypes())
-				.Where(p => type.IsAssignableFrom(p) && !p.IsInterface);
-
-			return types.Select(t => Activator.CreateInstance(t) as IValidator).ToList();
-		}
 	}
 }

--- a/Source/AudibleUtilities/ApiExtended.cs
+++ b/Source/AudibleUtilities/ApiExtended.cs
@@ -154,15 +154,16 @@ namespace AudibleUtilities
 #if DEBUG
 			//System.IO.File.WriteAllText(library_json, AudibleApi.Common.Converter.ToJson(items));
 #endif
-			var validators = new List<IValidator>();
-			validators.AddRange(Validators.GetValidators());
-			foreach (var v in validators)
-			{
-				var exceptions = v.Validate(items);
-				if (exceptions is not null && exceptions.Any())
-					throw new AggregateException(exceptions);
-			}
+			var exceptions = new List<Exception>();
 
+			exceptions.AddRange(IValidator.Validate<LibraryValidator>(items));
+			exceptions.AddRange(IValidator.Validate<BookValidator>(items));
+			exceptions.AddRange(IValidator.Validate<CategoryValidator>(items));
+			exceptions.AddRange(IValidator.Validate<ContributorValidator>(items));
+			exceptions.AddRange(IValidator.Validate<SeriesValidator>(items));
+
+			if (exceptions.Any())
+				throw new AggregateException(exceptions);
 			return items;
 		}
 

--- a/Source/AudibleUtilities/ApiExtended.cs
+++ b/Source/AudibleUtilities/ApiExtended.cs
@@ -206,7 +206,8 @@ namespace AudibleUtilities
 					if (numSeriesParents != 1)
 					{
 						//There should only ever be 1 top-level parent per episode. If not, log
-						//and throw so we can figure out what to do about those special cases.
+						//so we can figure out what to do about those special cases, and don't
+						//import the episode.
 						JsonSerializerSettings Settings = new()
 						{
 							MetadataPropertyHandling = MetadataPropertyHandling.Ignore,
@@ -216,9 +217,8 @@ namespace AudibleUtilities
 								new IsoDateTimeConverter { DateTimeStyles = DateTimeStyles.AssumeUniversal }
 							},
 						};
-						var ex = new ApplicationException($"Found {numSeriesParents} parents for {parent.Asin}");
-						Serilog.Log.Logger.Error(ex, $"Episode Product:\r\n{JsonConvert.SerializeObject(parent, Formatting.None, Settings)}");
-						throw ex;
+						Serilog.Log.Logger.Error($"Found {numSeriesParents} parents for {parent.Asin}\r\nEpisode Product:\r\n{JsonConvert.SerializeObject(parent, Formatting.None, Settings)}");
+						return new List<Item>();
 					}
 
 					var realParent = seriesParents.Single(p => p.IsSeriesParent);

--- a/Source/AudibleUtilities/AudibleApiValidators.cs
+++ b/Source/AudibleUtilities/AudibleApiValidators.cs
@@ -7,14 +7,11 @@ namespace AudibleUtilities
 {
 	public interface IValidator
 	{
-		public static abstract IEnumerable<Exception> Validate(IEnumerable<Item> items);
-		public static IEnumerable<Exception> Validate<T>(IEnumerable<Item> items)
-			where T : IValidator
-			=> T.Validate(items);
+		IEnumerable<Exception> Validate(IEnumerable<Item> items);
 	}
 	public class LibraryValidator : IValidator
 	{
-		public static IEnumerable<Exception> Validate(IEnumerable<Item> items)
+		public IEnumerable<Exception> Validate(IEnumerable<Item> items)
 		{
 			var exceptions = new List<Exception>();
 
@@ -28,7 +25,7 @@ namespace AudibleUtilities
 	}
 	public class BookValidator : IValidator
 	{
-		public static IEnumerable<Exception> Validate(IEnumerable<Item> items)
+		public IEnumerable<Exception> Validate(IEnumerable<Item> items)
 		{
 			var exceptions = new List<Exception>();
 
@@ -46,7 +43,7 @@ namespace AudibleUtilities
 	}
 	public class CategoryValidator : IValidator
 	{
-		public static IEnumerable<Exception> Validate(IEnumerable<Item> items)
+		public IEnumerable<Exception> Validate(IEnumerable<Item> items)
 		{
 			var exceptions = new List<Exception>();
 
@@ -61,7 +58,7 @@ namespace AudibleUtilities
 	}
 	public class ContributorValidator : IValidator
 	{
-		public static IEnumerable<Exception> Validate(IEnumerable<Item> items)
+		public IEnumerable<Exception> Validate(IEnumerable<Item> items)
 		{
 			var exceptions = new List<Exception>();
 
@@ -75,7 +72,7 @@ namespace AudibleUtilities
 	}
 	public class SeriesValidator : IValidator
 	{
-		public static IEnumerable<Exception> Validate(IEnumerable<Item> items)
+		public IEnumerable<Exception> Validate(IEnumerable<Item> items)
 		{
 			var exceptions = new List<Exception>();
 

--- a/Source/AudibleUtilities/AudibleApiValidators.cs
+++ b/Source/AudibleUtilities/AudibleApiValidators.cs
@@ -5,6 +5,18 @@ using AudibleApi.Common;
 
 namespace AudibleUtilities
 {
+	public static class Validators
+	{
+		public static IValidator[] GetValidators()
+			=> new IValidator[] 
+			{
+				new LibraryValidator(),
+				new BookValidator(),
+				new CategoryValidator(),
+				new ContributorValidator(),
+				new SeriesValidator(),
+			};
+	}
 	public interface IValidator
 	{
 		IEnumerable<Exception> Validate(IEnumerable<Item> items);

--- a/Source/AudibleUtilities/AudibleApiValidators.cs
+++ b/Source/AudibleUtilities/AudibleApiValidators.cs
@@ -5,25 +5,16 @@ using AudibleApi.Common;
 
 namespace AudibleUtilities
 {
-	public static class Validators
-	{
-		public static IValidator[] GetValidators()
-			=> new IValidator[] 
-			{
-				new LibraryValidator(),
-				new BookValidator(),
-				new CategoryValidator(),
-				new ContributorValidator(),
-				new SeriesValidator(),
-			};
-	}
 	public interface IValidator
 	{
-		IEnumerable<Exception> Validate(IEnumerable<Item> items);
+		public static abstract IEnumerable<Exception> Validate(IEnumerable<Item> items);
+		public static IEnumerable<Exception> Validate<T>(IEnumerable<Item> items)
+			where T : IValidator
+			=> T.Validate(items);
 	}
 	public class LibraryValidator : IValidator
 	{
-		public IEnumerable<Exception> Validate(IEnumerable<Item> items)
+		public static IEnumerable<Exception> Validate(IEnumerable<Item> items)
 		{
 			var exceptions = new List<Exception>();
 
@@ -37,7 +28,7 @@ namespace AudibleUtilities
 	}
 	public class BookValidator : IValidator
 	{
-		public IEnumerable<Exception> Validate(IEnumerable<Item> items)
+		public static IEnumerable<Exception> Validate(IEnumerable<Item> items)
 		{
 			var exceptions = new List<Exception>();
 
@@ -55,7 +46,7 @@ namespace AudibleUtilities
 	}
 	public class CategoryValidator : IValidator
 	{
-		public IEnumerable<Exception> Validate(IEnumerable<Item> items)
+		public static IEnumerable<Exception> Validate(IEnumerable<Item> items)
 		{
 			var exceptions = new List<Exception>();
 
@@ -70,7 +61,7 @@ namespace AudibleUtilities
 	}
 	public class ContributorValidator : IValidator
 	{
-		public IEnumerable<Exception> Validate(IEnumerable<Item> items)
+		public static IEnumerable<Exception> Validate(IEnumerable<Item> items)
 		{
 			var exceptions = new List<Exception>();
 
@@ -84,7 +75,7 @@ namespace AudibleUtilities
 	}
 	public class SeriesValidator : IValidator
 	{
-		public IEnumerable<Exception> Validate(IEnumerable<Item> items)
+		public static IEnumerable<Exception> Validate(IEnumerable<Item> items)
 		{
 			var exceptions = new List<Exception>();
 

--- a/Source/AudibleUtilities/AudibleUtilities.csproj
+++ b/Source/AudibleUtilities/AudibleUtilities.csproj
@@ -2,12 +2,11 @@
 
   <PropertyGroup>
     <TargetFramework>net6.0-windows</TargetFramework>
+	  <EnablePreviewFeatures>True</EnablePreviewFeatures>
   </PropertyGroup>
 
   <ItemGroup>
-   <!-- <PackageReference Include="AudibleApi" Version="4.2.2.1" /> -->
-	  <ProjectReference Include="..\..\..\audible api\AudibleApi\AudibleApi\AudibleApi.csproj" />
-
+   <PackageReference Include="AudibleApi" Version="4.2.2.1" />
   </ItemGroup>
 
 

--- a/Source/AudibleUtilities/AudibleUtilities.csproj
+++ b/Source/AudibleUtilities/AudibleUtilities.csproj
@@ -2,7 +2,6 @@
 
   <PropertyGroup>
     <TargetFramework>net6.0-windows</TargetFramework>
-	  <EnablePreviewFeatures>True</EnablePreviewFeatures>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Source/AudibleUtilities/AudibleUtilities.csproj
+++ b/Source/AudibleUtilities/AudibleUtilities.csproj
@@ -5,10 +5,22 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AudibleApi" Version="4.2.2.1" />
+   <!-- <PackageReference Include="AudibleApi" Version="4.2.2.1" /> -->
+	  <ProjectReference Include="..\..\..\audible api\AudibleApi\AudibleApi\AudibleApi.csproj" />
+
   </ItemGroup>
 
-  <ItemGroup>
+
+	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
+		<DebugType>embedded</DebugType>
+	</PropertyGroup>
+
+	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
+		<DebugType>embedded</DebugType>
+	</PropertyGroup>
+
+
+	<ItemGroup>
     <ProjectReference Include="..\LibationFileManager\LibationFileManager.csproj" />
   </ItemGroup>
 

--- a/Source/AudibleUtilities/AudibleUtilities.csproj
+++ b/Source/AudibleUtilities/AudibleUtilities.csproj
@@ -11,5 +11,13 @@
   <ItemGroup>
     <ProjectReference Include="..\LibationFileManager\LibationFileManager.csproj" />
   </ItemGroup>
+	
+	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
+		<DebugType>embedded</DebugType>
+	</PropertyGroup>
+
+	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
+		<DebugType>embedded</DebugType>
+	</PropertyGroup>
 
 </Project>

--- a/Source/AudibleUtilities/AudibleUtilities.csproj
+++ b/Source/AudibleUtilities/AudibleUtilities.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AudibleApi" Version="4.3.0.1" />
+    <PackageReference Include="AudibleApi" Version="4.3.1.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Source/AudibleUtilities/AudibleUtilities.csproj
+++ b/Source/AudibleUtilities/AudibleUtilities.csproj
@@ -5,20 +5,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-   <PackageReference Include="AudibleApi" Version="4.3.0.1" />
+    <PackageReference Include="AudibleApi" Version="4.3.0.1" />
   </ItemGroup>
 
-
-	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
-		<DebugType>embedded</DebugType>
-	</PropertyGroup>
-
-	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
-		<DebugType>embedded</DebugType>
-	</PropertyGroup>
-
-
-	<ItemGroup>
+  <ItemGroup>
     <ProjectReference Include="..\LibationFileManager\LibationFileManager.csproj" />
   </ItemGroup>
 

--- a/Source/AudibleUtilities/AudibleUtilities.csproj
+++ b/Source/AudibleUtilities/AudibleUtilities.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-   <PackageReference Include="AudibleApi" Version="4.2.2.1" />
+   <PackageReference Include="AudibleApi" Version="4.3.0.1" />
   </ItemGroup>
 
 

--- a/Source/DataLayer/Configurations/BookConfig.cs
+++ b/Source/DataLayer/Configurations/BookConfig.cs
@@ -12,11 +12,13 @@ namespace DataLayer.Configurations
 
             entity.OwnsOne(b => b.Rating);
 
+            entity.Property(nameof(Book._audioFormat));
             //
             // CRUCIAL: ignore unmapped collections, even get-only
             //
             entity.Ignore(nameof(Book.Authors));
             entity.Ignore(nameof(Book.Narrators));
+            entity.Ignore(nameof(Book.AudioFormat));
 			//// these don't seem to matter
 			//entity.Ignore(nameof(Book.AuthorNames));
 			//entity.Ignore(nameof(Book.NarratorNames));

--- a/Source/DataLayer/DataLayer.csproj
+++ b/Source/DataLayer/DataLayer.csproj
@@ -6,9 +6,7 @@
 
   <PropertyGroup>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
-    <ApplicationIcon />
     <OutputType>Library</OutputType>
-    <StartupObject />
   </PropertyGroup>
   
   <ItemGroup>
@@ -23,8 +21,16 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
   </ItemGroup>
-  
-  <ItemGroup>
+
+	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
+		<DebugType>embedded</DebugType>
+	</PropertyGroup>
+
+	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
+		<DebugType>embedded</DebugType>
+	</PropertyGroup>
+
+	<ItemGroup>
     <ProjectReference Include="..\LibationFileManager\LibationFileManager.csproj" />
   </ItemGroup>
   

--- a/Source/DataLayer/EfClasses/AudioFormat.cs
+++ b/Source/DataLayer/EfClasses/AudioFormat.cs
@@ -1,0 +1,62 @@
+﻿using System;
+
+namespace DataLayer
+{
+    internal enum AudioFormatEnum : long
+    {
+        //Defining the enum this way ensures that when comparing:
+        //LC_128_44100_stereo > LC_64_44100_stereo > LC_64_22050_stereo > LC_64_22050_stereo
+        //This matches how audible interprets these codecs when specifying quality using AudibleApi.DownloadQuality
+        //I've never seen mono formats.
+        Unknown = 0,
+        LC_32_22050_stereo = (32L << 18) | (22050 << 2) | 2,
+        LC_64_22050_stereo = (64L << 18) | (22050 << 2) | 2,
+        LC_64_44100_stereo = (64L << 18) | (44100 << 2) | 2,
+        LC_128_44100_stereo = (128L << 18) | (44100 << 2) | 2,
+    }
+
+    public class AudioFormat : IComparable<AudioFormat>, IComparable
+    {
+
+        internal int AudioFormatID { get; private set; }
+        public int Bitrate { get; private init; }
+        public int SampleRate { get; private init; }
+        public int Channels { get; private init; }
+        public bool IsValid => Bitrate != 0 && SampleRate != 0 && Channels != 0;
+
+        public static AudioFormat FromString(string formatStr)
+        {
+            if (Enum.TryParse(formatStr, ignoreCase: true, out AudioFormatEnum enumVal))
+                return FromEnum(enumVal);
+            return FromEnum(AudioFormatEnum.Unknown);
+        }
+
+        internal static AudioFormat FromEnum(AudioFormatEnum enumVal)
+        {
+            var val = (long)enumVal;
+
+            return new()
+            {
+                Bitrate = (int)(val >> 18),
+                SampleRate = (int)(val >> 2) & ushort.MaxValue,
+                Channels = (int)(val & 3)
+            };
+        }
+        internal AudioFormatEnum ToEnum()
+        {
+            var val = (AudioFormatEnum)(((long)Bitrate << 18) | ((long)SampleRate << 2) | (long)Channels);
+
+            return Enum.IsDefined(val) ?
+                val : AudioFormatEnum.Unknown;
+        }
+
+        public override string ToString()
+            => IsValid ?
+            $"{Bitrate} Kbps, {SampleRate / 1000d:F1} kHz, {(Channels == 2 ? "Stereo" : Channels)}" :
+            "Unknown";
+
+        public int CompareTo(AudioFormat other) => ToEnum().CompareTo(other.ToEnum());
+
+        public int CompareTo(object obj) => CompareTo(obj as AudioFormat);
+    }
+}

--- a/Source/DataLayer/EfClasses/Book.cs
+++ b/Source/DataLayer/EfClasses/Book.cs
@@ -25,6 +25,7 @@ namespace DataLayer
         Parent = 4,
     }
 
+
     public class Book
     {
         // implementation detail. set by db only. only used by data layer
@@ -37,6 +38,10 @@ namespace DataLayer
         public int LengthInMinutes { get; private set; }
         public ContentType ContentType { get; private set; }
         public string Locale { get; private set; }
+
+        internal AudioFormatEnum _audioFormat;
+
+        public AudioFormat AudioFormat { get => AudioFormat.FromEnum(_audioFormat); set => _audioFormat = value.ToEnum(); }
 
         // mutable
         public string PictureId { get; set; }

--- a/Source/DataLayer/Migrations/20220624214932_AddAudioFormat.Designer.cs
+++ b/Source/DataLayer/Migrations/20220624214932_AddAudioFormat.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using DataLayer;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -10,9 +11,10 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace DataLayer.Migrations
 {
     [DbContext(typeof(LibationContext))]
-    partial class LibationContextModelSnapshot : ModelSnapshot
+    [Migration("20220624214932_AddAudioFormat")]
+    partial class AddAudioFormat
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder.HasAnnotation("ProductVersion", "6.0.6");

--- a/Source/DataLayer/Migrations/20220624214932_AddAudioFormat.cs
+++ b/Source/DataLayer/Migrations/20220624214932_AddAudioFormat.cs
@@ -1,0 +1,26 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace DataLayer.Migrations
+{
+    public partial class AddAudioFormat : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<long>(
+                name: "_audioFormat",
+                table: "Books",
+                type: "INTEGER",
+                nullable: false,
+                defaultValue: 0L);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "_audioFormat",
+                table: "Books");
+        }
+    }
+}

--- a/Source/DtoImporterService/BookImporter.cs
+++ b/Source/DtoImporterService/BookImporter.cs
@@ -8,8 +8,10 @@ using Dinah.Core.Collections.Generic;
 
 namespace DtoImporterService
 {
-	public class BookImporter : ImporterBase<BookValidator>
+	public class BookImporter : ItemsImporterBase
 	{
+		protected override IValidator Validator => new BookValidator();
+
 		public Dictionary<string, Book> Cache { get; private set; } = new();
 
 		private ContributorImporter contributorImporter { get; }

--- a/Source/DtoImporterService/BookImporter.cs
+++ b/Source/DtoImporterService/BookImporter.cs
@@ -8,10 +8,8 @@ using Dinah.Core.Collections.Generic;
 
 namespace DtoImporterService
 {
-	public class BookImporter : ItemsImporterBase
+	public class BookImporter : ImporterBase<BookValidator>
 	{
-		protected override IValidator Validator => new BookValidator();
-
 		public Dictionary<string, Book> Cache { get; private set; } = new();
 
 		private ContributorImporter contributorImporter { get; }

--- a/Source/DtoImporterService/BookImporter.cs
+++ b/Source/DtoImporterService/BookImporter.cs
@@ -162,6 +162,9 @@ namespace DtoImporterService
 		{
 			var item = importItem.DtoItem;
 
+			var codec = item.AvailableCodecs?.Max(f => AudioFormat.FromString(f.EnhancedCodec)) ?? new AudioFormat();
+			book.AudioFormat = codec;
+
 			// set/update book-specific info which may have changed
 			if (item.PictureId is not null)
 				book.PictureId = item.PictureId;

--- a/Source/DtoImporterService/CategoryImporter.cs
+++ b/Source/DtoImporterService/CategoryImporter.cs
@@ -8,8 +8,10 @@ using Dinah.Core.Collections.Generic;
 
 namespace DtoImporterService
 {
-	public class CategoryImporter : ImporterBase<CategoryValidator>
+	public class CategoryImporter : ItemsImporterBase
 	{
+		protected override IValidator Validator => new CategoryValidator();
+
 		public Dictionary<string, Category> Cache { get; private set; } = new();
 
 		public CategoryImporter(LibationContext context) : base(context) { }

--- a/Source/DtoImporterService/CategoryImporter.cs
+++ b/Source/DtoImporterService/CategoryImporter.cs
@@ -8,10 +8,8 @@ using Dinah.Core.Collections.Generic;
 
 namespace DtoImporterService
 {
-	public class CategoryImporter : ItemsImporterBase
+	public class CategoryImporter : ImporterBase<CategoryValidator>
 	{
-		protected override IValidator Validator => new CategoryValidator();
-
 		public Dictionary<string, Category> Cache { get; private set; } = new();
 
 		public CategoryImporter(LibationContext context) : base(context) { }

--- a/Source/DtoImporterService/ContributorImporter.cs
+++ b/Source/DtoImporterService/ContributorImporter.cs
@@ -8,8 +8,10 @@ using Dinah.Core.Collections.Generic;
 
 namespace DtoImporterService
 {
-	public class ContributorImporter : ImporterBase<ContributorValidator>
+	public class ContributorImporter : ItemsImporterBase
 	{
+		protected override IValidator Validator => new ContributorValidator();
+
 		public Dictionary<string, Contributor> Cache { get; private set; } = new();
 
 		public ContributorImporter(LibationContext context) : base(context) { }
@@ -89,7 +91,7 @@ namespace DtoImporterService
 			return hash.Count;
 		}
 
-        private Contributor addContributor(string name, string id = null)
+		private Contributor addContributor(string name, string id = null)
 		{
 			try
 			{
@@ -106,6 +108,6 @@ namespace DtoImporterService
 				Serilog.Log.Logger.Error(ex, "Error adding contributor. {@DebugInfo}", new { name, id });
 				throw;
 			}
-        }
-    }
+		}
+	}
 }

--- a/Source/DtoImporterService/ContributorImporter.cs
+++ b/Source/DtoImporterService/ContributorImporter.cs
@@ -8,10 +8,8 @@ using Dinah.Core.Collections.Generic;
 
 namespace DtoImporterService
 {
-	public class ContributorImporter : ItemsImporterBase
+	public class ContributorImporter : ImporterBase<ContributorValidator>
 	{
-		protected override IValidator Validator => new ContributorValidator();
-
 		public Dictionary<string, Contributor> Cache { get; private set; } = new();
 
 		public ContributorImporter(LibationContext context) : base(context) { }

--- a/Source/DtoImporterService/DtoImporterService.csproj
+++ b/Source/DtoImporterService/DtoImporterService.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net6.0-windows</TargetFramework>
+	  <EnablePreviewFeatures>True</EnablePreviewFeatures>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">

--- a/Source/DtoImporterService/DtoImporterService.csproj
+++ b/Source/DtoImporterService/DtoImporterService.csproj
@@ -4,6 +4,14 @@
     <TargetFramework>net6.0-windows</TargetFramework>
   </PropertyGroup>
 
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
+    <DebugType>embedded</DebugType>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
+    <DebugType>embedded</DebugType>
+  </PropertyGroup>
+
   <ItemGroup>
     <ProjectReference Include="..\AudibleUtilities\AudibleUtilities.csproj" />
     <ProjectReference Include="..\DataLayer\DataLayer.csproj" />

--- a/Source/DtoImporterService/DtoImporterService.csproj
+++ b/Source/DtoImporterService/DtoImporterService.csproj
@@ -2,7 +2,6 @@
 
   <PropertyGroup>
     <TargetFramework>net6.0-windows</TargetFramework>
-	  <EnablePreviewFeatures>True</EnablePreviewFeatures>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">

--- a/Source/DtoImporterService/ImporterBase.cs
+++ b/Source/DtoImporterService/ImporterBase.cs
@@ -7,7 +7,7 @@ using Dinah.Core;
 
 namespace DtoImporterService
 {
-	public abstract class ImporterBase<T>
+	public abstract class ImporterBase<TValidate> where TValidate : IValidator
 	{
 		protected LibationContext DbContext { get; }
 
@@ -18,13 +18,13 @@ namespace DtoImporterService
 		}
 
 		/// <summary>LONG RUNNING. call with await Task.Run</summary>
-		public int Import(T param) => Run(DoImport, param);
+		public int Import(IEnumerable<ImportItem> param) => Run(DoImport, param);
 
-		public TResult Run<TResult>(Func<T, TResult> func, T param)
+		public TResult Run<TResult>(Func<IEnumerable<ImportItem>, TResult> func, IEnumerable<ImportItem> param)
 		{
 			try
 			{
-				var exceptions = Validate(param);
+				var exceptions = TValidate.Validate(param.Select(i => i.DtoItem));
 				if (exceptions is not null && exceptions.Any())
 					throw new AggregateException($"Importer validation failed", exceptions);
 			}
@@ -46,16 +46,6 @@ namespace DtoImporterService
 			}
 		}
 
-		protected abstract int DoImport(T elements);
-		public abstract IEnumerable<Exception> Validate(T param);
-	}
-
-	public abstract class ItemsImporterBase : ImporterBase<IEnumerable<ImportItem>>
-	{
-		protected ItemsImporterBase(LibationContext context) : base(context) { }
-
-		protected abstract IValidator Validator { get; }
-        public sealed override IEnumerable<Exception> Validate(IEnumerable<ImportItem> importItems)
-			=> Validator.Validate(importItems.Select(i => i.DtoItem));
+		protected abstract int DoImport(IEnumerable<ImportItem> elements);
 	}
 }

--- a/Source/DtoImporterService/ImporterBase.cs
+++ b/Source/DtoImporterService/ImporterBase.cs
@@ -7,7 +7,7 @@ using Dinah.Core;
 
 namespace DtoImporterService
 {
-	public abstract class ImporterBase<TValidate> where TValidate : IValidator
+	public abstract class ImporterBase<T>
 	{
 		protected LibationContext DbContext { get; }
 
@@ -18,13 +18,13 @@ namespace DtoImporterService
 		}
 
 		/// <summary>LONG RUNNING. call with await Task.Run</summary>
-		public int Import(IEnumerable<ImportItem> param) => Run(DoImport, param);
+		public int Import(T param) => Run(DoImport, param);
 
-		public TResult Run<TResult>(Func<IEnumerable<ImportItem>, TResult> func, IEnumerable<ImportItem> param)
+		public TResult Run<TResult>(Func<T, TResult> func, T param)
 		{
 			try
 			{
-				var exceptions = TValidate.Validate(param.Select(i => i.DtoItem));
+				var exceptions = Validate(param);
 				if (exceptions is not null && exceptions.Any())
 					throw new AggregateException($"Importer validation failed", exceptions);
 			}
@@ -46,6 +46,16 @@ namespace DtoImporterService
 			}
 		}
 
-		protected abstract int DoImport(IEnumerable<ImportItem> elements);
+		protected abstract int DoImport(T elements);
+		public abstract IEnumerable<Exception> Validate(T param);
+	}
+
+	public abstract class ItemsImporterBase : ImporterBase<IEnumerable<ImportItem>>
+	{
+		protected ItemsImporterBase(LibationContext context) : base(context) { }
+
+		protected abstract IValidator Validator { get; }
+		public sealed override IEnumerable<Exception> Validate(IEnumerable<ImportItem> importItems)
+			=> Validator.Validate(importItems.Select(i => i.DtoItem));
 	}
 }

--- a/Source/DtoImporterService/LibraryBookImporter.cs
+++ b/Source/DtoImporterService/LibraryBookImporter.cs
@@ -7,10 +7,8 @@ using Dinah.Core.Collections.Generic;
 
 namespace DtoImporterService
 {
-	public class LibraryBookImporter : ItemsImporterBase
+	public class LibraryBookImporter : ImporterBase<LibraryValidator>
 	{
-		protected override IValidator Validator => new LibraryValidator();
-
 		private BookImporter bookImporter { get; }
 
 		public LibraryBookImporter(LibationContext context) : base(context)

--- a/Source/DtoImporterService/LibraryBookImporter.cs
+++ b/Source/DtoImporterService/LibraryBookImporter.cs
@@ -7,8 +7,10 @@ using Dinah.Core.Collections.Generic;
 
 namespace DtoImporterService
 {
-	public class LibraryBookImporter : ImporterBase<LibraryValidator>
+	public class LibraryBookImporter : ItemsImporterBase
 	{
+		protected override IValidator Validator => new LibraryValidator();
+
 		private BookImporter bookImporter { get; }
 
 		public LibraryBookImporter(LibationContext context) : base(context)
@@ -47,7 +49,7 @@ namespace DtoImporterService
 			// just use the first
 			var hash = newItems.ToDictionarySafe(dto => dto.DtoItem.ProductId);
 			foreach (var kvp in hash)
-            {
+			{
 				var newItem = kvp.Value;
 
 				var libraryBook = new LibraryBook(

--- a/Source/DtoImporterService/SeriesImporter.cs
+++ b/Source/DtoImporterService/SeriesImporter.cs
@@ -8,8 +8,10 @@ using Dinah.Core.Collections.Generic;
 
 namespace DtoImporterService
 {
-	public class SeriesImporter : ImporterBase<SeriesValidator>
+	public class SeriesImporter : ItemsImporterBase
 	{
+		protected override IValidator Validator => new SeriesValidator();
+
 		public Dictionary<string, DataLayer.Series> Cache { get; private set; } = new();
 
 		public SeriesImporter(LibationContext context) : base(context) { }

--- a/Source/DtoImporterService/SeriesImporter.cs
+++ b/Source/DtoImporterService/SeriesImporter.cs
@@ -8,10 +8,8 @@ using Dinah.Core.Collections.Generic;
 
 namespace DtoImporterService
 {
-	public class SeriesImporter : ItemsImporterBase
+	public class SeriesImporter : ImporterBase<SeriesValidator>
 	{
-		protected override IValidator Validator => new SeriesValidator();
-
 		public Dictionary<string, DataLayer.Series> Cache { get; private set; } = new();
 
 		public SeriesImporter(LibationContext context) : base(context) { }

--- a/Source/FileLiberator/DownloadDecryptBook.cs
+++ b/Source/FileLiberator/DownloadDecryptBook.cs
@@ -166,6 +166,9 @@ namespace FileLiberator
 				};
 
 			var chapters = flattenChapters(contentLic.ContentMetadata.ChapterInfo.Chapters).OrderBy(c => c.StartOffsetMs).ToList();
+			
+			if (config.MergeOpeningAndEndCredits)
+				combineCredits(chapters);
 
 			if (config.AllowLibationFixup || outputFormat == OutputFormat.Mp3)
 			{
@@ -192,7 +195,7 @@ namespace FileLiberator
 			return dlOptions;
 		}
 
-		public static List<AudibleApi.Common.Chapter> flattenChapters(IEnumerable<AudibleApi.Common.Chapter> chapters, string titleConcat = ": ")
+		public static List<AudibleApi.Common.Chapter> flattenChapters(IList<AudibleApi.Common.Chapter> chapters, string titleConcat = ": ")
 		{
 			List<AudibleApi.Common.Chapter> chaps = new();
 
@@ -216,6 +219,22 @@ namespace FileLiberator
 			}
 			return chaps;
 		}
+
+		public static void combineCredits(IList<AudibleApi.Common.Chapter> chapters)
+		{
+			if (chapters.Count > 1 && chapters[0].Title == "Opening Credits")
+			{
+				chapters[1].StartOffsetMs = chapters[0].StartOffsetMs;
+				chapters[1].StartOffsetSec = chapters[0].StartOffsetSec;
+				chapters[1].LengthMs += chapters[0].LengthMs;
+				chapters.RemoveAt(0);
+			}
+			if (chapters.Count > 1 && chapters[^1].Title == "End Credits")
+			{
+				chapters[^2].LengthMs += chapters[^1].LengthMs;
+				chapters.Remove(chapters[^1]);
+			}
+		}		
 
 		private static void downloadValidation(LibraryBook libraryBook)
 		{

--- a/Source/FileLiberator/DownloadDecryptBook.cs
+++ b/Source/FileLiberator/DownloadDecryptBook.cs
@@ -165,7 +165,7 @@ namespace FileLiberator
 					LameConfig = GetLameOptions(config)
 				};
 
-			var chapters = getChapters(contentLic.ContentMetadata.ChapterInfo.Chapters).OrderBy(c => c.StartOffsetMs).ToList();
+			var chapters = flattenChapters(contentLic.ContentMetadata.ChapterInfo.Chapters).OrderBy(c => c.StartOffsetMs).ToList();
 
 			if (config.AllowLibationFixup || outputFormat == OutputFormat.Mp3)
 			{
@@ -192,7 +192,7 @@ namespace FileLiberator
 			return dlOptions;
 		}
 
-		public static List<AudibleApi.Common.Chapter> getChapters(IEnumerable<AudibleApi.Common.Chapter> chapters)
+		public static List<AudibleApi.Common.Chapter> flattenChapters(IEnumerable<AudibleApi.Common.Chapter> chapters, string titleConcat = ": ")
 		{
 			List<AudibleApi.Common.Chapter> chaps = new();
 
@@ -200,19 +200,14 @@ namespace FileLiberator
 			{
 				if (c.Chapters is not null)
 				{
-					c.Chapters[0] = new AudibleApi.Common.Chapter
-					{
-						Title = c.Chapters[0].Title,
-						StartOffsetMs = c.StartOffsetMs,
-						StartOffsetSec = c.StartOffsetSec,
-						LengthMs = c.LengthMs + c.Chapters[0].LengthMs,
-						Chapters = c.Chapters[0].Chapters
-					};
+					c.Chapters[0].StartOffsetMs = c.StartOffsetMs;
+					c.Chapters[0].StartOffsetSec = c.StartOffsetSec;
+					c.Chapters[0].LengthMs += c.LengthMs;
 
-					var children = getChapters(c.Chapters);
+					var children = flattenChapters(c.Chapters);
 
 					foreach (var child in children)
-						child.Title = string.IsNullOrEmpty(c.Title) ? child.Title : $"{c.Title}: {child.Title}";
+						child.Title = $"{c.Title}{titleConcat}{child.Title}";
 
 					chaps.AddRange(children);
 				}

--- a/Source/FileLiberator/FileLiberator.csproj
+++ b/Source/FileLiberator/FileLiberator.csproj
@@ -11,4 +11,13 @@
     <ProjectReference Include="..\AudibleUtilities\AudibleUtilities.csproj" />
   </ItemGroup>
 
+	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
+		<DebugType>embedded</DebugType>
+	</PropertyGroup>
+
+	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
+		<DebugType>embedded</DebugType>
+	</PropertyGroup>
+
+
 </Project>

--- a/Source/FileLiberator/FileLiberator.csproj
+++ b/Source/FileLiberator/FileLiberator.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net6.0-windows</TargetFramework>
+	  <EnablePreviewFeatures>True</EnablePreviewFeatures>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Source/FileLiberator/FileLiberator.csproj
+++ b/Source/FileLiberator/FileLiberator.csproj
@@ -2,7 +2,6 @@
 
   <PropertyGroup>
     <TargetFramework>net6.0-windows</TargetFramework>
-	  <EnablePreviewFeatures>True</EnablePreviewFeatures>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Source/FileManager/FileManager.csproj
+++ b/Source/FileManager/FileManager.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
@@ -8,5 +8,13 @@
     <PackageReference Include="Dinah.Core" Version="4.4.1.1" />
     <PackageReference Include="Polly" Version="7.2.3" />
   </ItemGroup>
+
+	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
+		<DebugType>embedded</DebugType>
+	</PropertyGroup>
+
+	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
+		<DebugType>embedded</DebugType>
+	</PropertyGroup>
 
 </Project>

--- a/Source/FileManager/ReplacementCharacters.cs
+++ b/Source/FileManager/ReplacementCharacters.cs
@@ -136,19 +136,21 @@ namespace FileManager
 		{
 			if (toReplace == Replacement.QUOTE_MARK)
 			{
-				if (preceding == default ||
-						(preceding != default
-						&& !char.IsLetter(preceding)
-						&& !char.IsNumber(preceding)
-						&& (char.IsLetter(succeding) || char.IsNumber(succeding))
+				if (
+					preceding == default ||
+						(
+							!char.IsLetter(preceding) &&
+							!char.IsNumber(preceding) &&
+							(char.IsLetter(succeding) || char.IsNumber(succeding))
 						)
 					)
 					return OpenQuote;
-				else if (succeding == default ||
-							(succeding != default
-							&& !char.IsLetter(succeding)
-							&& !char.IsNumber(succeding)
-							&& (char.IsLetter(preceding) || char.IsNumber(preceding))
+				else if (
+						succeding == default ||
+							(
+								!char.IsLetter(succeding) &&
+								!char.IsNumber(succeding) &&
+								(char.IsLetter(preceding) || char.IsNumber(preceding))
 							)
 						)
 					return CloseQuote;

--- a/Source/Hangover/Hangover.csproj
+++ b/Source/Hangover/Hangover.csproj
@@ -6,7 +6,7 @@
     <UseWindowsForms>true</UseWindowsForms>
     <ApplicationIcon>hangover.ico</ApplicationIcon>
     <ImplicitUsings>enable</ImplicitUsings>
-
+	  <EnablePreviewFeatures>True</EnablePreviewFeatures>
     <PublishReadyToRun>true</PublishReadyToRun>
     <RuntimeIdentifier>win-x64</RuntimeIdentifier>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>

--- a/Source/Hangover/Hangover.csproj
+++ b/Source/Hangover/Hangover.csproj
@@ -6,7 +6,6 @@
     <UseWindowsForms>true</UseWindowsForms>
     <ApplicationIcon>hangover.ico</ApplicationIcon>
     <ImplicitUsings>enable</ImplicitUsings>
-	  <EnablePreviewFeatures>True</EnablePreviewFeatures>
     <PublishReadyToRun>true</PublishReadyToRun>
     <RuntimeIdentifier>win-x64</RuntimeIdentifier>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>

--- a/Source/Hangover/Hangover.csproj
+++ b/Source/Hangover/Hangover.csproj
@@ -24,11 +24,13 @@
   edit debug and release output paths
   -->
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
-    <OutputPath>..\LibationWinForms\bin\Debug</OutputPath>
+    <OutputPath>..\bin\Debug</OutputPath>
+	  <DebugType>embedded</DebugType>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
-    <OutputPath>..\LibationWinForms\bin\Release</OutputPath>
+    <OutputPath>..\bin\Release</OutputPath>
+	  <DebugType>embedded</DebugType>
   </PropertyGroup>
 
   <ItemGroup>
@@ -37,7 +39,7 @@
     <ProjectReference Include="..\FileLiberator\FileLiberator.csproj" />
   </ItemGroup>
 
-  <ItemGroup>
+	<ItemGroup>
     <Compile Update="Form1.*.cs">
       <DependentUpon>Form1.cs</DependentUpon>
     </Compile>

--- a/Source/Hangover/Properties/PublishProfiles/FolderProfile.pubxml
+++ b/Source/Hangover/Properties/PublishProfiles/FolderProfile.pubxml
@@ -1,0 +1,16 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<!--
+https://go.microsoft.com/fwlink/?LinkID=208121.
+-->
+<Project>
+  <PropertyGroup>
+    <Configuration>Release</Configuration>
+    <Platform>Any CPU</Platform>
+    <PublishDir>..\bin\publish\</PublishDir>
+    <PublishProtocol>FileSystem</PublishProtocol>
+    <TargetFramework>net6.0-windows</TargetFramework>
+    <RuntimeIdentifier>win-x64</RuntimeIdentifier>
+    <SelfContained>false</SelfContained>
+    <PublishSingleFile>false</PublishSingleFile>
+  </PropertyGroup>
+</Project>

--- a/Source/LibationCli/LibationCli.csproj
+++ b/Source/LibationCli/LibationCli.csproj
@@ -5,6 +5,7 @@
     <OutputType>Exe</OutputType>
     <TargetFramework>net6.0-windows</TargetFramework>
     <PublishReadyToRun>true</PublishReadyToRun>
+	  <EnablePreviewFeatures>True</EnablePreviewFeatures>
     <RuntimeIdentifier>win-x64</RuntimeIdentifier>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
     <AppendRuntimeIdentifierToOutputPath>false</AppendRuntimeIdentifierToOutputPath>

--- a/Source/LibationCli/LibationCli.csproj
+++ b/Source/LibationCli/LibationCli.csproj
@@ -4,12 +4,11 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net6.0-windows</TargetFramework>
-
-    <PublishTrimmed>true</PublishTrimmed>
     <PublishReadyToRun>true</PublishReadyToRun>
     <RuntimeIdentifier>win-x64</RuntimeIdentifier>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
     <AppendRuntimeIdentifierToOutputPath>false</AppendRuntimeIdentifierToOutputPath>
+    <IsPublishable>True</IsPublishable>
   </PropertyGroup>
 
   <!--
@@ -23,11 +22,13 @@
   edit debug and release output paths
   -->
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
-    <OutputPath>..\LibationWinForms\bin\Debug</OutputPath>
+	  <OutputPath>..\bin\Debug</OutputPath>
+	  <DebugType>embedded</DebugType>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
-    <OutputPath>..\LibationWinForms\bin\Release</OutputPath>
+	  <OutputPath>..\bin\Release</OutputPath>
+	  <DebugType>embedded</DebugType>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Source/LibationCli/LibationCli.csproj
+++ b/Source/LibationCli/LibationCli.csproj
@@ -5,7 +5,6 @@
     <OutputType>Exe</OutputType>
     <TargetFramework>net6.0-windows</TargetFramework>
     <PublishReadyToRun>true</PublishReadyToRun>
-	  <EnablePreviewFeatures>True</EnablePreviewFeatures>
     <RuntimeIdentifier>win-x64</RuntimeIdentifier>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
     <AppendRuntimeIdentifierToOutputPath>false</AppendRuntimeIdentifierToOutputPath>

--- a/Source/LibationCli/Properties/PublishProfiles/FolderProfile.pubxml
+++ b/Source/LibationCli/Properties/PublishProfiles/FolderProfile.pubxml
@@ -1,0 +1,16 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<!--
+https://go.microsoft.com/fwlink/?LinkID=208121.
+-->
+<Project>
+  <PropertyGroup>
+    <Configuration>Release</Configuration>
+    <Platform>Any CPU</Platform>
+    <PublishDir>..\bin\publish\</PublishDir>
+    <PublishProtocol>FileSystem</PublishProtocol>
+    <TargetFramework>net6.0-windows</TargetFramework>
+    <RuntimeIdentifier>win-x64</RuntimeIdentifier>
+    <SelfContained>false</SelfContained>
+    <PublishSingleFile>false</PublishSingleFile>
+  </PropertyGroup>
+</Project>

--- a/Source/LibationFileManager/Configuration.cs
+++ b/Source/LibationFileManager/Configuration.cs
@@ -117,6 +117,13 @@ namespace LibationFileManager
 			set => persistentDictionary.SetNonString(nameof(SplitFilesByChapter), value);
 		}
 
+		[Description("Merge Opening/End Credits into the following/preceding chapters")]
+		public bool MergeOpeningAndEndCredits
+		{
+			get => persistentDictionary.GetNonString<bool>(nameof(MergeOpeningAndEndCredits));
+			set => persistentDictionary.SetNonString(nameof(MergeOpeningAndEndCredits), value);
+		}
+
 		[Description("Strip \"(Unabridged)\" from audiobook metadata tags")]
 		public bool StripUnabridged
 		{

--- a/Source/LibationFileManager/Configuration.cs
+++ b/Source/LibationFileManager/Configuration.cs
@@ -444,7 +444,7 @@ namespace LibationFileManager
 		#endregion
 
 		#region LibationFiles
-		private static string APPSETTINGS_JSON { get; } = Path.Combine(Path.GetDirectoryName(System.Reflection.Assembly.GetEntryAssembly().Location), "appsettings.json");
+		private static string APPSETTINGS_JSON { get; } = Path.Combine(Path.GetDirectoryName(System.Diagnostics.Process.GetCurrentProcess().MainModule.FileName), "appsettings.json");
 		private const string LIBATION_FILES_KEY = "LibationFiles";
 
 		[Description("Location for storage of program-created files")]

--- a/Source/LibationFileManager/LibationFileManager.csproj
+++ b/Source/LibationFileManager/LibationFileManager.csproj
@@ -14,4 +14,12 @@
     <ProjectReference Include="..\FileManager\FileManager.csproj" />
   </ItemGroup>
 
+	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
+		<DebugType>embedded</DebugType>
+	</PropertyGroup>
+
+	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
+		<DebugType>embedded</DebugType>
+	</PropertyGroup>
+	
 </Project>

--- a/Source/LibationSearchEngine/LibationSearchEngine.csproj
+++ b/Source/LibationSearchEngine/LibationSearchEngine.csproj
@@ -15,5 +15,14 @@
   <ItemGroup>
     <ProjectReference Include="..\DataLayer\DataLayer.csproj" />
   </ItemGroup>
+	
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
+    <DebugType>embedded</DebugType>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
+    <DebugType>embedded</DebugType>
+  </PropertyGroup>
+
 
 </Project>

--- a/Source/LibationWinForms/Dialogs/BookDetailsDialog.cs
+++ b/Source/LibationWinForms/Dialogs/BookDetailsDialog.cs
@@ -49,6 +49,7 @@ Title: {Book.Title}
 Author(s): {Book.AuthorNames()}
 Narrator(s): {Book.NarratorNames()}
 Length: {(Book.LengthInMinutes == 0 ? "" : $"{Book.LengthInMinutes / 60} hr {Book.LengthInMinutes % 60} min")}
+Audio Bitrate: {Book.AudioFormat}
 Category: {string.Join(" > ", Book.CategoriesNames())}
 Purchase Date: {_libraryBook.DateAdded.ToString("d")}
 ".Trim();

--- a/Source/LibationWinForms/Dialogs/SettingsDialog.AudioSettings.cs
+++ b/Source/LibationWinForms/Dialogs/SettingsDialog.AudioSettings.cs
@@ -13,6 +13,7 @@ namespace LibationWinForms.Dialogs
 			this.downloadCoverArtCbox.Text = desc(nameof(config.DownloadCoverArt));
 			this.retainAaxFileCbox.Text = desc(nameof(config.RetainAaxFile));
 			this.splitFilesByChapterCbox.Text = desc(nameof(config.SplitFilesByChapter));
+			this.mergeOpeningEndCreditsCbox.Text = desc(nameof(config.MergeOpeningAndEndCredits));
 			this.stripAudibleBrandingCbox.Text = desc(nameof(config.StripAudibleBrandAudio));
 			this.stripUnabridgedCbox.Text = desc(nameof(config.StripUnabridged));
 
@@ -21,6 +22,7 @@ namespace LibationWinForms.Dialogs
 			downloadCoverArtCbox.Checked = config.DownloadCoverArt;
 			retainAaxFileCbox.Checked = config.RetainAaxFile;
 			splitFilesByChapterCbox.Checked = config.SplitFilesByChapter;
+			mergeOpeningEndCreditsCbox.Checked = config.MergeOpeningAndEndCredits;
 			stripUnabridgedCbox.Checked = config.StripUnabridged;
 			stripAudibleBrandingCbox.Checked = config.StripAudibleBrandAudio;
 			convertLosslessRb.Checked = !config.DecryptToLossy;
@@ -50,6 +52,7 @@ namespace LibationWinForms.Dialogs
 			config.DownloadCoverArt = downloadCoverArtCbox.Checked;
 			config.RetainAaxFile = retainAaxFileCbox.Checked;
 			config.SplitFilesByChapter = splitFilesByChapterCbox.Checked;
+			config.MergeOpeningAndEndCredits = mergeOpeningEndCreditsCbox.Checked;
 			config.StripUnabridged = stripUnabridgedCbox.Checked;
 			config.StripAudibleBrandAudio = stripAudibleBrandingCbox.Checked;
 			config.DecryptToLossy = convertLossyRb.Checked;

--- a/Source/LibationWinForms/Dialogs/SettingsDialog.Designer.cs
+++ b/Source/LibationWinForms/Dialogs/SettingsDialog.Designer.cs
@@ -108,6 +108,7 @@
 			this.retainAaxFileCbox = new System.Windows.Forms.CheckBox();
 			this.downloadCoverArtCbox = new System.Windows.Forms.CheckBox();
 			this.createCueSheetCbox = new System.Windows.Forms.CheckBox();
+			this.mergeOpeningEndCreditsCbox = new System.Windows.Forms.CheckBox();
 			this.badBookGb.SuspendLayout();
 			this.tabControl.SuspendLayout();
 			this.tab1ImportantSettings.SuspendLayout();
@@ -251,7 +252,7 @@
 			// stripAudibleBrandingCbox
 			// 
 			this.stripAudibleBrandingCbox.AutoSize = true;
-			this.stripAudibleBrandingCbox.Location = new System.Drawing.Point(19, 168);
+			this.stripAudibleBrandingCbox.Location = new System.Drawing.Point(19, 193);
 			this.stripAudibleBrandingCbox.Name = "stripAudibleBrandingCbox";
 			this.stripAudibleBrandingCbox.Size = new System.Drawing.Size(143, 34);
 			this.stripAudibleBrandingCbox.TabIndex = 13;
@@ -285,7 +286,7 @@
 			// convertLossyRb
 			// 
 			this.convertLossyRb.AutoSize = true;
-			this.convertLossyRb.Location = new System.Drawing.Point(19, 232);
+			this.convertLossyRb.Location = new System.Drawing.Point(19, 257);
 			this.convertLossyRb.Name = "convertLossyRb";
 			this.convertLossyRb.Size = new System.Drawing.Size(329, 19);
 			this.convertLossyRb.TabIndex = 12;
@@ -297,7 +298,7 @@
 			// 
 			this.convertLosslessRb.AutoSize = true;
 			this.convertLosslessRb.Checked = true;
-			this.convertLosslessRb.Location = new System.Drawing.Point(19, 207);
+			this.convertLosslessRb.Location = new System.Drawing.Point(19, 232);
 			this.convertLosslessRb.Name = "convertLosslessRb";
 			this.convertLosslessRb.Size = new System.Drawing.Size(335, 19);
 			this.convertLosslessRb.TabIndex = 11;
@@ -608,6 +609,7 @@
 			this.tab4AudioFileOptions.Controls.Add(this.stripAudibleBrandingCbox);
 			this.tab4AudioFileOptions.Controls.Add(this.convertLosslessRb);
 			this.tab4AudioFileOptions.Controls.Add(this.stripUnabridgedCbox);
+			this.tab4AudioFileOptions.Controls.Add(this.mergeOpeningEndCreditsCbox);
 			this.tab4AudioFileOptions.Controls.Add(this.splitFilesByChapterCbox);
 			this.tab4AudioFileOptions.Controls.Add(this.retainAaxFileCbox);
 			this.tab4AudioFileOptions.Controls.Add(this.downloadCoverArtCbox);
@@ -980,7 +982,7 @@
 			// stripUnabridgedCbox
 			// 
 			this.stripUnabridgedCbox.AutoSize = true;
-			this.stripUnabridgedCbox.Location = new System.Drawing.Point(19, 143);
+			this.stripUnabridgedCbox.Location = new System.Drawing.Point(19, 168);
 			this.stripUnabridgedCbox.Name = "stripUnabridgedCbox";
 			this.stripUnabridgedCbox.Size = new System.Drawing.Size(147, 19);
 			this.stripUnabridgedCbox.TabIndex = 13;
@@ -1023,6 +1025,17 @@
 			this.createCueSheetCbox.Text = "[CreateCueSheet desc]";
 			this.createCueSheetCbox.UseVisualStyleBackColor = true;
 			this.createCueSheetCbox.CheckedChanged += new System.EventHandler(this.allowLibationFixupCbox_CheckedChanged);
+			// 
+			// mergeBeginningEndCreditsCbox
+			// 
+			this.mergeOpeningEndCreditsCbox.AutoSize = true;
+			this.mergeOpeningEndCreditsCbox.Location = new System.Drawing.Point(19, 143);
+			this.mergeOpeningEndCreditsCbox.Name = "mergeOpeningEndCreditsCbox";
+			this.mergeOpeningEndCreditsCbox.Size = new System.Drawing.Size(206, 19);
+			this.mergeOpeningEndCreditsCbox.TabIndex = 13;
+			this.mergeOpeningEndCreditsCbox.Text = "[MergeOpeningEndCredits desc]";
+			this.mergeOpeningEndCreditsCbox.UseVisualStyleBackColor = true;
+			this.mergeOpeningEndCreditsCbox.CheckedChanged += new System.EventHandler(this.splitFilesByChapterCbox_CheckedChanged);
 			// 
 			// SettingsDialog
 			// 
@@ -1155,5 +1168,6 @@
 		private System.Windows.Forms.Button chapterTitleTemplateBtn;
 		private System.Windows.Forms.TextBox chapterTitleTemplateTb;
 		private System.Windows.Forms.Button editCharreplacementBtn;
+		private System.Windows.Forms.CheckBox mergeOpeningEndCreditsCbox;
 	}
 }

--- a/Source/LibationWinForms/GridView/ProductsGrid.cs
+++ b/Source/LibationWinForms/GridView/ProductsGrid.cs
@@ -50,45 +50,52 @@ namespace LibationWinForms.GridView
 		#region Button controls
 		private void DataGridView_CellContentClick(object sender, DataGridViewCellEventArgs e)
 		{
-			// handle grid button click: https://stackoverflow.com/a/13687844
-			if (e.RowIndex < 0)
-				return;
+			try
+			{
+				// handle grid button click: https://stackoverflow.com/a/13687844
+				if (e.RowIndex < 0)
+					return;
 
-			var entry = getGridEntry(e.RowIndex);
-			if (entry is LibraryBookEntry lbEntry)
-			{
-				if (e.ColumnIndex == liberateGVColumn.Index)
-					LiberateClicked?.Invoke(lbEntry);
-				else if (e.ColumnIndex == tagAndDetailsGVColumn.Index)
-					DetailsClicked?.Invoke(lbEntry);
-				else if (e.ColumnIndex == descriptionGVColumn.Index)
-					DescriptionClicked?.Invoke(lbEntry, gridEntryDataGridView.GetCellDisplayRectangle(e.ColumnIndex, e.RowIndex, false));
-				else if (e.ColumnIndex == coverGVColumn.Index)
-					CoverClicked?.Invoke(lbEntry);
-			}
-			else if (entry is SeriesEntry sEntry)
-			{
-				if (e.ColumnIndex == liberateGVColumn.Index)
+				var entry = getGridEntry(e.RowIndex);
+				if (entry is LibraryBookEntry lbEntry)
 				{
-					if (sEntry.Liberate.Expanded)
-						bindingList.CollapseItem(sEntry);
-					else
-						bindingList.ExpandItem(sEntry);
-
-					sEntry.NotifyPropertyChanged(nameof(sEntry.Liberate));
-
-					VisibleCountChanged?.Invoke(this, bindingList.BookEntries().Count());
+					if (e.ColumnIndex == liberateGVColumn.Index)
+						LiberateClicked?.Invoke(lbEntry);
+					else if (e.ColumnIndex == tagAndDetailsGVColumn.Index)
+						DetailsClicked?.Invoke(lbEntry);
+					else if (e.ColumnIndex == descriptionGVColumn.Index)
+						DescriptionClicked?.Invoke(lbEntry, gridEntryDataGridView.GetCellDisplayRectangle(e.ColumnIndex, e.RowIndex, false));
+					else if (e.ColumnIndex == coverGVColumn.Index)
+						CoverClicked?.Invoke(lbEntry);
 				}
-				else if (e.ColumnIndex == descriptionGVColumn.Index)
-					DescriptionClicked?.Invoke(sEntry, gridEntryDataGridView.GetCellDisplayRectangle(e.ColumnIndex, e.RowIndex, false));
-				else if (e.ColumnIndex == coverGVColumn.Index)
-					CoverClicked?.Invoke(sEntry);
-			}
+				else if (entry is SeriesEntry sEntry)
+				{
+					if (e.ColumnIndex == liberateGVColumn.Index)
+					{
+						if (sEntry.Liberate.Expanded)
+							bindingList.CollapseItem(sEntry);
+						else
+							bindingList.ExpandItem(sEntry);
 
-			if (e.ColumnIndex == removeGVColumn.Index)
+						sEntry.NotifyPropertyChanged(nameof(sEntry.Liberate));
+
+						VisibleCountChanged?.Invoke(this, bindingList.BookEntries().Count());
+					}
+					else if (e.ColumnIndex == descriptionGVColumn.Index)
+						DescriptionClicked?.Invoke(sEntry, gridEntryDataGridView.GetCellDisplayRectangle(e.ColumnIndex, e.RowIndex, false));
+					else if (e.ColumnIndex == coverGVColumn.Index)
+						CoverClicked?.Invoke(sEntry);
+				}
+
+				if (e.ColumnIndex == removeGVColumn.Index)
+				{
+					gridEntryDataGridView.CommitEdit(DataGridViewDataErrorContexts.Commit);
+					RemovableCountChanged?.Invoke(this, EventArgs.Empty);
+				}
+			}
+			catch(Exception ex)
 			{
-				gridEntryDataGridView.CommitEdit(DataGridViewDataErrorContexts.Commit);
-				RemovableCountChanged?.Invoke(this, EventArgs.Empty);
+				Serilog.Log.Logger.Error(ex, $"An error was encountered while processing a user click in the {nameof(ProductsGrid)}");
 			}
 		}
 

--- a/Source/LibationWinForms/LibationWinForms.csproj
+++ b/Source/LibationWinForms/LibationWinForms.csproj
@@ -7,7 +7,7 @@
     <UseWindowsForms>true</UseWindowsForms>
     <ApplicationIcon>libation.ico</ApplicationIcon>
     <AssemblyName>Libation</AssemblyName>
-
+	  
     <PublishReadyToRun>true</PublishReadyToRun>
     <RuntimeIdentifier>win-x64</RuntimeIdentifier>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
@@ -25,6 +25,16 @@
     - Specifying only 'en' should load no language packs: broken, still loads all
     -->
     <SatelliteResourceLanguages>en;es</SatelliteResourceLanguages>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
+	  <OutputPath>..\bin\Debug</OutputPath>
+    <DebugType>embedded</DebugType>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
+	  <OutputPath>..\bin\Release</OutputPath>
+    <DebugType>embedded</DebugType>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Source/LibationWinForms/LibationWinForms.csproj
+++ b/Source/LibationWinForms/LibationWinForms.csproj
@@ -6,7 +6,6 @@
     <TargetFramework>net6.0-windows</TargetFramework>
     <UseWindowsForms>true</UseWindowsForms>
     <ApplicationIcon>libation.ico</ApplicationIcon>
-	  <EnablePreviewFeatures>True</EnablePreviewFeatures>
     <AssemblyName>Libation</AssemblyName>
 	  
     <PublishReadyToRun>true</PublishReadyToRun>

--- a/Source/LibationWinForms/LibationWinForms.csproj
+++ b/Source/LibationWinForms/LibationWinForms.csproj
@@ -6,6 +6,7 @@
     <TargetFramework>net6.0-windows</TargetFramework>
     <UseWindowsForms>true</UseWindowsForms>
     <ApplicationIcon>libation.ico</ApplicationIcon>
+	  <EnablePreviewFeatures>True</EnablePreviewFeatures>
     <AssemblyName>Libation</AssemblyName>
 	  
     <PublishReadyToRun>true</PublishReadyToRun>

--- a/Source/LibationWinForms/Properties/PublishProfiles/FolderProfile.pubxml
+++ b/Source/LibationWinForms/Properties/PublishProfiles/FolderProfile.pubxml
@@ -1,0 +1,16 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<!--
+https://go.microsoft.com/fwlink/?LinkID=208121.
+-->
+<Project>
+  <PropertyGroup>
+    <Configuration>Release</Configuration>
+    <Platform>Any CPU</Platform>
+    <PublishDir>..\bin\publish\</PublishDir>
+    <PublishProtocol>FileSystem</PublishProtocol>
+    <TargetFramework>net6.0-windows</TargetFramework>
+    <RuntimeIdentifier>win-x64</RuntimeIdentifier>
+    <SelfContained>false</SelfContained>
+    <PublishSingleFile>false</PublishSingleFile>
+  </PropertyGroup>
+</Project>

--- a/Source/LibationWinForms/Properties/PublishProfiles/FolderProfile.pubxml
+++ b/Source/LibationWinForms/Properties/PublishProfiles/FolderProfile.pubxml
@@ -5,7 +5,7 @@ https://go.microsoft.com/fwlink/?LinkID=208121.
 <Project>
   <PropertyGroup>
     <Configuration>Release</Configuration>
-    <Platform>Any CPU</Platform>
+    <Platform>x64</Platform>
     <PublishDir>..\bin\publish\</PublishDir>
     <PublishProtocol>FileSystem</PublishProtocol>
     <TargetFramework>net6.0-windows</TargetFramework>

--- a/Source/_Tests/AudibleUtilities.Tests/AudibleUtilities.Tests.csproj
+++ b/Source/_Tests/AudibleUtilities.Tests/AudibleUtilities.Tests.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net6.0-windows</TargetFramework>
+	  <EnablePreviewFeatures>True</EnablePreviewFeatures>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/Source/_Tests/AudibleUtilities.Tests/AudibleUtilities.Tests.csproj
+++ b/Source/_Tests/AudibleUtilities.Tests/AudibleUtilities.Tests.csproj
@@ -2,8 +2,6 @@
 
   <PropertyGroup>
     <TargetFramework>net6.0-windows</TargetFramework>
-	  <EnablePreviewFeatures>True</EnablePreviewFeatures>
-
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/Source/_Tests/FileLiberator.Tests/DownloadDecryptBookTests.cs
+++ b/Source/_Tests/FileLiberator.Tests/DownloadDecryptBookTests.cs
@@ -185,11 +185,11 @@ namespace FileLiberator.Tests
 					}
 				};
 
-			var flatChapters = DownloadDecryptBook.getChapters(hierarchicalChapters).OrderBy(c => c.StartOffsetMs).ToArray();
+			var flatChapters = DownloadDecryptBook.flattenChapters(hierarchicalChapters);
 
-			flatChapters.Length.Should().Be(flatChapters.Length);
+			flatChapters.Count.Should().Be(expected.Length);
 
-			for (int i = 0; i < flatChapters.Length; i++)
+			for (int i = 0; i < flatChapters.Count; i++)
 			{
 				flatChapters[i].Title.Should().Be(expected[i].Title);
 				flatChapters[i].StartOffsetMs.Should().Be(expected[i].StartOffsetMs);

--- a/Source/_Tests/FileLiberator.Tests/DownloadDecryptBookTests.cs
+++ b/Source/_Tests/FileLiberator.Tests/DownloadDecryptBookTests.cs
@@ -14,8 +14,142 @@ namespace FileLiberator.Tests
 	[TestClass]
 	public class DownloadDecryptBookTests
 	{
+		private static Chapter[] HierarchicalChapters => new Chapter[]
+		{
+			new ()
+			{
+				Title = "Opening Credits",
+				StartOffsetMs = 0,
+				StartOffsetSec = 0,
+				LengthMs = 10000,
+			},
+			new ()
+			{
+				Title = "Book 1",
+				StartOffsetMs = 10000,
+				StartOffsetSec = 10,
+				LengthMs = 2000,
+				Chapters = new Chapter[]
+				{
+					new ()
+					{
+						Title = "Part 1",
+						StartOffsetMs = 12000,
+						StartOffsetSec = 12,
+						LengthMs = 2000,
+						Chapters = new Chapter[]
+						{
+							new ()
+							{
+								Title = "Chapter 1",
+								StartOffsetMs = 14000,
+								StartOffsetSec = 14,
+								LengthMs = 86000,
+							},
+							new()
+							{
+								Title = "Chapter 2",
+								StartOffsetMs = 100000,
+								StartOffsetSec = 100,
+								LengthMs = 100000,
+							},
+						}
+					},
+					new()
+					{
+						Title = "Part 2",
+						StartOffsetMs = 200000,
+						StartOffsetSec = 200,
+						LengthMs = 2000,
+						Chapters = new Chapter[]
+						{
+							new()
+							{
+								Title = "Chapter 3",
+								StartOffsetMs = 202000,
+								StartOffsetSec = 202,
+								LengthMs = 98000,
+							},
+							new()
+							{
+								Title = "Chapter 4",
+								StartOffsetMs = 300000,
+								StartOffsetSec = 300,
+								LengthMs = 100000,
+							},
+						}
+					}
+				}
+			},
+			new()
+			{
+				Title = "Book 2",
+				StartOffsetMs = 400000,
+				StartOffsetSec = 400,
+				LengthMs = 2000,
+				Chapters = new Chapter[]
+				{
+					new()
+					{
+						Title = "Part 3",
+						StartOffsetMs = 402000,
+						StartOffsetSec = 402,
+						LengthMs = 2000,
+						Chapters = new Chapter[]
+						{
+							new()
+							{
+								Title = "Chapter 5",
+								StartOffsetMs = 404000,
+								StartOffsetSec = 404,
+								LengthMs = 96000,
+							},
+							new()
+							{
+								Title = "Chapter 6",
+								StartOffsetMs = 500000,
+								StartOffsetSec = 500,
+								LengthMs = 100000,
+							},
+						}
+					},
+					new()
+					{
+						Title = "Part 4",
+						StartOffsetMs = 600000,
+						StartOffsetSec = 600,
+						LengthMs = 2000,
+						Chapters = new Chapter[]
+						{
+							new()
+							{
+								Title = "Chapter 7",
+								StartOffsetMs = 602000,
+								StartOffsetSec = 602,
+								LengthMs = 98000,
+							},
+							new()
+							{
+								Title = "Chapter 8",
+								StartOffsetMs = 700000,
+								StartOffsetSec = 700,
+								LengthMs = 100000,
+							},
+						}
+					}
+				}
+			},
+			new()
+			{
+				Title = "End Credits",
+				StartOffsetMs = 800000,
+				StartOffsetSec = 800,
+				LengthMs = 10000,
+			},
+		};
+
 		[TestMethod]
-		public void HierarchicalChapters_Flatten()
+		public void Chapters_CombineCredits()
 		{
 			var expected = new Chapter[]
 			{
@@ -73,129 +207,109 @@ namespace FileLiberator.Tests
 					Title = "Book 2: Part 4: Chapter 8",
 					StartOffsetMs = 700000,
 					StartOffsetSec = 700,
-					LengthMs = 100000,
+					LengthMs = 110000,
 				}
 			};
 
-			var hierarchicalChapters = new Chapter[]
-				{
-					new()
-					{
-						Title = "Book 1",
-						StartOffsetMs = 0,
-						StartOffsetSec = 0,
-						LengthMs = 2000,
-						Chapters = new Chapter[]
-						{
-							new()
-							{   Title = "Part 1",
-								StartOffsetMs = 2000,
-								StartOffsetSec = 2,
-								LengthMs = 2000,
-								Chapters = new Chapter[]
-								{
-									new()
-									{   Title = "Chapter 1",
-										StartOffsetMs = 4000,
-										StartOffsetSec = 4,
-										LengthMs = 96000,
-									},
-									new()
-									{   Title = "Chapter 2",
-										StartOffsetMs = 100000,
-										StartOffsetSec = 100,
-										LengthMs = 100000,
-									},
-								}
-							},
-							new()
-							{   Title = "Part 2",
-								StartOffsetMs = 200000,
-								StartOffsetSec = 200,
-								LengthMs = 2000,
-								Chapters = new Chapter[]
-								{
-									new()
-									{   Title = "Chapter 3",
-										StartOffsetMs = 202000,
-										StartOffsetSec = 202,
-										LengthMs = 98000,
-									},
-									new()
-									{   Title = "Chapter 4",
-										StartOffsetMs = 300000,
-										StartOffsetSec = 300,
-										LengthMs = 100000,
-									},
-								}
-							}
-						}
-					},
-					new()
-					{
-						Title = "Book 2",
-						StartOffsetMs = 400000,
-						StartOffsetSec = 400,
-						LengthMs = 2000,
-						Chapters = new Chapter[]
-						{
-							new()
-							{   Title = "Part 3",
-								StartOffsetMs = 402000,
-								StartOffsetSec = 402,
-								LengthMs = 2000,
-								Chapters = new Chapter[]
-								{
-									new()
-									{   Title = "Chapter 5",
-										StartOffsetMs = 404000,
-										StartOffsetSec = 404,
-										LengthMs = 96000,
-									},
-									new()
-									{   Title = "Chapter 6",
-										StartOffsetMs = 500000,
-										StartOffsetSec = 500,
-										LengthMs = 100000,
-									},
-								}
-							},
-							new()
-							{   Title = "Part 4",
-								StartOffsetMs = 600000,
-								StartOffsetSec = 600,
-								LengthMs = 2000,
-								Chapters = new Chapter[]
-								{
-									new()
-									{   Title = "Chapter 7",
-										StartOffsetMs = 602000,
-										StartOffsetSec = 602,
-										LengthMs = 98000,
-									},
-									new()
-									{   Title = "Chapter 8",
-										StartOffsetMs = 700000,
-										StartOffsetSec = 700,
-										LengthMs = 100000,
-									},
-								}
-							}
-						}
-					}
-				};
+			var flatChapters = DownloadDecryptBook.flattenChapters(HierarchicalChapters);
+			DownloadDecryptBook.combineCredits(flatChapters);
+			checkChapters(flatChapters, expected);
+		}
 
-			var flatChapters = DownloadDecryptBook.flattenChapters(hierarchicalChapters);
 
-			flatChapters.Count.Should().Be(expected.Length);
-
-			for (int i = 0; i < flatChapters.Count; i++)
+		[TestMethod]
+		public void HierarchicalChapters_Flatten()
+		{
+			var expected = new Chapter[]
 			{
-				flatChapters[i].Title.Should().Be(expected[i].Title);
-				flatChapters[i].StartOffsetMs.Should().Be(expected[i].StartOffsetMs);
-				flatChapters[i].StartOffsetSec.Should().Be(expected[i].StartOffsetSec);
-				flatChapters[i].LengthMs.Should().Be(expected[i].LengthMs);
-				flatChapters[i].Chapters.Should().BeNull();
+				new()
+				{
+					Title = "Opening Credits",
+					StartOffsetMs = 0,
+					StartOffsetSec = 0,
+					LengthMs = 10000,
+				},
+				new()
+				{
+					Title = "Book 1: Part 1: Chapter 1",
+					StartOffsetMs = 10000,
+					StartOffsetSec = 10,
+					LengthMs = 90000,
+				},
+				new()
+				{
+					Title = "Book 1: Part 1: Chapter 2",
+					StartOffsetMs = 100000,
+					StartOffsetSec = 100,
+					LengthMs = 100000,
+				},
+				new()
+				{
+					Title = "Book 1: Part 2: Chapter 3",
+					StartOffsetMs = 200000,
+					StartOffsetSec = 200,
+					LengthMs = 100000,
+				},
+				new()
+				{
+					Title = "Book 1: Part 2: Chapter 4",
+					StartOffsetMs = 300000,
+					StartOffsetSec = 300,
+					LengthMs = 100000,
+				},
+				new()
+				{
+					Title = "Book 2: Part 3: Chapter 5",
+					StartOffsetMs = 400000,
+					StartOffsetSec = 400,
+					LengthMs = 100000,
+				},
+				new()
+				{
+					Title = "Book 2: Part 3: Chapter 6",
+					StartOffsetMs = 500000,
+					StartOffsetSec = 500,
+					LengthMs = 100000,
+				},
+				new()
+				{
+					Title = "Book 2: Part 4: Chapter 7",
+					StartOffsetMs = 600000,
+					StartOffsetSec = 600,
+					LengthMs = 100000,
+				},
+				new()
+				{
+					Title = "Book 2: Part 4: Chapter 8",
+					StartOffsetMs = 700000,
+					StartOffsetSec = 700,
+					LengthMs = 100000,
+				},
+				new()
+				{
+					Title = "End Credits",
+					StartOffsetMs = 800000,
+					StartOffsetSec = 800,
+					LengthMs = 10000,
+				}
+			};
+			
+			var flatChapters = DownloadDecryptBook.flattenChapters(HierarchicalChapters);
+
+			checkChapters(flatChapters, expected);
+		}
+
+		private static void checkChapters(IList<Chapter> value, IList<Chapter> expected)
+		{
+			value.Count.Should().Be(expected.Count);
+
+			for (int i = 0; i < value.Count; i++)
+			{
+				value[i].Title.Should().Be(expected[i].Title);
+				value[i].StartOffsetMs.Should().Be(expected[i].StartOffsetMs);
+				value[i].StartOffsetSec.Should().Be(expected[i].StartOffsetSec);
+				value[i].LengthMs.Should().Be(expected[i].LengthMs);
+				value[i].Chapters.Should().BeNull();
 			}
 		}
 	}

--- a/Source/_Tests/FileLiberator.Tests/FileLiberator.Tests.csproj
+++ b/Source/_Tests/FileLiberator.Tests/FileLiberator.Tests.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net6.0-windows</TargetFramework>
+	  <EnablePreviewFeatures>True</EnablePreviewFeatures>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/Source/_Tests/FileLiberator.Tests/FileLiberator.Tests.csproj
+++ b/Source/_Tests/FileLiberator.Tests/FileLiberator.Tests.csproj
@@ -2,8 +2,6 @@
 
   <PropertyGroup>
     <TargetFramework>net6.0-windows</TargetFramework>
-	  <EnablePreviewFeatures>True</EnablePreviewFeatures>
-
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/Source/publish.bat
+++ b/Source/publish.bat
@@ -1,4 +1,4 @@
 rmdir bin\Publish /S /Q
-dotnet publish LibationWinForms\LibationWinForms.csproj -p:PublishProfile=LibationWinForms\Properties\PublishProfiles\FolderProfile.pubxml
-dotnet publish LibationCli\LibationCli.csproj -p:PublishProfile=LibationCli\Properties\PublishProfiles\FolderProfile.pubxml
-dotnet publish Hangover\Hangover.csproj -p:PublishProfile=Hangover\Properties\PublishProfiles\FolderProfile.pubxml
+dotnet publish -c Release LibationWinForms\LibationWinForms.csproj -p:PublishProfile=LibationWinForms\Properties\PublishProfiles\FolderProfile.pubxml
+dotnet publish -c Release LibationCli\LibationCli.csproj -p:PublishProfile=LibationCli\Properties\PublishProfiles\FolderProfile.pubxml
+dotnet publish -c Release Hangover\Hangover.csproj -p:PublishProfile=Hangover\Properties\PublishProfiles\FolderProfile.pubxml

--- a/Source/publish.bat
+++ b/Source/publish.bat
@@ -1,0 +1,4 @@
+rmdir bin\Publish /S /Q
+dotnet publish LibationWinForms\LibationWinForms.csproj -p:PublishProfile=LibationWinForms\Properties\PublishProfiles\FolderProfile.pubxml
+dotnet publish LibationCli\LibationCli.csproj -p:PublishProfile=LibationCli\Properties\PublishProfiles\FolderProfile.pubxml
+dotnet publish Hangover\Hangover.csproj -p:PublishProfile=Hangover\Properties\PublishProfiles\FolderProfile.pubxml

--- a/Source/publish.bat
+++ b/Source/publish.bat
@@ -1,4 +1,0 @@
-rmdir bin\Publish /S /Q
-dotnet publish -c Release LibationWinForms\LibationWinForms.csproj -p:PublishProfile=LibationWinForms\Properties\PublishProfiles\FolderProfile.pubxml
-dotnet publish -c Release LibationCli\LibationCli.csproj -p:PublishProfile=LibationCli\Properties\PublishProfiles\FolderProfile.pubxml
-dotnet publish -c Release Hangover\Hangover.csproj -p:PublishProfile=Hangover\Properties\PublishProfiles\FolderProfile.pubxml

--- a/Source/publish.ps1
+++ b/Source/publish.ps1
@@ -1,0 +1,15 @@
+<# You must enable running powershell scripts.
+
+	Set-ExecutionPolicy -Scope CurrentUser Unrestricted
+#>
+
+$pubDir = "bin\Publish"
+Remove-Item $pubDir -Recurse -Force
+
+dotnet publish -c Release LibationWinForms\LibationWinForms.csproj -p:PublishProfile=LibationWinForms\Properties\PublishProfiles\FolderProfile.pubxml
+dotnet publish -c Release LibationCli\LibationCli.csproj -p:PublishProfile=LibationCli\Properties\PublishProfiles\FolderProfile.pubxml
+dotnet publish -c Release Hangover\Hangover.csproj -p:PublishProfile=Hangover\Properties\PublishProfiles\FolderProfile.pubxml
+
+$verMatch = Select-String -Path 'AppScaffolding\AppScaffolding.csproj' -Pattern '<Version>(\d{0,3}\.\d{0,3}\.\d{0,3})\.\d{0,3}</Version>'
+$archiveName = "bin\Libation."+$verMatch.Matches.Groups[1].Value+".zip"
+Compress-Archive -Path $pubDir -DestinationPath $archiveName -Force

--- a/Source/publish.ps1
+++ b/Source/publish.ps1
@@ -12,4 +12,5 @@ dotnet publish -c Release Hangover\Hangover.csproj -p:PublishProfile=Hangover\Pr
 
 $verMatch = Select-String -Path 'AppScaffolding\AppScaffolding.csproj' -Pattern '<Version>(\d{0,3}\.\d{0,3}\.\d{0,3})\.\d{0,3}</Version>'
 $archiveName = "bin\Libation."+$verMatch.Matches.Groups[1].Value+".zip"
-Compress-Archive -Path $pubDir -DestinationPath $archiveName -Force
+Get-ChildItem -Path $pubDir -Recurse |
+	Compress-Archive -DestinationPath $archiveName -Force


### PR DESCRIPTION
- Added a new user audio setting to merge Opening and End Credits chapters with the following/preceding chapter. I also added more chapter tests.
- Added audio bitrate to the database.  I added it as an enum type, `AudioFormatEnum`, that stores bitrate, sample rate, and channel configuration.  `AudioFormatEnum` is internal to DataLayer, and is exposed to referencing assemblies inside `AudioFormat `, which displays the info in a much more friendly way.  `AudioFormatEnum` enum value names match the `AvailableCodec.EnhancedCodec` names, allowing them to be parsed from strings.  The bitrate info is displayed in the `BookDetailsDialog`, but nowhere else yet.
- Configured libation to build via publish.
  -  To do this, I had to get rid of MSBUMP.  It would work, but after cleaning the solution `dotnet publish` would fail.  I replaced it with a dotnet tool: [frogvall.dotnetbumpversion](https://www.nuget.org/packages/Frogvall.DotnetBumpVersion/).  A pre-bild command will increment the build version, but only for debug builds. That way you can publish all 3 Libation exe files without AppScaffolding's build being incremented each time.
  - Added FolderPublish config files for all 3 libation exe's.
  - Added publish.ps1to the Source dir.  To publish, all you have to do is open the dev console and type `.\publish`.  The script will build all files and zip them to \\Source\\bin\\Libation.[ver].zip
    - NOTE: to run powershell scripts you need to enable script execution.  Run this command to enable: 
    - `Set-ExecutionPolicy -Scope CurrentUser Unrestricted`