### PR TITLE
Add useCoverAsFolderIconCb setting to avalonia

### DIFF
--- a/Source/LibationAvalonia/Dialogs/SettingsDialog.axaml
+++ b/Source/LibationAvalonia/Dialogs/SettingsDialog.axaml
@@ -2,8 +2,8 @@
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-        mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="600"
-		MinWidth="800" MinHeight="600"
+        mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="620"
+		MinWidth="800" MinHeight="620"
         x:Class="LibationAvalonia.Dialogs.SettingsDialog"
         xmlns:controls="clr-namespace:LibationAvalonia.Controls"
         Title="Edit Settings"
@@ -206,7 +206,7 @@
 					BorderThickness="2"
 					BorderBrush="{DynamicResource DataGridGridLinesBrush}">
 
-					<Grid RowDefinitions="Auto,Auto,*">
+					<Grid RowDefinitions="Auto,Auto,Auto,*">
 						<controls:GroupBox
 							Grid.Row="0"
 							Margin="5"
@@ -367,6 +367,20 @@
 
 
 						</StackPanel>
+
+						<CheckBox
+							Grid.Row="3"
+							Margin="5"
+							VerticalAlignment="Top"
+							IsVisible="{Binding IsWindows}"
+							IsChecked="{Binding DownloadDecryptSettings.UseCoverAsFolderIcon, Mode=TwoWay}">
+
+							<TextBlock
+								TextWrapping="Wrap"
+								Text="{Binding DownloadDecryptSettings.UseCoverAsFolderIconText}" />
+
+						</CheckBox>
+
 					</Grid>
 				</Border>
 			</TabItem>

--- a/Source/LibationAvalonia/Dialogs/SettingsDialog.axaml.cs
+++ b/Source/LibationAvalonia/Dialogs/SettingsDialog.axaml.cs
@@ -107,6 +107,7 @@ namespace LibationAvalonia.Dialogs
 			LoadSettings(config);
 		}
 
+		public bool IsWindows => AppScaffolding.LibationScaffolding.ReleaseIdentifier is AppScaffolding.ReleaseIdentifier.WindowsAvalonia;
 		public ImportantSettings ImportantSettings { get; private set; }
 		public ImportSettings ImportSettings { get; private set; }
 		public DownloadDecryptSettings DownloadDecryptSettings { get; private set; }
@@ -257,6 +258,7 @@ namespace LibationAvalonia.Dialogs
 			InProgressDirectory
 				= config.InProgress == Configuration.AppDir_Absolute ? Configuration.KnownDirectories.AppDir
 				: Configuration.GetKnownDirectory(config.InProgress);
+			UseCoverAsFolderIcon = config.UseCoverAsFolderIcon;
 		}
 
 		public async Task<bool> SaveSettingsAsync(Configuration config)
@@ -294,9 +296,12 @@ namespace LibationAvalonia.Dialogs
 				= InProgressDirectory is Configuration.KnownDirectories.AppDir ? Configuration.AppDir_Absolute
 				: Configuration.GetKnownDirectoryPath(InProgressDirectory);
 
+			config.UseCoverAsFolderIcon = UseCoverAsFolderIcon;
+
 			return true;
 		}
 
+		public string UseCoverAsFolderIconText { get; } = Configuration.GetDescription(nameof(Configuration.UseCoverAsFolderIcon));
 		public string BadBookGroupboxText { get; } = Configuration.GetDescription(nameof(Configuration.BadBook));
 		public string BadBookAskText { get; } = Configuration.BadBookAction.Ask.GetDescription();
 		public string BadBookAbortText { get; } = Configuration.BadBookAction.Abort.GetDescription();
@@ -311,6 +316,7 @@ namespace LibationAvalonia.Dialogs
 		public string FolderTemplate { get => _folderTemplate; set { this.RaiseAndSetIfChanged(ref _folderTemplate, value); } }
 		public string FileTemplate { get => _fileTemplate; set { this.RaiseAndSetIfChanged(ref _fileTemplate, value); } }
 		public string ChapterFileTemplate { get => _chapterFileTemplate; set { this.RaiseAndSetIfChanged(ref _chapterFileTemplate, value); } }
+		public bool UseCoverAsFolderIcon { get; set; }
 
 		public bool BadBookAsk
 		{


### PR DESCRIPTION
I thought this would make a great teaching opportunity, so I added the setting myself and explained the process below.
---
We need to add two properties to the SettingsDialog view model:
- `UseCoverAsFolderIcon`: holds the setting's boolean value.
- `UseCoverAsFolderIconText`: contains the control's display string ("Set cover art as the folder's icon. (Windows only)")

The `CheckBox` will reside in the Download/Decrypt tab, so we need to add those two properties to `DownloadDecryptSettings`

Inside SettingsDialog.axaml, I added the `CheckBox` control to the bottom of the Download/Decrypt `TabItem` . Note that the `TabItem` is organized inside a `Grid`. That `Grid` had 3 rows, but now we're adding a 4th row so we need to change its `RowDefinitions`.

I added the `CheckBox` control to the end of the `Grid` xml, and set it to display inside the new 4th row (`Grid.Row="3"`).
I bound `CheckBox.IsChecked` to the newly-added `UseCoverAsFolderIcon` with a TwoWay binding. TwoWay means that the `CheckBox` will read the value from the bound property, and it will set the bound property's value when the user changes it.

The `TextBlock` nested inside `CheckBox` is the CheckBoxs's label, and I bound its `Text` property to `UseCoverAsFolderIconText`

Lastly, since this is a Windows-Only setting, I added a boolean `IsWindows` property to `SettingsPages` and bound `CheckBox.IsVisible` to it. Now this `CheckBox` (and its child `TextBox` control) will only be visible on Windows versions.

