### PR TITLE
Add dynamic context menus to products grid

### DIFF
--- a/Source/LibationAvalonia/Assets/LibationStyles.xaml
+++ b/Source/LibationAvalonia/Assets/LibationStyles.xaml
@@ -1,8 +1,8 @@
 <Styles xmlns="https://github.com/avaloniaui" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
 	<Styles.Resources>
-		<Color x:Key="SeriesEntryGridBackgroundColor">#FFE6FFE6</Color>
+		<Color x:Key="SeriesEntryGridBackgroundColor">#cdffcd</Color>
 
-		<SolidColorBrush x:Key="SeriesEntryGridBackgroundBrush"  Color="{StaticResource SeriesEntryGridBackgroundColor}" />
+		<SolidColorBrush x:Key="SeriesEntryGridBackgroundBrush" Opacity="0.5" Color="{StaticResource SeriesEntryGridBackgroundColor}" />
 		<SolidColorBrush x:Key="ProcessQueueBookFailedBrush" Color="LightCoral" />
 		<SolidColorBrush x:Key="ProcessQueueBookCompletedBrush" Color="PaleGreen" />
 		<SolidColorBrush x:Key="ProcessQueueBookCancelledBrush" Color="Khaki" />

--- a/Source/LibationAvalonia/Controls/DataGridTemplateColumnExt.axaml
+++ b/Source/LibationAvalonia/Controls/DataGridTemplateColumnExt.axaml
@@ -1,0 +1,7 @@
+<DataGridTemplateColumn xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             x:Class="LibationAvalonia.Controls.DataGridTemplateColumnExt">
+	
+</DataGridTemplateColumn>

--- a/Source/LibationAvalonia/Controls/DataGridTemplateColumnExt.axaml.cs
+++ b/Source/LibationAvalonia/Controls/DataGridTemplateColumnExt.axaml.cs
@@ -7,10 +7,10 @@ using System.Reflection;
 
 namespace LibationAvalonia.Controls
 {	
-	public class DataGridViewCellContextMenuStripNeededEventArgs
+	public class DataGridCellContextMenuStripNeededEventArgs
 	{
 		private static readonly MethodInfo GetCellValueMethod;
-		static DataGridViewCellContextMenuStripNeededEventArgs()
+		static DataGridCellContextMenuStripNeededEventArgs()
 		{
 			GetCellValueMethod = typeof(DataGridColumn).GetMethod("GetCellValue", BindingFlags.NonPublic | BindingFlags.Instance);
 		}
@@ -28,7 +28,7 @@ namespace LibationAvalonia.Controls
 
 	public partial class DataGridTemplateColumnExt : DataGridTemplateColumn
 	{
-		public event EventHandler<DataGridViewCellContextMenuStripNeededEventArgs> CellContextMenuStripNeeded;
+		public event EventHandler<DataGridCellContextMenuStripNeededEventArgs> CellContextMenuStripNeeded;
 
 		private static readonly ContextMenu ContextMenu = new();
 		private static readonly AvaloniaList<MenuItem> MenuItems  = new();
@@ -43,7 +43,7 @@ namespace LibationAvalonia.Controls
 		{
 			if (sender is DataGridCell cell && cell.DataContext is GridEntry entry)
 			{
-				var args = new DataGridViewCellContextMenuStripNeededEventArgs
+				var args = new DataGridCellContextMenuStripNeededEventArgs
 				{
 					Column = this,
 					GridEntry = entry,

--- a/Source/LibationAvalonia/Controls/DataGridTemplateColumnExt.axaml.cs
+++ b/Source/LibationAvalonia/Controls/DataGridTemplateColumnExt.axaml.cs
@@ -30,8 +30,8 @@ namespace LibationAvalonia.Controls
 	{
 		public event EventHandler<DataGridViewCellContextMenuStripNeededEventArgs> CellContextMenuStripNeeded;
 
-		private readonly ContextMenu ContextMenu = new();
-		private readonly AvaloniaList<MenuItem> MenuItems  = new();
+		private static readonly ContextMenu ContextMenu = new();
+		private static readonly AvaloniaList<MenuItem> MenuItems  = new();
 
 		public DataGridTemplateColumnExt()
 		{

--- a/Source/LibationAvalonia/Controls/DataGridTemplateColumnExt.axaml.cs
+++ b/Source/LibationAvalonia/Controls/DataGridTemplateColumnExt.axaml.cs
@@ -1,0 +1,73 @@
+using Avalonia.Collections;
+using Avalonia.Controls;
+using Avalonia.Markup.Xaml;
+using LibationAvalonia.ViewModels;
+using System;
+using System.Reflection;
+
+namespace LibationAvalonia.Controls
+{	
+	public class DataGridViewCellContextMenuStripNeededEventArgs
+	{
+		private static readonly MethodInfo GetCellValueMethod;
+		static DataGridViewCellContextMenuStripNeededEventArgs()
+		{
+			GetCellValueMethod = typeof(DataGridColumn).GetMethod("GetCellValue", BindingFlags.NonPublic | BindingFlags.Instance);
+		}
+
+		private static string GetCellValue(DataGridColumn column, object item)
+			=> GetCellValueMethod.Invoke(column, new object[] { item, column.ClipboardContentBinding })?.ToString() ?? "";
+
+		public string CellClipboardContents => GetCellValue(Column, GridEntry);
+		public DataGridTemplateColumnExt Column { get; init; }
+		public GridEntry GridEntry { get; init; }
+		public ContextMenu ContextMenu { get; init; }
+		public AvaloniaList<MenuItem> ContextMenuItems
+			=> ContextMenu.Items as AvaloniaList<MenuItem>;
+	}
+
+	public partial class DataGridTemplateColumnExt : DataGridTemplateColumn
+	{
+		public event EventHandler<DataGridViewCellContextMenuStripNeededEventArgs> CellContextMenuStripNeeded;
+
+		private readonly ContextMenu ContextMenu = new();
+		private readonly AvaloniaList<MenuItem> MenuItems  = new();
+
+		public DataGridTemplateColumnExt()
+		{
+			AvaloniaXamlLoader.Load(this);
+			ContextMenu.Items = MenuItems;
+		}
+
+		private void Cell_ContextRequested(object sender, ContextRequestedEventArgs e)
+		{
+			if (sender is DataGridCell cell && cell.DataContext is GridEntry entry)
+			{
+				var args = new DataGridViewCellContextMenuStripNeededEventArgs
+				{
+					Column = this,
+					GridEntry = entry,
+					ContextMenu = ContextMenu
+				};
+				args.ContextMenuItems.Clear();
+
+				CellContextMenuStripNeeded?.Invoke(sender, args);
+				
+				e.Handled = args.ContextMenuItems.Count == 0;
+			}
+			else
+				e.Handled = true;
+		}
+
+		protected override IControl GenerateElement(DataGridCell cell, object dataItem)
+		{
+			if (cell.ContextMenu is null)
+			{
+				cell.ContextRequested += Cell_ContextRequested;
+				cell.ContextMenu = ContextMenu;
+			}
+
+			return base.GenerateElement(cell, dataItem);
+		}
+	}
+}

--- a/Source/LibationAvalonia/LibationAvalonia.csproj
+++ b/Source/LibationAvalonia/LibationAvalonia.csproj
@@ -89,6 +89,9 @@
   </ItemGroup>
 
   <ItemGroup>
+    <Compile Update="Controls\DataGridTemplateColumnExt.axaml.cs">
+      <DependentUpon>DataGridTemplateColumnExt.axaml</DependentUpon>
+    </Compile>
     <Compile Update="Properties\Resources.Designer.cs">
       <DesignTime>True</DesignTime>
       <AutoGen>True</AutoGen>

--- a/Source/LibationAvalonia/LibationAvalonia.csproj
+++ b/Source/LibationAvalonia/LibationAvalonia.csproj
@@ -89,9 +89,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Compile Update="Controls\DataGridTemplateColumnExt.axaml.cs">
-      <DependentUpon>DataGridTemplateColumnExt.axaml</DependentUpon>
-    </Compile>
     <Compile Update="Properties\Resources.Designer.cs">
       <DesignTime>True</DesignTime>
       <AutoGen>True</AutoGen>

--- a/Source/LibationAvalonia/ViewModels/GridEntry.cs
+++ b/Source/LibationAvalonia/ViewModels/GridEntry.cs
@@ -51,7 +51,8 @@ namespace LibationAvalonia.ViewModels
 		public abstract bool IsSeries { get; }
 		public abstract bool IsEpisode { get; }
 		public abstract bool IsBook { get; }
-		public IBrush BackgroundBrush => IsEpisode ? App.SeriesEntryGridBackgroundBrush : null;
+		public abstract double Opacity { get; }
+		public IBrush BackgroundBrush => IsEpisode ? App.SeriesEntryGridBackgroundBrush : Brushes.Transparent;
 
 		#endregion
 

--- a/Source/LibationAvalonia/ViewModels/LibraryBookEntry.cs
+++ b/Source/LibationAvalonia/ViewModels/LibraryBookEntry.cs
@@ -53,6 +53,7 @@ namespace LibationAvalonia.ViewModels
 		public override bool IsSeries => false;
 		public override bool IsEpisode => Parent is not null;
 		public override bool IsBook => Parent is null;
+		public override double Opacity => Book.UserDefinedItem.Tags.ToLower().Contains("hidden") ? 0.4 : 1;
 
 		#endregion
 
@@ -99,6 +100,7 @@ namespace LibationAvalonia.ViewModels
 				case nameof(udi.Tags):
 					Book.UserDefinedItem.Tags = udi.Tags; 
 					this.RaisePropertyChanged(nameof(BookTags));
+					this.RaisePropertyChanged(nameof(Opacity));
 					break;
 				case nameof(udi.BookStatus):
 					Book.UserDefinedItem.BookStatus = udi.BookStatus;

--- a/Source/LibationAvalonia/ViewModels/SeriesEntry.cs
+++ b/Source/LibationAvalonia/ViewModels/SeriesEntry.cs
@@ -50,6 +50,7 @@ namespace LibationAvalonia.ViewModels
 		public override bool IsSeries => true;
 		public override bool IsEpisode => false;
 		public override bool IsBook => false;
+		public override double Opacity => 1;
 
 		#endregion
 

--- a/Source/LibationAvalonia/Views/ProductsDisplay.axaml
+++ b/Source/LibationAvalonia/Views/ProductsDisplay.axaml
@@ -16,10 +16,11 @@
 			AutoGenerateColumns="False"
 			Items="{Binding GridEntries}"
 			CanUserSortColumns="True"
+			SelectionMode="Single"
 			CanUserReorderColumns="True">
 
 			<DataGrid.Columns>
-			
+
 				<DataGridTemplateColumn
 					CanUserSort="True"
 					IsVisible="{Binding RemoveColumnVisivle}"
@@ -28,7 +29,7 @@
 					IsReadOnly="False"
 					SortMemberPath="Remove"
 					Width="75">
-					
+
 					<DataGridTemplateColumn.CellTemplate>
 						<DataTemplate>
 							<CheckBox
@@ -39,22 +40,15 @@
 					</DataGridTemplateColumn.CellTemplate>
 				</DataGridTemplateColumn>
 
-				<DataGridTemplateColumn CanUserSort="True" Width="75" Header="Liberate" SortMemberPath="Liberate" ClipboardContentBinding="{Binding Liberate.ToolTip}">
+				<controls:DataGridTemplateColumnExt CanUserSort="True" Width="75" Header="Liberate" SortMemberPath="Liberate" ClipboardContentBinding="{Binding Liberate.ToolTip}">
 					<DataGridTemplateColumn.CellTemplate>
 						<DataTemplate>
 							<Button Padding="0" HorizontalAlignment="Stretch" VerticalAlignment="Stretch" Click="LiberateButton_Click" ToolTip.Tip="{Binding Liberate.ToolTip}">
 								<Image Stretch="None" Source="{Binding Liberate.Image}" />
-								<Button.ContextMenu>
-									<ContextMenu IsVisible="{Binding !Liberate.IsSeries}">
-										<MenuItem Header="Item 1" Click="ContextMenuItem1_Click" />
-										<MenuItem Header="Item 2" Click="ContextMenuItem2_Click" />
-										<MenuItem Header="Item 3" Click="ContextMenuItem3_Click" />
-									</ContextMenu>
-								</Button.ContextMenu>
 							</Button>
 						</DataTemplate>
 					</DataGridTemplateColumn.CellTemplate>
-				</DataGridTemplateColumn>
+				</controls:DataGridTemplateColumnExt>
 
 				<DataGridTemplateColumn CanUserSort="False" Width="80" Header="Cover" SortMemberPath="Cover" ClipboardContentBinding="{Binding LibraryBook.Book.PictureLarge}">
 					<DataGridTemplateColumn.CellTemplate>
@@ -64,7 +58,7 @@
 					</DataGridTemplateColumn.CellTemplate>
 				</DataGridTemplateColumn>
 
-				<DataGridTemplateColumn MinWidth="150" Width="2*" Header="Title" CanUserSort="True" SortMemberPath="Title" ClipboardContentBinding="{Binding Title}">
+				<controls:DataGridTemplateColumnExt MinWidth="150" Width="2*" Header="Title" CanUserSort="True" SortMemberPath="Title" ClipboardContentBinding="{Binding Title}">
 					<DataGridTemplateColumn.CellTemplate>
 						<DataTemplate>
 							<Panel Background="{Binding BackgroundBrush}">
@@ -74,9 +68,9 @@
 							</Panel>
 						</DataTemplate>
 					</DataGridTemplateColumn.CellTemplate>
-				</DataGridTemplateColumn>
+				</controls:DataGridTemplateColumnExt>
 
-				<DataGridTemplateColumn MinWidth="80" Width="1*" Header="Authors" CanUserSort="True" SortMemberPath="Authors" ClipboardContentBinding="{Binding Authors}">
+				<controls:DataGridTemplateColumnExt MinWidth="80" Width="1*" Header="Authors" CanUserSort="True" SortMemberPath="Authors" ClipboardContentBinding="{Binding Authors}">
 					<DataGridTemplateColumn.CellTemplate>
 						<DataTemplate>
 							<Panel Background="{Binding BackgroundBrush}">
@@ -86,9 +80,9 @@
 							</Panel>
 						</DataTemplate>
 					</DataGridTemplateColumn.CellTemplate>
-				</DataGridTemplateColumn>
+				</controls:DataGridTemplateColumnExt>
 
-				<DataGridTemplateColumn MinWidth="80" Width="1*"  Header="Narrators" CanUserSort="True" SortMemberPath="Narrators" ClipboardContentBinding="{Binding Narrators}">
+				<controls:DataGridTemplateColumnExt MinWidth="80" Width="1*"  Header="Narrators" CanUserSort="True" SortMemberPath="Narrators" ClipboardContentBinding="{Binding Narrators}">
 					<DataGridTemplateColumn.CellTemplate>
 						<DataTemplate>
 							<Panel Background="{Binding BackgroundBrush}">
@@ -98,9 +92,9 @@
 							</Panel>
 						</DataTemplate>
 					</DataGridTemplateColumn.CellTemplate>
-				</DataGridTemplateColumn>
+				</controls:DataGridTemplateColumnExt>
 
-				<DataGridTemplateColumn Width="90"  Header="Length" CanUserSort="True" SortMemberPath="Length" ClipboardContentBinding="{Binding Length}">
+				<controls:DataGridTemplateColumnExt Width="90"  Header="Length" CanUserSort="True" SortMemberPath="Length" ClipboardContentBinding="{Binding Length}">
 					<DataGridTemplateColumn.CellTemplate>
 						<DataTemplate>
 							<Panel Background="{Binding BackgroundBrush}">
@@ -110,9 +104,9 @@
 							</Panel>
 						</DataTemplate>
 					</DataGridTemplateColumn.CellTemplate>
-				</DataGridTemplateColumn>
+				</controls:DataGridTemplateColumnExt>
 
-				<DataGridTemplateColumn MinWidth="80" Width="1*" Header="Series" CanUserSort="True" SortMemberPath="Series" ClipboardContentBinding="{Binding Series}">
+				<controls:DataGridTemplateColumnExt MinWidth="80" Width="1*" Header="Series" CanUserSort="True" SortMemberPath="Series" ClipboardContentBinding="{Binding Series}">
 					<DataGridTemplateColumn.CellTemplate>
 						<DataTemplate>
 							<Panel Background="{Binding BackgroundBrush}">
@@ -122,9 +116,9 @@
 							</Panel>
 						</DataTemplate>
 					</DataGridTemplateColumn.CellTemplate>
-				</DataGridTemplateColumn>
+				</controls:DataGridTemplateColumnExt>
 
-				<DataGridTemplateColumn MinWidth="100" Width="1*" Header="Description" CanUserSort="True" SortMemberPath="Description" ClipboardContentBinding="{Binding LongDescription}">
+				<controls:DataGridTemplateColumnExt MinWidth="100" Width="1*" Header="Description" CanUserSort="True" SortMemberPath="Description" ClipboardContentBinding="{Binding LongDescription}">
 					<DataGridTemplateColumn.CellTemplate>
 						<DataTemplate>
 							<Panel Background="{Binding BackgroundBrush}">
@@ -134,9 +128,9 @@
 							</Panel>
 						</DataTemplate>
 					</DataGridTemplateColumn.CellTemplate>
-				</DataGridTemplateColumn>
+				</controls:DataGridTemplateColumnExt>
 
-				<DataGridTemplateColumn Width="100" Header="Category" CanUserSort="True" SortMemberPath="Category" ClipboardContentBinding="{Binding Category}">
+				<controls:DataGridTemplateColumnExt Width="100" Header="Category" CanUserSort="True" SortMemberPath="Category" ClipboardContentBinding="{Binding Category}">
 					<DataGridTemplateColumn.CellTemplate>
 						<DataTemplate>
 							<Panel Background="{Binding BackgroundBrush}">
@@ -146,9 +140,9 @@
 							</Panel>
 						</DataTemplate>
 					</DataGridTemplateColumn.CellTemplate>
-				</DataGridTemplateColumn>
+				</controls:DataGridTemplateColumnExt>
 
-				<DataGridTemplateColumn Width="120" Header="Product&#xA;Rating" CanUserSort="True" SortMemberPath="ProductRating" ClipboardContentBinding="{Binding ProductRating}">
+				<controls:DataGridTemplateColumnExt Width="120" Header="Product&#xA;Rating" CanUserSort="True" SortMemberPath="ProductRating" ClipboardContentBinding="{Binding ProductRating}">
 					<DataGridTemplateColumn.CellTemplate>
 						<DataTemplate>
 							<Panel Background="{Binding BackgroundBrush}">
@@ -158,9 +152,9 @@
 							</Panel>
 						</DataTemplate>
 					</DataGridTemplateColumn.CellTemplate>
-				</DataGridTemplateColumn>
+				</controls:DataGridTemplateColumnExt>
 
-				<DataGridTemplateColumn Width="90" Header="Purchase&#xA;Date" CanUserSort="True" SortMemberPath="PurchaseDate" ClipboardContentBinding="{Binding PurchaseDate}">
+				<controls:DataGridTemplateColumnExt Width="90" Header="Purchase&#xA;Date" CanUserSort="True" SortMemberPath="PurchaseDate" ClipboardContentBinding="{Binding PurchaseDate}">
 					<DataGridTemplateColumn.CellTemplate>
 						<DataTemplate>
 							<Panel Background="{Binding BackgroundBrush}">
@@ -170,9 +164,9 @@
 							</Panel>
 						</DataTemplate>
 					</DataGridTemplateColumn.CellTemplate>
-				</DataGridTemplateColumn>
+				</controls:DataGridTemplateColumnExt>
 
-				<DataGridTemplateColumn Width="120" Header="My Rating" CanUserSort="True" SortMemberPath="MyRating" ClipboardContentBinding="{Binding MyRating}">
+				<controls:DataGridTemplateColumnExt Width="120" Header="My Rating" CanUserSort="True" SortMemberPath="MyRating" ClipboardContentBinding="{Binding MyRating}">
 					<DataGridTemplateColumn.CellTemplate>
 						<DataTemplate>
 							<Panel Background="{Binding BackgroundBrush}">
@@ -182,9 +176,9 @@
 							</Panel>
 						</DataTemplate>
 					</DataGridTemplateColumn.CellTemplate>
-				</DataGridTemplateColumn>
+				</controls:DataGridTemplateColumnExt>
 
-				<DataGridTemplateColumn Width="135" Header="Misc" CanUserSort="True" SortMemberPath="Misc" ClipboardContentBinding="{Binding Misc}">
+				<controls:DataGridTemplateColumnExt Width="135" Header="Misc" CanUserSort="True" SortMemberPath="Misc" ClipboardContentBinding="{Binding Misc}">
 					<DataGridTemplateColumn.CellTemplate>
 						<DataTemplate>
 							<Panel Background="{Binding BackgroundBrush}">
@@ -194,9 +188,9 @@
 							</Panel>
 						</DataTemplate>
 					</DataGridTemplateColumn.CellTemplate>
-				</DataGridTemplateColumn>
+				</controls:DataGridTemplateColumnExt>
 
-				<DataGridTemplateColumn CanUserSort="True" Width="100" Header="Tags" SortMemberPath="BookTags" ClipboardContentBinding="{Binding BookTags.Tags}">
+				<controls:DataGridTemplateColumnExt CanUserSort="True" Width="100" Header="Tags" SortMemberPath="BookTags" ClipboardContentBinding="{Binding BookTags.Tags}">
 					<DataGridTemplateColumn.CellTemplate>
 						<DataTemplate>
 							<StackPanel Orientation="Horizontal">
@@ -209,7 +203,7 @@
 							</StackPanel>
 						</DataTemplate>
 					</DataGridTemplateColumn.CellTemplate>
-				</DataGridTemplateColumn>
+				</controls:DataGridTemplateColumnExt>
 
 			</DataGrid.Columns>
 		</DataGrid>

--- a/Source/LibationAvalonia/Views/ProductsDisplay.axaml
+++ b/Source/LibationAvalonia/Views/ProductsDisplay.axaml
@@ -15,8 +15,21 @@
 			GridLinesVisibility="All"
 			AutoGenerateColumns="False"
 			Items="{Binding GridEntries}"
-			CanUserSortColumns="True"
+			CanUserSortColumns="True" BorderThickness="3"
 			CanUserReorderColumns="True">
+
+			<DataGrid.Styles>
+				<Style Selector="DataGridCell > Panel">
+					<Setter Property="Margin" Value="0,1,0,1"/>
+					<Setter Property="Height" Value="80"/>
+				</Style>
+				<Style Selector="DataGridCell > Panel > TextBlock">
+					<Setter Property="VerticalAlignment" Value="Center"/>
+					<Setter Property="HorizontalAlignment" Value="Stretch"/>
+					<Setter Property="TextWrapping" Value="Wrap"/>
+					<Setter Property="Padding" Value="4"/>
+				</Style>
+			</DataGrid.Styles>
 
 			<DataGrid.Columns>
 
@@ -42,8 +55,8 @@
 				<controls:DataGridTemplateColumnExt CanUserSort="True" Width="75" Header="Liberate" SortMemberPath="Liberate" ClipboardContentBinding="{Binding Liberate.ToolTip}">
 					<DataGridTemplateColumn.CellTemplate>
 						<DataTemplate>
-							<Button Padding="0" HorizontalAlignment="Stretch" VerticalAlignment="Stretch" Click="LiberateButton_Click" ToolTip.Tip="{Binding Liberate.ToolTip}">
-								<Image Stretch="None" Source="{Binding Liberate.Image}" />
+							<Button Opacity="{Binding Opacity}" Padding="0" HorizontalAlignment="Stretch" VerticalAlignment="Stretch" Click="LiberateButton_Click" ToolTip.Tip="{Binding Liberate.ToolTip}">
+								<Image Source="{Binding Liberate.Image}" Stretch="None" />
 							</Button>
 						</DataTemplate>
 					</DataGridTemplateColumn.CellTemplate>
@@ -52,7 +65,7 @@
 				<DataGridTemplateColumn CanUserSort="False" Width="80" Header="Cover" SortMemberPath="Cover" ClipboardContentBinding="{Binding LibraryBook.Book.PictureLarge}">
 					<DataGridTemplateColumn.CellTemplate>
 						<DataTemplate>
-							<Image Tapped="Cover_Click" Height="80" Source="{Binding Cover}" ToolTip.Tip="Click to see full size" />
+							<Image Opacity="{Binding Opacity}" Tapped="Cover_Click" Height="80" Source="{Binding Cover}" ToolTip.Tip="Click to see full size" />
 						</DataTemplate>
 					</DataGridTemplateColumn.CellTemplate>
 				</DataGridTemplateColumn>
@@ -60,10 +73,8 @@
 				<controls:DataGridTemplateColumnExt MinWidth="150" Width="2*" Header="Title" CanUserSort="True" SortMemberPath="Title" ClipboardContentBinding="{Binding Title}">
 					<DataGridTemplateColumn.CellTemplate>
 						<DataTemplate>
-							<Panel Background="{Binding BackgroundBrush}">
-								<Border Background="{Binding BackgroundBrush}" BorderThickness="3" Height="80">
-									<TextBlock VerticalAlignment="Center" TextWrapping="Wrap" Text="{Binding Title}" />
-								</Border>
+							<Panel Background="{Binding BackgroundBrush}" Opacity="{Binding Opacity}">
+								<TextBlock Text="{Binding Title}" />
 							</Panel>
 						</DataTemplate>
 					</DataGridTemplateColumn.CellTemplate>
@@ -72,10 +83,8 @@
 				<controls:DataGridTemplateColumnExt MinWidth="80" Width="1*" Header="Authors" CanUserSort="True" SortMemberPath="Authors" ClipboardContentBinding="{Binding Authors}">
 					<DataGridTemplateColumn.CellTemplate>
 						<DataTemplate>
-							<Panel Background="{Binding BackgroundBrush}">
-								<Border BorderThickness="3" Height="80">
-									<TextBlock VerticalAlignment="Center" TextWrapping="Wrap" Text="{Binding Authors}" />
-								</Border>
+							<Panel Background="{Binding BackgroundBrush}" Opacity="{Binding Opacity}">
+								<TextBlock Text="{Binding Authors}" />
 							</Panel>
 						</DataTemplate>
 					</DataGridTemplateColumn.CellTemplate>
@@ -84,10 +93,8 @@
 				<controls:DataGridTemplateColumnExt MinWidth="80" Width="1*"  Header="Narrators" CanUserSort="True" SortMemberPath="Narrators" ClipboardContentBinding="{Binding Narrators}">
 					<DataGridTemplateColumn.CellTemplate>
 						<DataTemplate>
-							<Panel Background="{Binding BackgroundBrush}">
-								<Border BorderThickness="3" Height="80">
-									<TextBlock VerticalAlignment="Center" TextWrapping="Wrap" Text="{Binding Narrators}" />
-								</Border>
+							<Panel Background="{Binding BackgroundBrush}" Opacity="{Binding Opacity}">
+								<TextBlock Text="{Binding Narrators}" />
 							</Panel>
 						</DataTemplate>
 					</DataGridTemplateColumn.CellTemplate>
@@ -96,10 +103,8 @@
 				<controls:DataGridTemplateColumnExt Width="90"  Header="Length" CanUserSort="True" SortMemberPath="Length" ClipboardContentBinding="{Binding Length}">
 					<DataGridTemplateColumn.CellTemplate>
 						<DataTemplate>
-							<Panel Background="{Binding BackgroundBrush}">
-								<Border BorderThickness="3" Height="80">
-									<TextBlock VerticalAlignment="Center" TextWrapping="Wrap" Text="{Binding Length}" />
-								</Border>
+							<Panel Background="{Binding BackgroundBrush}" Opacity="{Binding Opacity}">
+								<TextBlock Text="{Binding Length}" />
 							</Panel>
 						</DataTemplate>
 					</DataGridTemplateColumn.CellTemplate>
@@ -108,10 +113,8 @@
 				<controls:DataGridTemplateColumnExt MinWidth="80" Width="1*" Header="Series" CanUserSort="True" SortMemberPath="Series" ClipboardContentBinding="{Binding Series}">
 					<DataGridTemplateColumn.CellTemplate>
 						<DataTemplate>
-							<Panel Background="{Binding BackgroundBrush}">
-								<Border BorderThickness="3" Height="80">
-									<TextBlock VerticalAlignment="Center" TextWrapping="Wrap" Text="{Binding Series}" />
-								</Border>
+							<Panel Background="{Binding BackgroundBrush}" Opacity="{Binding Opacity}">
+								<TextBlock Text="{Binding Series}" />
 							</Panel>
 						</DataTemplate>
 					</DataGridTemplateColumn.CellTemplate>
@@ -120,10 +123,8 @@
 				<controls:DataGridTemplateColumnExt MinWidth="100" Width="1*" Header="Description" CanUserSort="True" SortMemberPath="Description" ClipboardContentBinding="{Binding LongDescription}">
 					<DataGridTemplateColumn.CellTemplate>
 						<DataTemplate>
-							<Panel Background="{Binding BackgroundBrush}">
-								<Border BorderThickness="3" Height="80">
-									<TextBlock Tapped="Description_Click" VerticalAlignment="Center" TextWrapping="Wrap" ToolTip.Tip="Click to see full description" Text="{Binding Description}" />
-								</Border>
+							<Panel Background="{Binding BackgroundBrush}" Opacity="{Binding Opacity}" Tapped="Description_Click" ToolTip.Tip="Click to see full description" >
+								<TextBlock Text="{Binding Description}" />
 							</Panel>
 						</DataTemplate>
 					</DataGridTemplateColumn.CellTemplate>
@@ -132,10 +133,8 @@
 				<controls:DataGridTemplateColumnExt Width="100" Header="Category" CanUserSort="True" SortMemberPath="Category" ClipboardContentBinding="{Binding Category}">
 					<DataGridTemplateColumn.CellTemplate>
 						<DataTemplate>
-							<Panel Background="{Binding BackgroundBrush}">
-								<Border BorderThickness="3" Height="80">
-									<TextBlock VerticalAlignment="Center" TextWrapping="Wrap" Text="{Binding Category}" />
-								</Border>
+							<Panel Background="{Binding BackgroundBrush}" Opacity="{Binding Opacity}">
+								<TextBlock Text="{Binding Category}" />
 							</Panel>
 						</DataTemplate>
 					</DataGridTemplateColumn.CellTemplate>
@@ -144,10 +143,8 @@
 				<controls:DataGridTemplateColumnExt Width="120" Header="Product&#xA;Rating" CanUserSort="True" SortMemberPath="ProductRating" ClipboardContentBinding="{Binding ProductRating}">
 					<DataGridTemplateColumn.CellTemplate>
 						<DataTemplate>
-							<Panel Background="{Binding BackgroundBrush}">
-								<Border BorderThickness="3" Height="80">
-									<TextBlock VerticalAlignment="Center" TextWrapping="Wrap" FontSize="11" Text="{Binding ProductRating}" />
-								</Border>
+							<Panel  Background="{Binding BackgroundBrush}" Opacity="{Binding Opacity}">
+								<TextBlock Text="{Binding ProductRating}" TextWrapping="NoWrap" FontSize="11" />
 							</Panel>
 						</DataTemplate>
 					</DataGridTemplateColumn.CellTemplate>
@@ -156,10 +153,8 @@
 				<controls:DataGridTemplateColumnExt Width="90" Header="Purchase&#xA;Date" CanUserSort="True" SortMemberPath="PurchaseDate" ClipboardContentBinding="{Binding PurchaseDate}">
 					<DataGridTemplateColumn.CellTemplate>
 						<DataTemplate>
-							<Panel Background="{Binding BackgroundBrush}">
-								<Border BorderThickness="3" Height="80">
-									<TextBlock VerticalAlignment="Center" TextWrapping="Wrap" Text="{Binding PurchaseDate}" />
-								</Border>
+							<Panel Background="{Binding BackgroundBrush}" Opacity="{Binding Opacity}">
+								<TextBlock Text="{Binding PurchaseDate}" />
 							</Panel>
 						</DataTemplate>
 					</DataGridTemplateColumn.CellTemplate>
@@ -168,10 +163,8 @@
 				<controls:DataGridTemplateColumnExt Width="120" Header="My Rating" CanUserSort="True" SortMemberPath="MyRating" ClipboardContentBinding="{Binding MyRating}">
 					<DataGridTemplateColumn.CellTemplate>
 						<DataTemplate>
-							<Panel Background="{Binding BackgroundBrush}">
-								<Border BorderThickness="3" Height="80">
-									<TextBlock VerticalAlignment="Center" TextWrapping="Wrap" FontSize="11" Text="{Binding MyRating}" />
-								</Border>
+							<Panel Background="{Binding BackgroundBrush}" Opacity="{Binding Opacity}">
+								<TextBlock Text="{Binding MyRating}" TextWrapping="NoWrap" FontSize="11" />
 							</Panel>
 						</DataTemplate>
 					</DataGridTemplateColumn.CellTemplate>
@@ -180,10 +173,8 @@
 				<controls:DataGridTemplateColumnExt Width="135" Header="Misc" CanUserSort="True" SortMemberPath="Misc" ClipboardContentBinding="{Binding Misc}">
 					<DataGridTemplateColumn.CellTemplate>
 						<DataTemplate>
-							<Panel Background="{Binding BackgroundBrush}">
-								<Border BorderThickness="3" Height="80">
-									<TextBlock VerticalAlignment="Center" TextWrapping="WrapWithOverflow" FontSize="10" Text="{Binding Misc}" />
-								</Border>
+							<Panel Background="{Binding BackgroundBrush}" Opacity="{Binding Opacity}">
+								<TextBlock Text="{Binding Misc}" TextWrapping="WrapWithOverflow" FontSize="10" />
 							</Panel>
 						</DataTemplate>
 					</DataGridTemplateColumn.CellTemplate>
@@ -192,14 +183,12 @@
 				<controls:DataGridTemplateColumnExt CanUserSort="True" Width="100" Header="Tags" SortMemberPath="BookTags" ClipboardContentBinding="{Binding BookTags.Tags}">
 					<DataGridTemplateColumn.CellTemplate>
 						<DataTemplate>
-							<StackPanel Orientation="Horizontal">
-								<Button IsVisible="{Binding !IsSeries}" Width="100" Height="80" Click="OnTagsButtonClick" ToolTip.Tip="Click to edit tags" >
-									<Panel>
-										<Image IsVisible="{Binding !BookTags.HasTags}" Stretch="None" Source="/Assets/edit_25x25.png" />
-										<TextBlock IsVisible="{Binding BookTags.HasTags}" FontSize="12" TextWrapping="WrapWithOverflow" Text="{Binding BookTags.Tags}"/>
-									</Panel>
-								</Button>
-							</StackPanel>
+							<Button IsVisible="{Binding !IsSeries}" Width="100" Height="80" Click="OnTagsButtonClick" ToolTip.Tip="Click to edit tags" >
+								<Panel>
+									<Image IsVisible="{Binding !BookTags.HasTags}" Stretch="None" Source="/Assets/edit_25x25.png" />
+									<TextBlock IsVisible="{Binding BookTags.HasTags}" FontSize="12" TextWrapping="WrapWithOverflow" Text="{Binding BookTags.Tags}"/>
+								</Panel>
+							</Button>
 						</DataTemplate>
 					</DataGridTemplateColumn.CellTemplate>
 				</controls:DataGridTemplateColumnExt>

--- a/Source/LibationAvalonia/Views/ProductsDisplay.axaml
+++ b/Source/LibationAvalonia/Views/ProductsDisplay.axaml
@@ -45,13 +45,6 @@
 						<DataTemplate>
 							<Button Padding="0" HorizontalAlignment="Stretch" VerticalAlignment="Stretch" Click="LiberateButton_Click" ToolTip.Tip="{Binding Liberate.ToolTip}">
 								<Image Stretch="None" Source="{Binding Liberate.Image}" />
-								<Button.ContextMenu>
-									<ContextMenu IsVisible="{Binding !Liberate.IsSeries}">
-										<MenuItem Header="Item 1" Click="ContextMenuItem1_Click" />
-										<MenuItem Header="Item 2" Click="ContextMenuItem2_Click" />
-										<MenuItem Header="Item 3" Click="ContextMenuItem3_Click" />
-									</ContextMenu>
-								</Button.ContextMenu>
 							</Button>
 						</DataTemplate>
 					</DataGridTemplateColumn.CellTemplate>

--- a/Source/LibationAvalonia/Views/ProductsDisplay.axaml
+++ b/Source/LibationAvalonia/Views/ProductsDisplay.axaml
@@ -16,7 +16,6 @@
 			AutoGenerateColumns="False"
 			Items="{Binding GridEntries}"
 			CanUserSortColumns="True"
-			SelectionMode="Single"
 			CanUserReorderColumns="True">
 
 			<DataGrid.Columns>

--- a/Source/LibationAvalonia/Views/ProductsDisplay.axaml.cs
+++ b/Source/LibationAvalonia/Views/ProductsDisplay.axaml.cs
@@ -73,7 +73,7 @@ namespace LibationAvalonia.Views
 
 		#region Cell Context Menu
 
-		public void ProductsGrid_CellContextMenuStripNeeded(object sender, DataGridViewCellContextMenuStripNeededEventArgs args)
+		public void ProductsGrid_CellContextMenuStripNeeded(object sender, DataGridCellContextMenuStripNeededEventArgs args)
 		{
 			if (args.Column.SortMemberPath == "Liberate")
 			{
@@ -277,9 +277,9 @@ namespace LibationAvalonia.Views
 
 		public void Description_Click(object sender, Avalonia.Input.TappedEventArgs args)
 		{
-			if (sender is TextBlock tblock && tblock.DataContext is GridEntry gEntry)
+			if (sender is Control tblock && tblock.DataContext is GridEntry gEntry)
 			{
-				var pt = tblock.Parent.PointToScreen(tblock.Parent.Bounds.TopRight);
+				var pt = tblock.PointToScreen(tblock.Bounds.TopRight);
 				var displayWindow = new DescriptionDisplayDialog
 				{
 					SpawnLocation = new Point(pt.X, pt.Y),

--- a/Source/LibationAvalonia/Views/ProductsDisplay.axaml.cs
+++ b/Source/LibationAvalonia/Views/ProductsDisplay.axaml.cs
@@ -10,7 +10,7 @@ using LibationAvalonia.Dialogs;
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using Avalonia.Interactivity;
+using LibationAvalonia.Controls;
 
 namespace LibationAvalonia.Views
 {
@@ -53,7 +53,7 @@ namespace LibationAvalonia.Views
 			{
 				column.CustomSortComparer = new RowComparer(column);
 			}
-		}
+		}		
 
 		private void RemoveColumn_PropertyChanged(object sender, AvaloniaPropertyChangedEventArgs e)
 		{
@@ -70,6 +70,29 @@ namespace LibationAvalonia.Views
 
 			productsGrid = this.FindControl<DataGrid>(nameof(productsGrid));
 		}
+
+		#region Cell Context Menu
+
+		public void ProductsGrid_CellContextMenuStripNeeded(object sender, DataGridViewCellContextMenuStripNeededEventArgs args)
+		{
+			if (args.Column.SortMemberPath == "Liberate")
+			{
+
+			}
+			else
+			{
+				// any non-stop light column
+				// (except for the Cover column which does not have a context menu)
+				var menuItem = new MenuItem { Header = "_Copy Cell Contents" };
+
+				menuItem.Click += async (s, e)
+					=> await Application.Current.Clipboard.SetTextAsync(args.CellClipboardContents);
+
+				args.ContextMenuItems.Add(menuItem);
+			}
+		}
+
+		#endregion
 
 		#region Column Customizations
 
@@ -96,6 +119,10 @@ namespace LibationAvalonia.Views
 
 			foreach (var column in productsGrid.Columns)
 			{
+				//Wire up column context menu
+				if (column is DataGridTemplateColumnExt tc)
+					tc.CellContextMenuStripNeeded += ProductsGrid_CellContextMenuStripNeeded;
+
 				var itemName = column.SortMemberPath;
 
 				if (itemName == nameof(GridEntry.Remove))
@@ -184,22 +211,6 @@ namespace LibationAvalonia.Views
 		#endregion
 
 		#region Button Click Handlers
-
-		public void ContextMenuItem1_Click(object sender, Avalonia.Interactivity.RoutedEventArgs args)
-		{
-			var lbe = getBoundEntry(args.Source);
-		}
-		public void ContextMenuItem2_Click(object sender, Avalonia.Interactivity.RoutedEventArgs args)
-		{
-			var lbe = getBoundEntry(args.Source);
-		}
-		public void ContextMenuItem3_Click(object sender, Avalonia.Interactivity.RoutedEventArgs args)
-		{
-			var lbe = getBoundEntry(args.Source);
-		}
-
-		private static LibraryBookEntry getBoundEntry(IInteractive source)
-			=> (source is IStyledElement se && se.DataContext is LibraryBookEntry lbe ? lbe : null);
 
 		public void LiberateButton_Click(object sender, Avalonia.Interactivity.RoutedEventArgs args)
 		{


### PR DESCRIPTION
I added grid cell dynamic context menus. Every time you right-click on a cell, `ProductsDisplay.ProductsGrid_CellContextMenuStripNeeded` will fire and you can create custom context menus. I added the "Copy Cell Value" menu item like you already did for winforms, and you can follow that pattern for adding other menu items.

I also implemented the "hidden" tag grey-out feature. I'd forgotten about that one until I saw you'd mentioned it elsewhere. While I was at it, I also cleaned up the ProductsDisplay xaml.

