### PR TITLE
Update workflows and AAXClean

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,12 @@ on:
         type: boolean
         description: 'Skip running unit tests'
         required: false
-        default: true
+        default: true        
+      build_deb:
+        type: boolean
+        description: 'Build Debian package'
+        required: false
+        default: false
 
 jobs:
   windows:
@@ -31,6 +36,7 @@ jobs:
 
   linux_deb:
     needs: [linux]
+    if: inputs.build_deb
     uses: ./.github/workflows/build-deb.yml
     with:
       version: ${{ needs.linux.outputs.version }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,6 +33,7 @@ jobs:
     with:
       version_override: ${{ needs.prerelease.outputs.version }}
       run_unit_tests: false
+      build_deb: true
       
   release:
     needs: [prerelease,build]
@@ -50,7 +51,7 @@ jobs:
           GITHUB_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
         with:
           tag_name: '${{ github.ref }}'
-          release_name: 'Libation ${{ steps.version.outputs.version }}'
+          release_name: 'Libation ${{ needs.prerelease.outputs.version }}'
           body: <Put a body here>
           draft: true
           prerelease: false

--- a/.github/workflows/scripts/targz2deb.sh
+++ b/.github/workflows/scripts/targz2deb.sh
@@ -105,6 +105,9 @@ ln -s /usr/lib/libation/Libation /usr/bin/libation
 ln -s /usr/lib/libation/Hangover /usr/bin/hangover
 ln -s /usr/lib/libation/LibationCli /usr/bin/libationcli
 
+# Increase the maximum number of inotify instances
+echo fs.inotify.max_user_instances=524288 | tee -a /etc/sysctl.conf && sysctl -p
+
 # workaround until this file is moved to the user's home directory
 touch /usr/lib/libation/appsettings.json
 chmod 666 /usr/lib/libation/appsettings.json

--- a/Source/AaxDecrypter/AaxDecrypter.csproj
+++ b/Source/AaxDecrypter/AaxDecrypter.csproj
@@ -13,7 +13,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-	  <PackageReference Include="AAXClean.Codecs" Version="0.3.1" />
+	  <PackageReference Include="AAXClean.Codecs" Version="0.5.0" />
 	</ItemGroup>
 
 	<ItemGroup>


### PR DESCRIPTION
I added a line to the deb build script that is probably necessary for a lot of users. Also, deb now only builds with the release workflow, not the verify workflow.

I also did a major update to AAXClean. The new version will properly throw exceptions to the caller without locking up. If something goes wrong, Libation will catch and log the exception instead of AAXClean just swallowing it and returning an unhelpful "Failed" status.