### PR TITLE
Fixed #453

### DIFF
--- a/Source/AaxDecrypter/AaxcDownloadMultiConverter.cs
+++ b/Source/AaxDecrypter/AaxcDownloadMultiConverter.cs
@@ -203,7 +203,8 @@ That naming may not be desirable for everyone, but it's an easy change to instea
 		private FileStream createOutputFileStream(MultiConvertFileProperties multiConvertFileProperties)
 		{
 			var fileName = DownloadOptions.GetMultipartFileName(multiConvertFileProperties);
-			fileName = FileUtility.GetValidFilename(fileName, DownloadOptions.ReplacementCharacters);
+			var extension = Path.GetExtension(fileName);
+			fileName = FileUtility.GetValidFilename(fileName, DownloadOptions.ReplacementCharacters, extension);
 
 			multiPartFilePaths.Add(fileName);
 

--- a/Source/AaxDecrypter/AudiobookDownloadBase.cs
+++ b/Source/AaxDecrypter/AudiobookDownloadBase.cs
@@ -93,7 +93,7 @@ namespace AaxDecrypter
 			try
 			{
 				var path = Path.ChangeExtension(OutputFileName, ".cue");
-				path = FileUtility.GetValidFilename(path, DownloadOptions.ReplacementCharacters);
+				path = FileUtility.GetValidFilename(path, DownloadOptions.ReplacementCharacters, ".cue");
 				File.WriteAllText(path, Cue.CreateContents(Path.GetFileName(OutputFileName), DownloadOptions.ChapterInfo));
 				OnFileCreated(path);
 			}

--- a/Source/FileManager/FileNamingTemplate.cs
+++ b/Source/FileManager/FileNamingTemplate.cs
@@ -13,7 +13,7 @@ namespace FileManager
 		public FileNamingTemplate(string template) : base(template) { }
 
 		/// <summary>Generate a valid path for this file or directory</summary>
-		public LongPath GetFilePath(ReplacementCharacters replacements, bool returnFirstExisting = false)
+		public LongPath GetFilePath(ReplacementCharacters replacements, string fileExtension, bool returnFirstExisting = false)
 		{
 			string fileName = 
 				Template.EndsWith(Path.DirectorySeparatorChar) || Template.EndsWith(Path.AltDirectorySeparatorChar) ?
@@ -44,7 +44,6 @@ namespace FileManager
 			var fileNamePart = pathParts[^1];
 			pathParts.Remove(fileNamePart);
 
-			var fileExtension = Path.GetExtension(fileNamePart);
 			fileNamePart = fileNamePart[..^fileExtension.Length];
 
 			LongPath directory = Path.Join(pathParts.Select(p => replaceFileName(p, paramReplacements, LongPath.MaxFilenameLength)).ToArray());
@@ -56,6 +55,7 @@ namespace FileManager
 			.GetValidFilename(
 				Path.Join(directory, replaceFileName(fileNamePart, paramReplacements, LongPath.MaxFilenameLength - fileExtension.Length - 5)) + fileExtension,
 				replacements,
+				fileExtension,
 				returnFirstExisting
 				);
 		}

--- a/Source/LibationAvalonia/Dialogs/EditTemplateDialog.axaml.cs
+++ b/Source/LibationAvalonia/Dialogs/EditTemplateDialog.axaml.cs
@@ -162,14 +162,17 @@ namespace LibationAvalonia.Dialogs
 					Title = chapterName
 				};
 
+				/*
+				* Path must be rooted for windows to allow long file paths. This is
+				* only necessary for folder templates because they may contain several
+				* subdirectories. Without rooting, we won't be allowed to create a
+				* relative path longer than MAX_PATH.
+				*/
+
 				var books = config.Books;
 				var folder = Templates.Folder.GetPortionFilename(
 					libraryBookDto,
-				//Path must be rooted for windows to allow long file paths. This is
-				//only necessary for folder templates because they may contain several
-				//subdirectories. Without rooting, we won't be allowed to create a
-				//relative path longer than MAX_PATH
-				Path.Combine(books, isFolder ? workingTemplateText : config.FolderTemplate));
+					Path.Combine(books, isFolder ? workingTemplateText : config.FolderTemplate), "");
 
 				folder = Path.GetRelativePath(books, folder);
 
@@ -182,7 +185,7 @@ namespace LibationAvalonia.Dialogs
 					"")
 				: Templates.File.GetPortionFilename(
 					libraryBookDto,
-					isFolder ? config.FileTemplate : workingTemplateText);
+					isFolder ? config.FileTemplate : workingTemplateText, "");
 				var ext = config.DecryptToLossy ? "mp3" : "m4b";
 
 				var chapterTitle = Templates.ChapterTitle.GetPortionTitle(libraryBookDto, workingTemplateText, partFileProperties);

--- a/Source/LibationWinForms/Dialogs/EditTemplateDialog.cs
+++ b/Source/LibationWinForms/Dialogs/EditTemplateDialog.cs
@@ -98,15 +98,16 @@ namespace LibationWinForms.Dialogs
 			};
 
 
-
+			/*
+			* Path must be rooted for windows to allow long file paths. This is
+			* only necessary for folder templates because they may contain several
+			* subdirectories. Without rooting, we won't be allowed to create a
+			* relative path longer than MAX_PATH.
+			*/
 			var books = config.Books;
 			var folder = Templates.Folder.GetPortionFilename(
-				libraryBookDto,
-				//Path must be rooted for windows to allow long file paths. This is
-				//only necessary for folder templates because they may contain several
-				//subdirectories. Without rooting, we won't be allowed to create a
-				//relative path longer than MAX_PATH
-				Path.Combine(books, isFolder ? workingTemplateText : config.FolderTemplate));
+				libraryBookDto,				
+				Path.Combine(books, isFolder ? workingTemplateText : config.FolderTemplate), "");
 
 			folder = Path.GetRelativePath(books, folder);
 
@@ -119,7 +120,7 @@ namespace LibationWinForms.Dialogs
 					"")
 				: Templates.File.GetPortionFilename(
 					libraryBookDto,
-					isFolder ? config.FileTemplate : workingTemplateText);
+					isFolder ? config.FileTemplate : workingTemplateText, "");
 			var ext = config.DecryptToLossy ? "mp3" : "m4b";
 
 			var chapterTitle = Templates.ChapterTitle.GetPortionTitle(libraryBookDto, workingTemplateText, partFileProperties);

--- a/Source/_Tests/FileManager.Tests/FileNamingTemplateTests.cs
+++ b/Source/_Tests/FileManager.Tests/FileNamingTemplateTests.cs
@@ -33,12 +33,13 @@ namespace FileNamingTemplateTests
 		{
 			var template = $"<title> [<id>]";
 
-			var fullfilename = Path.Combine(dirFullPath, template + FileUtility.GetStandardizedExtension(extension));
+			extension = FileUtility.GetStandardizedExtension(extension);
+			var fullfilename = Path.Combine(dirFullPath, template + extension);
 
 			var fileNamingTemplate = new FileNamingTemplate(fullfilename);
 			fileNamingTemplate.AddParameterReplacement("title", filename);
 			fileNamingTemplate.AddParameterReplacement("id", metadataSuffix);
-			return fileNamingTemplate.GetFilePath(Replacements).PathWithoutPrefix;
+			return fileNamingTemplate.GetFilePath(Replacements, extension).PathWithoutPrefix;
 		}
 
 		[TestMethod]
@@ -57,12 +58,13 @@ namespace FileNamingTemplateTests
 			// 100-999 => 001-999
 			var chapterCountLeadingZeros = partsPosition.ToString().PadLeft(partsTotal.ToString().Length, '0');
 
-			var t = Path.ChangeExtension(originalPath, null) + " - <chapter> - <title>" + Path.GetExtension(originalPath);
+			var estension = Path.GetExtension(originalPath);
+			var t = Path.ChangeExtension(originalPath, null) + " - <chapter> - <title>" + estension;
 
 			var fileNamingTemplate = new FileNamingTemplate(t);
 			fileNamingTemplate.AddParameterReplacement("chapter", chapterCountLeadingZeros);
 			fileNamingTemplate.AddParameterReplacement("title", suffix);
-			return fileNamingTemplate.GetFilePath(Replacements).PathWithoutPrefix;
+			return fileNamingTemplate.GetFilePath(Replacements, estension).PathWithoutPrefix;
 		}
 
 		[TestMethod]
@@ -74,7 +76,7 @@ namespace FileNamingTemplateTests
 			{
 				var fileNamingTemplate = new FileNamingTemplate(inStr);
 				fileNamingTemplate.AddParameterReplacement("title", @"s\l/a\s/h\e/s");
-				fileNamingTemplate.GetFilePath(Replacements).PathWithoutPrefix.Should().Be(outStr);
+				fileNamingTemplate.GetFilePath(Replacements, "txt").PathWithoutPrefix.Should().Be(outStr);
 			}
 		}
 	}

--- a/Source/_Tests/FileManager.Tests/FileUtilityTests.cs
+++ b/Source/_Tests/FileManager.Tests/FileUtilityTests.cs
@@ -197,30 +197,30 @@ namespace FileUtilityTests
 
 		[TestMethod]
 		// dot-files
-		[DataRow(@"C:\a bc\x y z\.f i l e.txt", PlatformID.Win32NT)]
-		[DataRow(@"/a bc/x y z/.f i l e.txt", PlatformID.Unix)]
+		[DataRow(@"C:\a bc\x y z\.f i l e.txt", "txt", PlatformID.Win32NT)]
+		[DataRow(@"/a bc/x y z/.f i l e.txt", "txt", PlatformID.Unix)]
 		// dot-folders
-		[DataRow(@"C:\a bc\.x y z\f i l e.txt", PlatformID.Win32NT)]
-		[DataRow(@"/a bc/.x y z/f i l e.txt", PlatformID.Unix)]
-		public void Valid(string input, PlatformID platformID) => Tests(input, input, platformID);
+		[DataRow(@"C:\a bc\.x y z\f i l e.txt", "txt", PlatformID.Win32NT)]
+		[DataRow(@"/a bc/.x y z/f i l e.txt", "txt", PlatformID.Unix)]
+		public void Valid(string input, string extension, PlatformID platformID) => Tests(input, extension, input, platformID);
 
 		[TestMethod]
 		// folder spaces
-		[DataRow(@"C:\   a bc   \x y z   ", @"C:\a bc\x y z", PlatformID.Win32NT)]
-		[DataRow(@"/   a bc   /x y z   ", @"/a bc/x y z", PlatformID.Unix)]
+		[DataRow(@"C:\   a bc   \x y z   ","", @"C:\a bc\x y z", PlatformID.Win32NT)]
+		[DataRow(@"/   a bc   /x y z   ", "", @"/a bc/x y z", PlatformID.Unix)]
 		// file spaces
-		[DataRow(@"C:\a bc\x y z\   f i l e.txt   ", @"C:\a bc\x y z\f i l e.txt", PlatformID.Win32NT)]
-		[DataRow(@"/a bc/x y z/   f i l e.txt   ", @"/a bc/x y z/f i l e.txt", PlatformID.Unix)]
+		[DataRow(@"C:\a bc\x y z\   f i l e.txt   ", "txt", @"C:\a bc\x y z\f i l e.txt", PlatformID.Win32NT)]
+		[DataRow(@"/a bc/x y z/   f i l e.txt   ", "txt", @"/a bc/x y z/f i l e.txt", PlatformID.Unix)]
 		// eliminate beginning space and end dots and spaces
-		[DataRow(@"C:\a bc\   . . . x y z . . .   \f i l e.txt", @"C:\a bc\. . . x y z\f i l e.txt", PlatformID.Win32NT)]
-		[DataRow(@"/a bc/   . . . x y z . . .   /f i l e.txt", @"/a bc/. . . x y z/f i l e.txt", PlatformID.Unix)]
+		[DataRow(@"C:\a bc\   . . . x y z . . .   \f i l e.txt", "txt", @"C:\a bc\. . . x y z\f i l e.txt", PlatformID.Win32NT)]
+		[DataRow(@"/a bc/   . . . x y z . . .   /f i l e.txt", "txt", @"/a bc/. . . x y z/f i l e.txt", PlatformID.Unix)]
 		// file end dots
-		[DataRow(@"C:\a bc\x y z\f i l e.txt . . .", @"C:\a bc\x y z\f i l e.txt", PlatformID.Win32NT)]
-		[DataRow(@"/a bc/x y z/f i l e.txt . . .", @"/a bc/x y z/f i l e.txt", PlatformID.Unix)]
-		public void Tests(string input, string expected, PlatformID platformID)
+		[DataRow(@"C:\a bc\x y z\f i l e.txt . . .", "txt", @"C:\a bc\x y z\f i l e.txt", PlatformID.Win32NT)]
+		[DataRow(@"/a bc/x y z/f i l e.txt . . .", "txt", @"/a bc/x y z/f i l e.txt", PlatformID.Unix)]
+		public void Tests(string input, string extension, string expected, PlatformID platformID)
 		{
 			if (Environment.OSVersion.Platform == platformID)
-				FileUtility.GetValidFilename(input, Replacements).PathWithoutPrefix.Should().Be(expected);
+				FileUtility.GetValidFilename(input, Replacements, extension).PathWithoutPrefix.Should().Be(expected);
 		}
 	}
 

--- a/Source/_Tests/LibationFileManager.Tests/TemplatesTests.cs
+++ b/Source/_Tests/LibationFileManager.Tests/TemplatesTests.cs
@@ -81,23 +81,25 @@ namespace TemplatesTests
 			=> Templates.getFileNamingTemplate(GetLibraryBook(), template, dirFullPath, extension);
 
 		[TestMethod]
-		[DataRow("f.txt", @"C:\foo\bar", null, @"C:\foo\bar\f.txt", PlatformID.Win32NT)]
-		[DataRow("f.txt", @"/foo/bar", null, @"/foo/bar/f.txt", PlatformID.Unix)]
-		[DataRow("f.txt", @"C:\foo\bar", "ext", @"C:\foo\bar\f.txt.ext", PlatformID.Win32NT)]
-		[DataRow("f.txt", @"/foo/bar", "ext", @"/foo/bar/f.txt.ext", PlatformID.Unix)]
-		[DataRow("f", @"C:\foo\bar", "ext", @"C:\foo\bar\f.ext", PlatformID.Win32NT)]
-		[DataRow("f", @"/foo/bar", "ext", @"/foo/bar/f.ext", PlatformID.Unix)]
-		[DataRow("<id>", @"C:\foo\bar", "ext", @"C:\foo\bar\asin.ext", PlatformID.Win32NT)]
-		[DataRow("<id>", @"/foo/bar", "ext", @"/foo/bar/asin.ext", PlatformID.Unix)]
-        [DataRow("<bitrate> - <samplerate> - <channels>", @"C:\foo\bar", "ext", @"C:\foo\bar\128 - 44100 - 2.ext", PlatformID.Win32NT)]
-        [DataRow("<bitrate> - <samplerate> - <channels>", @"/foo/bar", "ext", @"/foo/bar/128 - 44100 - 2.ext", PlatformID.Unix)]
-        [DataRow("<year> - <channels>", @"C:\foo\bar", "ext", @"C:\foo\bar\2017 - 2.ext", PlatformID.Win32NT)]
-        [DataRow("<year> - <channels>", @"/foo/bar", "ext", @"/foo/bar/2017 - 2.ext", PlatformID.Unix)]
-        public void Tests(string template, string dirFullPath, string extension, string expected, PlatformID platformID)
+		[DataRow("f.txt", @"C:\foo\bar", "", @"C:\foo\bar\f.txt", PlatformID.Win32NT)]
+		[DataRow("f.txt", @"/foo/bar", "", @"/foo/bar/f.txt", PlatformID.Unix)]
+		[DataRow("f.txt", @"C:\foo\bar", ".ext", @"C:\foo\bar\f.txt.ext", PlatformID.Win32NT)]
+		[DataRow("f.txt", @"/foo/bar", ".ext", @"/foo/bar/f.txt.ext", PlatformID.Unix)]
+		[DataRow("f", @"C:\foo\bar", ".ext", @"C:\foo\bar\f.ext", PlatformID.Win32NT)]
+		[DataRow("f", @"/foo/bar", ".ext", @"/foo/bar/f.ext", PlatformID.Unix)]
+		[DataRow("<id>", @"C:\foo\bar", ".ext", @"C:\foo\bar\asin.ext", PlatformID.Win32NT)]
+		[DataRow("<id>", @"/foo/bar", ".ext", @"/foo/bar/asin.ext", PlatformID.Unix)]
+        [DataRow("<bitrate> - <samplerate> - <channels>", @"C:\foo\bar", ".ext", @"C:\foo\bar\128 - 44100 - 2.ext", PlatformID.Win32NT)]
+        [DataRow("<bitrate> - <samplerate> - <channels>", @"/foo/bar", ".ext", @"/foo/bar/128 - 44100 - 2.ext", PlatformID.Unix)]
+        [DataRow("<year> - <channels>", @"C:\foo\bar", ".ext", @"C:\foo\bar\2017 - 2.ext", PlatformID.Win32NT)]
+        [DataRow("<year> - <channels>", @"/foo/bar", ".ext", @"/foo/bar/2017 - 2.ext", PlatformID.Unix)]
+		[DataRow("(000.0) <year> - <channels>", @"C:\foo\bar", "ext", @"C:\foo\bar\(000.0) 2017 - 2.ext", PlatformID.Win32NT)]
+		[DataRow("(000.0) <year> - <channels>", @"/foo/bar", ".ext", @"/foo/bar/(000.0) 2017 - 2.ext", PlatformID.Unix)]
+		public void Tests(string template, string dirFullPath, string extension, string expected, PlatformID platformID)
 		{
 			if (Environment.OSVersion.Platform == platformID)
 				Templates.getFileNamingTemplate(GetLibraryBook(), template, dirFullPath, extension)
-				.GetFilePath(Replacements)
+				.GetFilePath(Replacements, extension)
 				.PathWithoutPrefix
 				.Should().Be(expected);
 		}
@@ -109,7 +111,7 @@ namespace TemplatesTests
 		{
 			if (Environment.OSVersion.Platform == platformID)
 				Templates.getFileNamingTemplate(GetLibraryBook(), "foo<if series-><-if series>bar", directory, "ext")
-				.GetFilePath(Replacements)
+				.GetFilePath(Replacements, ".ext")
 				.PathWithoutPrefix
 				.Should().Be(expected);
 		}
@@ -121,7 +123,7 @@ namespace TemplatesTests
 		{
 			if (Environment.OSVersion.Platform == platformID)
 				Templates.getFileNamingTemplate(GetLibraryBook(null), "foo<if series->-<series>-<id>-<-if series>bar", directory, "ext")
-				.GetFilePath(Replacements)
+				.GetFilePath(Replacements, ".ext")
 				.PathWithoutPrefix
 				.Should().Be(expected);
 		}
@@ -133,7 +135,7 @@ namespace TemplatesTests
 		{
 			if (Environment.OSVersion.Platform == platformID)
 				Templates.getFileNamingTemplate(GetLibraryBook(), "foo<if series->-<series>-<id>-<-if series>bar", directory, "ext")
-				.GetFilePath(Replacements)
+				.GetFilePath(Replacements, ".ext")
 				.PathWithoutPrefix
 				.Should().Be(expected);
 		}


### PR DESCRIPTION
Recently I added a check to FileNamingTemplate.GetFilePath() to try to preserve the file extension from being obliterated by replaceFileName(). If GetPortionFilename() was called on a template that contains a period, GetFilePath() assumed everything that came after the dot was a file extension and would preserve it from the templating procedure.

My fix is to require callers to specify the file extension being used. Also, refrain from using Path.GetFileNameWithoutExtension() unless you know that the filename 1) is a file not a directory, and 2) knows the filename already has an extension. GetFileNameWithoutExtension is just too dumb.
 