### PR TITLE
Change assembly loadig

### DIFF
--- a/Source/LibationFileManager/InteropFactory.cs
+++ b/Source/LibationFileManager/InteropFactory.cs
@@ -121,7 +121,6 @@ namespace LibationFileManager
 
 #if DEBUG
 
-            // `First` instead of `FirstOrDefault`. If it's not present we're going to fail anyway. May as well be here
             var modulePath = ModuleList.SingleOrDefault(m => m.ModuleName.EqualsInsensitive(asmName))?.FileName;
 #else
             var here = Path.GetDirectoryName(Environment.ProcessPath);
@@ -134,6 +133,7 @@ namespace LibationFileManager
 #endif
             if (modulePath is null)
             {
+                //Let the runtime handle any dll not found exceptions.
                 Serilog.Log.Logger.Error($"Unable to load module {args.Name}");
                 return null;
             }

--- a/Source/LibationFileManager/InteropFactory.cs
+++ b/Source/LibationFileManager/InteropFactory.cs
@@ -66,7 +66,7 @@ namespace LibationFileManager
         {
             var here = Path.GetDirectoryName(Environment.ProcessPath);
 
-            // find '*ConfigApp.exe' files
+            // find '*ConfigApp.dll' files
             var appName =
                 Directory.EnumerateFiles(here, $"*{CONFIG_APP_ENDING}", SearchOption.TopDirectoryOnly)
                 // sanity check. shouldn't ever be true

--- a/Source/LibationFileManager/InteropFactory.cs
+++ b/Source/LibationFileManager/InteropFactory.cs
@@ -46,13 +46,17 @@ namespace LibationFileManager
                 return;
             }
 
+            /*
+            * Commented code used to locate assemblies from the *ConfigApp.exe's module list.
+            * Use this method to locate dependencies when they are not in Libation's program files directory.
 #if DEBUG
 
-            // runs the exe and gets the exe's loaded modules
-            ModuleList = LoadModuleList(Path.GetFileNameWithoutExtension(configApp))
-                .OrderBy(x => x.ModuleName)
-                .ToList();
+           // runs the exe and gets the exe's loaded modules
+           ModuleList = LoadModuleList(Path.GetFileNameWithoutExtension(configApp))
+               .OrderBy(x => x.ModuleName)
+               .ToList();
 #endif
+            */
 
             AppDomain.CurrentDomain.AssemblyResolve += CurrentDomain_AssemblyResolve;
 
@@ -76,6 +80,9 @@ namespace LibationFileManager
             return appName;
         }
 
+       /*
+        * Use this method to locate dependencies when they are not in Libation's program files directory.
+        * 
         private static List<ProcessModule> LoadModuleList(string exeName)
         {
             var proc = new Process
@@ -112,24 +119,30 @@ namespace LibationFileManager
 
             return modules;
         }
+        */
 
         private static Assembly CurrentDomain_AssemblyResolve(object sender, ResolveEventArgs args)
         {
             // e.g. "System.Windows.Forms, Version=6.0.2.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
             var asmName = args.Name.Split(',')[0] + ".dll";
 
-#if DEBUG
+
+            /*
+             * Commented code used to locate assemblies from the *ConfigApp.exe's module list.
+             * Use this method to locate dependencies when they are not in Libation's program files directory.
+ #if DEBUG
 
             var modulePath = ModuleList.SingleOrDefault(m => m.ModuleName.EqualsInsensitive(asmName))?.FileName;
-#else
+ #else
+            */
             var here = Path.GetDirectoryName(Environment.ProcessPath);
 
-            // find '*ConfigApp.dll' files
+            // find the requested assembly in the program files directory
             var modulePath =
                 Directory.EnumerateFiles(here, asmName, SearchOption.TopDirectoryOnly)
                 .SingleOrDefault();
 
-#endif
+            //#endif
             if (modulePath is null)
             {
                 //Let the runtime handle any dll not found exceptions.

--- a/Source/LibationFileManager/InteropFactory.cs
+++ b/Source/LibationFileManager/InteropFactory.cs
@@ -48,7 +48,6 @@ namespace LibationFileManager
 
 #if DEBUG
 
-
             // runs the exe and gets the exe's loaded modules
             ModuleList = LoadModuleList(Path.GetFileNameWithoutExtension(configApp))
                 .OrderBy(x => x.ModuleName)
@@ -69,7 +68,7 @@ namespace LibationFileManager
 
             // find '*ConfigApp.exe' files
             var appName =
-                Directory.EnumerateFiles(here, $"*{CONFIG_APP_ENDING}*", SearchOption.TopDirectoryOnly)
+                Directory.EnumerateFiles(here, $"*{CONFIG_APP_ENDING}", SearchOption.TopDirectoryOnly)
                 // sanity check. shouldn't ever be true
                 .Except(new[] { Environment.ProcessPath })
                 .FirstOrDefault(exe => MatchesOS(exe));

--- a/Source/LibationFileManager/InteropFactory.cs
+++ b/Source/LibationFileManager/InteropFactory.cs
@@ -39,14 +39,15 @@ namespace LibationFileManager
             // searches file names for potential matches; doesn't run anything
             var configApp = getOSConfigApp();
 
-#if DEBUG
-
             // nothing to load
             if (configApp is null)
             {
                 Serilog.Log.Logger.Error($"Unable to locate *{CONFIG_APP_ENDING}");
                 return;
             }
+
+#if DEBUG
+
 
             // runs the exe and gets the exe's loaded modules
             ModuleList = LoadModuleList(Path.GetFileNameWithoutExtension(configApp))
@@ -56,7 +57,7 @@ namespace LibationFileManager
 
             AppDomain.CurrentDomain.AssemblyResolve += CurrentDomain_AssemblyResolve;
 
-            var configAppAssembly = Assembly.LoadFrom(Path.ChangeExtension(configApp, "dll"));
+            var configAppAssembly = Assembly.LoadFrom(configApp);
             var type = typeof(IInteropFunctions);
             InteropFunctionsType = configAppAssembly
                 .GetTypes()
@@ -121,7 +122,7 @@ namespace LibationFileManager
 #if DEBUG
 
             // `First` instead of `FirstOrDefault`. If it's not present we're going to fail anyway. May as well be here
-            var modulePath = ModuleList.SingleOrDefault(m => m.ModuleName.EqualsInsensitive(asmName)).FileName;
+            var modulePath = ModuleList.SingleOrDefault(m => m.ModuleName.EqualsInsensitive(asmName))?.FileName;
 #else
             var here = Path.GetDirectoryName(Environment.ProcessPath);
 


### PR DESCRIPTION
Hopefully this fixes #361 

Changes:

- Only execute the *ConfigApp.exe if debugging. Published standalone builds have all dependencies inside the Libation folder, so load by filename in release builds.
- Search for *ConfigApp.dll instead of *ConfigApp.exe because Linux and Mac don't use the exe extension, but dotnet still uses the dll extension on those platforms.
- When resolving assemblies, look for the exact name. If it's not found, log that it's not found and return null instead of throwing an exception inside the AssemblyResolve event handler. This will let the runtime handle the assembly not found error. This event was firing for "Libation.resources, Version=1.0.0.0, Culture=en-US, PublicKeyToken=null", and since our handler couldn't find a file starting with "Libation.resources" it threw an exception. I don't know why that wasn't causing problems for everyone, but it could be the culprit we're looking for.