### PR TITLE
Upgrade AAXClean.Codecs to 0.5.12, add moov relocation, and fix #459

### DIFF
--- a/Source/AaxDecrypter/AaxDecrypter.csproj
+++ b/Source/AaxDecrypter/AaxDecrypter.csproj
@@ -13,7 +13,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-	  <PackageReference Include="AAXClean.Codecs" Version="0.5.10" />
+	  <PackageReference Include="AAXClean.Codecs" Version="0.5.11" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/Source/AaxDecrypter/AaxDecrypter.csproj
+++ b/Source/AaxDecrypter/AaxDecrypter.csproj
@@ -13,7 +13,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-	  <PackageReference Include="AAXClean.Codecs" Version="0.5.11" />
+	  <PackageReference Include="AAXClean.Codecs" Version="0.5.12" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/Source/AaxDecrypter/AaxDecrypter.csproj
+++ b/Source/AaxDecrypter/AaxDecrypter.csproj
@@ -13,7 +13,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-	  <PackageReference Include="AAXClean.Codecs" Version="0.5.0" />
+	  <PackageReference Include="AAXClean.Codecs" Version="0.5.10" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/Source/AaxDecrypter/AaxcDownloadConvertBase.cs
+++ b/Source/AaxDecrypter/AaxcDownloadConvertBase.cs
@@ -10,6 +10,7 @@ namespace AaxDecrypter
 		public event EventHandler<AppleTags> RetrievedMetadata;
 
 		protected AaxFile AaxFile;
+		protected Mp4Operation aaxConversion;
 
 		protected AaxcDownloadConvertBase(string outFileName, string cacheDirectory, IDownloadOptions dlOptions)
 			: base(outFileName, cacheDirectory, dlOptions) { }
@@ -101,9 +102,9 @@ namespace AaxDecrypter
 		public override async Task CancelAsync()
 		{
 			IsCanceled = true;
-			if (AaxFile != null)
-				await AaxFile.CancelAsync();
-			AaxFile?.Dispose();
+				if (aaxConversion != null)
+					await aaxConversion.CancelAsync();
+			AaxFile?.Close();
 			CloseInputFileStream();
 		}
 	}

--- a/Source/AaxDecrypter/AaxcDownloadMultiConverter.cs
+++ b/Source/AaxDecrypter/AaxcDownloadMultiConverter.cs
@@ -140,6 +140,10 @@ That naming may not be desirable for everyone, but it's an easy change to instea
 
 				aaxConversion.ConversionProgressUpdate += AaxFile_ConversionProgressUpdate;
 				await aaxConversion;
+
+				if (aaxConversion.IsCompletedSuccessfully)
+					moveMoovToBeginning(workingFileStream?.Name);
+
 				return aaxConversion.IsCompletedSuccessfully;
 			}
 			catch(Exception ex)
@@ -195,10 +199,24 @@ That naming may not be desirable for everyone, but it's an easy change to instea
 				PartsTotal = splitChapters.Count,
 				Title = newSplitCallback?.Chapter?.Title,
 			};
+
+			moveMoovToBeginning(workingFileStream?.Name);
+
 			newSplitCallback.OutputFile = createOutputFileStream(props);
 			newSplitCallback.TrackTitle = DownloadOptions.GetMultipartTitleName(props);
 			newSplitCallback.TrackNumber = currentChapter;
 			newSplitCallback.TrackCount = splitChapters.Count;
+		}
+
+		private void moveMoovToBeginning(string filename)
+		{
+			if (DownloadOptions.OutputFormat is OutputFormat.M4b
+				&& DownloadOptions.MoveMoovToBeginning
+				&& filename is not null
+				&& File.Exists(filename))
+			{
+				Mp4File.RelocateMoovAsync(filename).GetAwaiter().GetResult();
+			}
 		}
 
 		private FileStream createOutputFileStream(MultiConvertFileProperties multiConvertFileProperties)

--- a/Source/AaxDecrypter/AaxcDownloadMultiConverter.cs
+++ b/Source/AaxDecrypter/AaxcDownloadMultiConverter.cs
@@ -133,32 +133,33 @@ That naming may not be desirable for everyone, but it's an easy change to instea
 
 			try
 			{
-				ConversionResult result;
-
-				AaxFile.ConversionProgressUpdate += AaxFile_ConversionProgressUpdate;
 				if (DownloadOptions.OutputFormat == OutputFormat.M4b)
-					result = await ConvertToMultiMp4a(splitChapters);
+					aaxConversion = ConvertToMultiMp4a(splitChapters);
 				else
-					result = await ConvertToMultiMp3(splitChapters);
+					aaxConversion = ConvertToMultiMp3(splitChapters);
 
-				return result == ConversionResult.NoErrorsDetected;
+				aaxConversion.ConversionProgressUpdate += AaxFile_ConversionProgressUpdate;
+				await aaxConversion;
+				return aaxConversion.IsCompletedSuccessfully;
 			}
 			catch(Exception ex)
 			{
 				Serilog.Log.Error(ex, "AAXClean Error");
 				workingFileStream?.Close();
-				FileUtility.SaferDelete(workingFileStream.Name);
+				if (workingFileStream?.Name is not null)
+					FileUtility.SaferDelete(workingFileStream.Name);
 				return false;
 			}
 			finally
 			{
-				AaxFile.ConversionProgressUpdate -= AaxFile_ConversionProgressUpdate;
+				if (aaxConversion is not null)
+					aaxConversion.ConversionProgressUpdate -= AaxFile_ConversionProgressUpdate;
 
 				Step_DownloadAudiobook_End(zeroProgress);
 			}
 		}
 
-		private Task<ConversionResult> ConvertToMultiMp4a(ChapterInfo splitChapters)
+		private Mp4Operation ConvertToMultiMp4a(ChapterInfo splitChapters)
 		{
 			var chapterCount = 0;
 			return AaxFile.ConvertToMultiMp4aAsync
@@ -169,7 +170,7 @@ That naming may not be desirable for everyone, but it's an easy change to instea
 				);
 		}
 
-		private Task<ConversionResult> ConvertToMultiMp3(ChapterInfo splitChapters)
+		private Mp4Operation ConvertToMultiMp3(ChapterInfo splitChapters)
 		{
 			var chapterCount = 0;
 			return AaxFile.ConvertToMultiMp3Async

--- a/Source/AaxDecrypter/AaxcDownloadSingleConverter.cs
+++ b/Source/AaxDecrypter/AaxcDownloadSingleConverter.cs
@@ -98,11 +98,20 @@ namespace AaxDecrypter
 				aaxConversion.ConversionProgressUpdate += AaxFile_ConversionProgressUpdate;
 				await aaxConversion;
 
-				if (aaxConversion.IsCompletedSuccessfully)
+				outputFile.Close();
+
+				if (aaxConversion.IsCompletedSuccessfully
+					&& DownloadOptions.OutputFormat is OutputFormat.M4b
+					&& DownloadOptions.MoveMoovToBeginning)
 				{
-					outputFile.Close();
-					base.OnFileCreated(OutputFileName);
+					aaxConversion.ConversionProgressUpdate += AaxFile_ConversionProgressUpdate;
+					aaxConversion = Mp4File.RelocateMoovAsync(OutputFileName);
+					aaxConversion.ConversionProgressUpdate += AaxFile_ConversionProgressUpdate;
+					await aaxConversion;
 				}
+
+				if (aaxConversion.IsCompletedSuccessfully)
+					base.OnFileCreated(OutputFileName);
 
 				return aaxConversion.IsCompletedSuccessfully;
 			}
@@ -117,7 +126,7 @@ namespace AaxDecrypter
 				outputFile.Close();
 
 				if (aaxConversion is not null)
-					aaxConversion.ConversionProgressUpdate += AaxFile_ConversionProgressUpdate;
+					aaxConversion.ConversionProgressUpdate -= AaxFile_ConversionProgressUpdate;
 
 				Step_DownloadAudiobook_End(zeroProgress);
 			}

--- a/Source/AaxDecrypter/AaxcDownloadSingleConverter.cs
+++ b/Source/AaxDecrypter/AaxcDownloadSingleConverter.cs
@@ -104,7 +104,7 @@ namespace AaxDecrypter
 					&& DownloadOptions.OutputFormat is OutputFormat.M4b
 					&& DownloadOptions.MoveMoovToBeginning)
 				{
-					aaxConversion.ConversionProgressUpdate += AaxFile_ConversionProgressUpdate;
+					aaxConversion.ConversionProgressUpdate -= AaxFile_ConversionProgressUpdate;
 					aaxConversion = Mp4File.RelocateMoovAsync(OutputFileName);
 					aaxConversion.ConversionProgressUpdate += AaxFile_ConversionProgressUpdate;
 					await aaxConversion;

--- a/Source/AaxDecrypter/IDownloadOptions.cs
+++ b/Source/AaxDecrypter/IDownloadOptions.cs
@@ -24,6 +24,7 @@ namespace AaxDecrypter
         NAudio.Lame.LameConfig LameConfig { get; }
         bool Downsample { get; }
         bool MatchSourceBitrate { get; }
+        bool MoveMoovToBeginning { get; }
         string GetMultipartFileName(MultiConvertFileProperties props);
         string GetMultipartTitleName(MultiConvertFileProperties props);
         Task<string> SaveClipsAndBookmarks(string fileName);

--- a/Source/FileLiberator/DownloadDecryptBook.cs
+++ b/Source/FileLiberator/DownloadDecryptBook.cs
@@ -160,6 +160,7 @@ namespace FileLiberator
                 AudibleKey = contentLic?.Voucher?.Key,
                 AudibleIV = contentLic?.Voucher?.Iv,
                 OutputFormat = outputFormat,
+                MoveMoovToBeginning = config.MoveMoovToBeginning,
                 TrimOutputToChapterLength = config.AllowLibationFixup && config.StripAudibleBrandAudio,
                 RetainEncryptedFile = config.RetainAaxFile && encrypted,
                 StripUnabridged = config.AllowLibationFixup && config.StripUnabridged,

--- a/Source/FileLiberator/DownloadOptions.cs
+++ b/Source/FileLiberator/DownloadOptions.cs
@@ -34,6 +34,8 @@ namespace FileLiberator
 		public bool MatchSourceBitrate { get; init; }
 		public ReplacementCharacters ReplacementCharacters => Configuration.Instance.ReplacementCharacters;
 
+		public bool MoveMoovToBeginning { get; init; }
+
 		public string GetMultipartFileName(MultiConvertFileProperties props)
 			=> Templates.ChapterFile.GetFilename(LibraryBookDto, props);
 

--- a/Source/FileManager/FileUtility.cs
+++ b/Source/FileManager/FileUtility.cs
@@ -151,9 +151,9 @@ namespace FileManager
 		/// <br/>- Perform <see cref="SaferMove"/>
 		/// <br/>- Return valid path
 		/// </summary>
-		public static string SaferMoveToValidPath(LongPath source, LongPath destination, ReplacementCharacters replacements)
+		public static string SaferMoveToValidPath(LongPath source, LongPath destination, ReplacementCharacters replacements, string extension = null)
 		{
-			var extension = Path.GetExtension(source);
+			extension = extension ?? Path.GetExtension(source);
 			destination = GetValidFilename(destination, replacements, extension);
 			SaferMove(source, destination);
 			return destination;

--- a/Source/Libation.sln
+++ b/Source/Libation.sln
@@ -93,14 +93,6 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MacOSConfigApp", "LoadByOS\
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "WindowsConfigApp", "LoadByOS\WindowsConfigApp\WindowsConfigApp.csproj", "{5F65A509-26E3-4B02-B403-EEB6F0EF391F}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "AAXClean.Codecs", "..\..\AaxClean\AaxTest\AAXClean.Codecs\src\AAXClean.Codecs\AAXClean.Codecs.csproj", "{EE7189CE-D9BB-4CE9-AC82-2688E1F5A838}"
-EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "AAXClean", "..\..\AaxClean\AaxTest\AAXClean\src\AAXClean\AAXClean.csproj", "{3252C885-DED3-4119-8C69-7DADD3EC22E9}"
-EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Mpeg4Lib", "..\..\AaxClean\AaxTest\AAXClean\src\Mpeg4Lib\Mpeg4Lib.csproj", "{9E9F33F4-1F03-43D9-BA88-B3BFC98D6AEF}"
-EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "NAudio.Lame_SA", "..\..\AaxClean\AaxTest\NAudio.Lame_SA\NAudio.Lame_SA\NAudio.Lame_SA.csproj", "{EF8F35AD-581C-434A-A2FB-E82F428C4DD8}"
-EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -215,22 +207,6 @@ Global
 		{5F65A509-26E3-4B02-B403-EEB6F0EF391F}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{5F65A509-26E3-4B02-B403-EEB6F0EF391F}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{5F65A509-26E3-4B02-B403-EEB6F0EF391F}.Release|Any CPU.Build.0 = Release|Any CPU
-		{EE7189CE-D9BB-4CE9-AC82-2688E1F5A838}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{EE7189CE-D9BB-4CE9-AC82-2688E1F5A838}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{EE7189CE-D9BB-4CE9-AC82-2688E1F5A838}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{EE7189CE-D9BB-4CE9-AC82-2688E1F5A838}.Release|Any CPU.Build.0 = Release|Any CPU
-		{3252C885-DED3-4119-8C69-7DADD3EC22E9}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{3252C885-DED3-4119-8C69-7DADD3EC22E9}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{3252C885-DED3-4119-8C69-7DADD3EC22E9}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{3252C885-DED3-4119-8C69-7DADD3EC22E9}.Release|Any CPU.Build.0 = Release|Any CPU
-		{9E9F33F4-1F03-43D9-BA88-B3BFC98D6AEF}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{9E9F33F4-1F03-43D9-BA88-B3BFC98D6AEF}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{9E9F33F4-1F03-43D9-BA88-B3BFC98D6AEF}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{9E9F33F4-1F03-43D9-BA88-B3BFC98D6AEF}.Release|Any CPU.Build.0 = Release|Any CPU
-		{EF8F35AD-581C-434A-A2FB-E82F428C4DD8}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{EF8F35AD-581C-434A-A2FB-E82F428C4DD8}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{EF8F35AD-581C-434A-A2FB-E82F428C4DD8}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{EF8F35AD-581C-434A-A2FB-E82F428C4DD8}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/Source/LibationAvalonia/Dialogs/SettingsDialog.axaml
+++ b/Source/LibationAvalonia/Dialogs/SettingsDialog.axaml
@@ -2,8 +2,8 @@
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-        mc:Ignorable="d" d:DesignWidth="850" d:DesignHeight="620"
-		MinWidth="800" MinHeight="620"
+        mc:Ignorable="d" d:DesignWidth="900" d:DesignHeight="680"
+		MinWidth="900" MinHeight="680"
         x:Class="LibationAvalonia.Dialogs.SettingsDialog"
         xmlns:controls="clr-namespace:LibationAvalonia.Controls"
         Title="Edit Settings"
@@ -34,6 +34,378 @@
 					<Setter Property="MinHeight" Value="5"/>
 				</Style>
 			</TabControl.Styles>
+			<TabItem>
+
+				<TabItem.Header>
+
+					<TextBlock
+						FontSize="14"
+						VerticalAlignment="Center"
+						Text="Audio File Settings"/>
+
+				</TabItem.Header>
+
+				<Border
+					Grid.Column="0"
+					Grid.Row="0"
+					BorderThickness="2"
+					BorderBrush="{DynamicResource DataGridGridLinesBrush}">
+
+					<Grid
+						RowDefinitions="*,Auto"
+						ColumnDefinitions="*,*">
+
+						<StackPanel
+							Margin="5"
+							Grid.Row="0"
+							Grid.Column="0">
+
+							<CheckBox
+								Margin="0,0,0,5"
+								IsChecked="{Binding AudioSettings.CreateCueSheet, Mode=TwoWay}">
+
+								<TextBlock
+									TextWrapping="Wrap"
+									Text="{Binding AudioSettings.CreateCueSheetText}" />
+
+							</CheckBox>
+
+							<CheckBox
+								Margin="0,0,0,5"
+								IsChecked="{Binding AudioSettings.DownloadCoverArt, Mode=TwoWay}">
+
+								<TextBlock
+									TextWrapping="Wrap"
+									Text="{Binding AudioSettings.DownloadCoverArtText}" />
+
+							</CheckBox>
+
+							<StackPanel Orientation="Horizontal">
+								
+								<CheckBox
+									Margin="0,0,0,5"
+									IsChecked="{Binding AudioSettings.DownloadClipsBookmarks, Mode=TwoWay}">
+
+									<TextBlock
+										TextWrapping="Wrap"
+										Text="Download Clips, Notes and Bookmarks as" />
+
+								</CheckBox>
+								
+								<controls:WheelComboBox
+									Margin="5,0,0,0"
+									IsEnabled="{Binding AudioSettings.DownloadClipsBookmarks}"
+									Items="{Binding AudioSettings.ClipBookmarkFormats}"
+									SelectedItem="{Binding AudioSettings.ClipBookmarkFormat}"/>
+							
+							</StackPanel>
+
+							<CheckBox
+								Margin="0,0,0,5"
+								IsChecked="{Binding AudioSettings.RetainAaxFile, Mode=TwoWay}">
+
+								<TextBlock
+									TextWrapping="Wrap"
+									Text="{Binding AudioSettings.RetainAaxFileText}" />
+
+							</CheckBox>
+
+							<CheckBox
+								Margin="0,0,0,5"
+								IsChecked="{Binding AudioSettings.MergeOpeningAndEndCredits, Mode=TwoWay}">
+
+								<TextBlock
+									TextWrapping="Wrap"
+									Text="{Binding AudioSettings.MergeOpeningEndCreditsText}" />
+
+							</CheckBox>
+
+							<CheckBox
+								Margin="0,0,0,5"
+								IsChecked="{Binding AudioSettings.AllowLibationFixup, Mode=TwoWay}">
+
+								<TextBlock
+									TextWrapping="Wrap"
+									Text="{Binding AudioSettings.AllowLibationFixupText}" />
+							</CheckBox>
+
+							<controls:GroupBox
+								BorderWidth="1"
+								Label="Audiobook Fix-ups"
+								IsEnabled="{Binding AudioSettings.AllowLibationFixup}">
+
+								<StackPanel Orientation="Vertical">
+
+									<CheckBox
+										Margin="0,0,0,5"
+										IsChecked="{Binding AudioSettings.SplitFilesByChapter, Mode=TwoWay}">
+
+										<TextBlock
+											TextWrapping="Wrap"
+											Text="{Binding AudioSettings.SplitFilesByChapterText}" />
+
+									</CheckBox>
+
+									<CheckBox
+										Margin="0,0,0,5"
+										IsChecked="{Binding AudioSettings.StripAudibleBrandAudio, Mode=TwoWay}">
+
+										<TextBlock
+											TextWrapping="Wrap"
+											Text="{Binding AudioSettings.StripAudibleBrandingText}" />
+
+									</CheckBox>
+
+									<CheckBox
+										Margin="0,0,0,5"
+										IsChecked="{Binding AudioSettings.StripUnabridged, Mode=TwoWay}">
+
+										<TextBlock
+											TextWrapping="Wrap"
+											Text="{Binding AudioSettings.StripUnabridgedText}" />
+
+									</CheckBox>
+
+									<RadioButton
+										Margin="0,5,0,5"
+										IsChecked="{Binding !AudioSettings.DecryptToLossy, Mode=TwoWay}">
+
+										<StackPanel >
+											
+											<TextBlock
+											TextWrapping="Wrap"
+											Text="Download my books in the original audio format (Lossless)" />
+											<CheckBox
+												Margin="0,0,0,5"
+												IsEnabled="{Binding !AudioSettings.DecryptToLossy}"
+												IsChecked="{Binding AudioSettings.MoveMoovToBeginning, Mode=TwoWay}">
+
+												<TextBlock
+													TextWrapping="Wrap"
+													Text="{Binding AudioSettings.MoveMoovToBeginningText}" />
+
+											</CheckBox>
+											
+										</StackPanel>
+									</RadioButton>
+
+									<RadioButton
+										Margin="0,5,0,5"
+										IsChecked="{Binding AudioSettings.DecryptToLossy, Mode=TwoWay}">
+
+										<TextBlock
+											TextWrapping="Wrap"
+											Text="Download my books as .MP3 files (transcode if necessary)" />
+
+									</RadioButton>
+								</StackPanel>
+							</controls:GroupBox>
+						</StackPanel>
+
+						<StackPanel
+							Grid.Row="0"
+							Grid.Column="1">
+
+							<controls:GroupBox
+								BorderWidth="1"
+								Label="Mp3 Encoding Options">
+
+								<StackPanel Orientation="Vertical">
+
+									<Grid
+										Margin="5,5,5,0"
+										ColumnDefinitions="Auto,*">
+
+										<controls:GroupBox
+											BorderWidth="1"
+											Grid.Column="0"
+											Label="Target">
+
+											<StackPanel Orientation="Horizontal">
+
+												<RadioButton
+													Margin="10"
+													Content="Bitrate"
+													IsChecked="{Binding AudioSettings.LameTargetBitrate, Mode=TwoWay}"/>
+
+												<RadioButton
+													Margin="10"
+													Content="Quality"
+													IsChecked="{Binding !AudioSettings.LameTargetBitrate, Mode=TwoWay}"/>
+
+											</StackPanel>
+										</controls:GroupBox>
+
+										<CheckBox
+											HorizontalAlignment="Right"
+											Grid.Column="1"
+											IsChecked="{Binding AudioSettings.LameDownsampleMono, Mode=TwoWay}">
+
+											<TextBlock
+												TextWrapping="Wrap"
+												Text="Downsample to mono? (Recommended)" />
+
+										</CheckBox>
+									</Grid>
+
+									<controls:GroupBox
+										Margin="5,5,5,0"
+										BorderWidth="1"
+										Label="Bitrate"
+										IsEnabled="{Binding AudioSettings.LameTargetBitrate}" >
+
+										<StackPanel>
+
+											<Grid ColumnDefinitions="*,25,Auto">
+
+												<Slider
+													Grid.Column="0"
+													IsEnabled="{Binding !AudioSettings.LameMatchSource}"
+													Value="{Binding AudioSettings.LameBitrate, Mode=TwoWay}"
+													Minimum="16"
+													Maximum="320"
+													IsSnapToTickEnabled="True" TickFrequency="16"
+													Ticks="16,32,48,64,80,96,112,128,144,160,176,192,208,224,240,256,272,288,304,320"
+													TickPlacement="Outside">
+
+													<Slider.Styles>
+														<Style Selector="Slider /template/ Thumb">
+															<Setter Property="ToolTip.Tip" Value="{Binding $parent[Slider].Value, Mode=OneWay, StringFormat='\{0:f0\} Kbps'}" />
+															<Setter Property="ToolTip.Placement" Value="Top" />
+															<Setter Property="ToolTip.VerticalOffset" Value="-10" />
+															<Setter Property="ToolTip.HorizontalOffset" Value="-30" />
+														</Style>
+													</Slider.Styles>
+												</Slider>
+
+												<TextBlock
+													Grid.Column="1"
+													HorizontalAlignment="Right"
+													Text="{Binding AudioSettings.LameBitrate}" />
+
+												<TextBlock
+													Grid.Column="2"
+													Text=" Kbps" />
+
+											</Grid>
+
+											<Grid ColumnDefinitions="*,*">
+
+												<CheckBox
+													Grid.Column="0"
+													IsChecked="{Binding AudioSettings.LameConstantBitrate, Mode=TwoWay}">
+
+													<TextBlock
+														TextWrapping="Wrap"
+														Text="Restrict Encoder to Constant Bitrate?" />
+
+												</CheckBox>
+
+												<CheckBox
+													Grid.Column="1"
+													HorizontalAlignment="Right"
+													IsChecked="{Binding AudioSettings.LameMatchSource, Mode=TwoWay}">
+
+													<TextBlock
+														TextWrapping="Wrap"
+														Text="Match Source Bitrate?" />
+
+												</CheckBox>
+											</Grid>
+										</StackPanel>
+									</controls:GroupBox>
+
+									<controls:GroupBox
+										Margin="5,5,5,0"
+										BorderWidth="1"
+										Label="Quality"
+										IsEnabled="{Binding !AudioSettings.LameTargetBitrate}">
+
+										<Grid
+											ColumnDefinitions="*,*,25"
+											RowDefinitions="*,Auto">
+
+											<Slider
+												Grid.Column="0"
+												Grid.ColumnSpan="2"
+												Value="{Binding AudioSettings.LameVBRQuality, Mode=TwoWay}"
+												Minimum="0"
+												Maximum="9"
+												IsSnapToTickEnabled="True" TickFrequency="1"
+												Ticks="0,1,2,3,4,5,6,7,8,9"
+												TickPlacement="Outside">
+												<Slider.Styles>
+													<Style Selector="Slider /template/ Thumb">
+														<Setter Property="ToolTip.Tip" Value="{Binding $parent[Slider].Value, Mode=OneWay, StringFormat='V\{0:f0\}'}" />
+														<Setter Property="ToolTip.Placement" Value="Top" />
+														<Setter Property="ToolTip.VerticalOffset" Value="-10" />
+														<Setter Property="ToolTip.HorizontalOffset" Value="-30" />
+													</Style>
+												</Slider.Styles>
+											</Slider>
+
+											<StackPanel
+												Grid.Column="2"
+												HorizontalAlignment="Right"
+												Orientation="Horizontal">
+
+												<TextBlock Text="V" />
+												<TextBlock Text="{Binding AudioSettings.LameVBRQuality}" />
+
+											</StackPanel>
+
+											<TextBlock
+												Grid.Column="0"
+												Grid.Row="1"
+												Margin="10,0,0,0"
+												Text="Higher" />
+
+											<TextBlock
+												Grid.Column="1"
+												Grid.Row="1"
+												Margin="0,0,10,0"
+												HorizontalAlignment="Right"
+												Text="Lower" />
+
+										</Grid>
+									</controls:GroupBox>
+
+									<TextBlock
+										Margin="5,5,5,5"
+										Text="Using L.A.M.E encoding engine"
+										FontStyle="Italic" />
+
+								</StackPanel>
+							</controls:GroupBox>
+						</StackPanel>
+
+						<controls:GroupBox
+							Grid.Row="1"
+							Grid.ColumnSpan="2"
+							Margin="5"
+							BorderWidth="1" IsEnabled="{Binding AudioSettings.SplitFilesByChapter}"
+							Label="{Binding AudioSettings.ChapterTitleTemplateText}">
+
+							<Grid ColumnDefinitions="*,Auto">
+
+								<TextBox
+									Grid.Column="0"
+									Margin="0,10,10,10"
+									FontSize="14"
+									IsReadOnly="True"
+									Text="{Binding AudioSettings.ChapterTitleTemplate}" />
+
+								<Button
+									Grid.Column="1"
+									Content="Edit"
+									Height="30"
+									Padding="30,3,30,3"
+									Click="EditChapterTitleTemplateButton_Click" />
+							</Grid>
+						</controls:GroupBox>
+					</Grid>
+				</Border>
+			</TabItem>
 
 
 			<TabItem>
@@ -116,7 +488,6 @@
 					</Grid>
 				</Border>
 			</TabItem>
-
 
 			<TabItem>
 
@@ -390,367 +761,6 @@
 				</Border>
 			</TabItem>
 
-			<TabItem>
-
-				<TabItem.Header>
-
-					<TextBlock
-						FontSize="14"
-						VerticalAlignment="Center"
-						Text="Audio File Settings"/>
-
-				</TabItem.Header>
-
-				<Border
-					Grid.Column="0"
-					Grid.Row="0"
-					BorderThickness="2"
-					BorderBrush="{DynamicResource DataGridGridLinesBrush}">
-
-					<Grid
-						RowDefinitions="*,Auto"
-						ColumnDefinitions="*,*">
-
-						<StackPanel
-							Margin="5"
-							Grid.Row="0"
-							Grid.Column="0">
-
-							<CheckBox
-								Margin="0,0,0,5"
-								IsChecked="{Binding AudioSettings.CreateCueSheet, Mode=TwoWay}">
-
-								<TextBlock
-									TextWrapping="Wrap"
-									Text="{Binding AudioSettings.CreateCueSheetText}" />
-
-							</CheckBox>
-
-							<CheckBox
-								Margin="0,0,0,5"
-								IsChecked="{Binding AudioSettings.DownloadCoverArt, Mode=TwoWay}">
-
-								<TextBlock
-									TextWrapping="Wrap"
-									Text="{Binding AudioSettings.DownloadCoverArtText}" />
-
-							</CheckBox>
-
-							<StackPanel Orientation="Horizontal">
-								
-								<CheckBox
-									Margin="0,0,0,5"
-									IsChecked="{Binding AudioSettings.DownloadClipsBookmarks, Mode=TwoWay}">
-
-									<TextBlock
-										TextWrapping="Wrap"
-										Text="Download Clips, Notes and Bookmarks as" />
-
-								</CheckBox>
-								
-								<controls:WheelComboBox
-									Margin="5,0,0,0"
-									IsEnabled="{Binding AudioSettings.DownloadClipsBookmarks}"
-									Items="{Binding AudioSettings.ClipBookmarkFormats}"
-									SelectedItem="{Binding AudioSettings.ClipBookmarkFormat}"/>
-							
-							</StackPanel>
-
-							<CheckBox
-								Margin="0,0,0,5"
-								IsChecked="{Binding AudioSettings.RetainAaxFile, Mode=TwoWay}">
-
-								<TextBlock
-									TextWrapping="Wrap"
-									Text="{Binding AudioSettings.RetainAaxFileText}" />
-
-							</CheckBox>
-
-							<CheckBox
-								Margin="0,0,0,5"
-								IsChecked="{Binding AudioSettings.MergeOpeningAndEndCredits, Mode=TwoWay}">
-
-								<TextBlock
-									TextWrapping="Wrap"
-									Text="{Binding AudioSettings.MergeOpeningEndCreditsText}" />
-
-							</CheckBox>
-
-							<CheckBox
-								Margin="0,0,0,5"
-								IsChecked="{Binding AudioSettings.AllowLibationFixup, Mode=TwoWay}">
-
-								<TextBlock
-									TextWrapping="Wrap"
-									Text="{Binding AudioSettings.AllowLibationFixupText}" />
-							</CheckBox>
-
-							<controls:GroupBox
-								BorderWidth="1"
-								Label="Audiobook Fix-ups"
-								IsEnabled="{Binding AudioSettings.AllowLibationFixup}">
-
-								<StackPanel Orientation="Vertical">
-
-									<CheckBox
-										Margin="0,0,0,5"
-										IsChecked="{Binding AudioSettings.SplitFilesByChapter, Mode=TwoWay}">
-
-										<TextBlock
-											TextWrapping="Wrap"
-											Text="{Binding AudioSettings.SplitFilesByChapterText}" />
-
-									</CheckBox>
-
-									<CheckBox
-										Margin="0,0,0,5"
-										IsChecked="{Binding AudioSettings.StripAudibleBrandAudio, Mode=TwoWay}">
-
-										<TextBlock
-											TextWrapping="Wrap"
-											Text="{Binding AudioSettings.StripAudibleBrandingText}" />
-
-									</CheckBox>
-
-									<CheckBox
-										Margin="0,0,0,5"
-										IsChecked="{Binding AudioSettings.StripUnabridged, Mode=TwoWay}">
-
-										<TextBlock
-											TextWrapping="Wrap"
-											Text="{Binding AudioSettings.StripUnabridgedText}" />
-
-									</CheckBox>
-
-									<RadioButton
-										Margin="0,5,0,5"
-										IsChecked="{Binding !AudioSettings.DecryptToLossy, Mode=TwoWay}">
-
-										<TextBlock
-											TextWrapping="Wrap"
-											Text="Download my books in the original audio format (Lossless)" />
-
-									</RadioButton>
-
-									<RadioButton
-										Margin="0,5,0,5"
-										IsEnabled="{Binding AudioSettings.IsMp3Supported}"
-										IsChecked="{Binding AudioSettings.DecryptToLossy, Mode=TwoWay}">
-
-										<TextBlock
-											TextWrapping="Wrap"
-											Text="Download my books as .MP3 files (transcode if necessary)" />
-
-									</RadioButton>
-								</StackPanel>
-							</controls:GroupBox>
-						</StackPanel>
-
-						<StackPanel
-							Grid.Row="0"
-							IsVisible="{Binding AudioSettings.IsMp3Supported}"
-							Grid.Column="1">
-
-							<controls:GroupBox
-								BorderWidth="1"
-								Label="Mp3 Encoding Options">
-
-								<StackPanel Orientation="Vertical">
-
-									<Grid
-										Margin="5,5,5,0"
-										ColumnDefinitions="Auto,*">
-
-										<controls:GroupBox
-											BorderWidth="1"
-											Grid.Column="0"
-											Label="Target">
-
-											<StackPanel Orientation="Horizontal">
-
-												<RadioButton
-													Margin="10"
-													Content="Bitrate"
-													IsChecked="{Binding AudioSettings.LameTargetBitrate, Mode=TwoWay}"/>
-
-												<RadioButton
-													Margin="10"
-													Content="Quality"
-													IsChecked="{Binding !AudioSettings.LameTargetBitrate, Mode=TwoWay}"/>
-
-											</StackPanel>
-										</controls:GroupBox>
-
-										<CheckBox
-											HorizontalAlignment="Right"
-											Grid.Column="1"
-											IsChecked="{Binding AudioSettings.LameDownsampleMono, Mode=TwoWay}">
-
-											<TextBlock
-												TextWrapping="Wrap"
-												Text="Downsample to mono? (Recommended)" />
-
-										</CheckBox>
-									</Grid>
-
-									<controls:GroupBox
-										Margin="5,5,5,0"
-										BorderWidth="1"
-										Label="Bitrate"
-										IsEnabled="{Binding AudioSettings.LameTargetBitrate}" >
-
-										<StackPanel>
-
-											<Grid ColumnDefinitions="*,25,Auto">
-
-												<Slider
-													Grid.Column="0"
-													IsEnabled="{Binding !AudioSettings.LameMatchSource}"
-													Value="{Binding AudioSettings.LameBitrate, Mode=TwoWay}"
-													Minimum="16"
-													Maximum="320"
-													IsSnapToTickEnabled="True" TickFrequency="16"
-													Ticks="16,32,48,64,80,96,112,128,144,160,176,192,208,224,240,256,272,288,304,320"
-													TickPlacement="Outside">
-
-													<Slider.Styles>
-														<Style Selector="Slider /template/ Thumb">
-															<Setter Property="ToolTip.Tip" Value="{Binding $parent[Slider].Value, Mode=OneWay, StringFormat='\{0:f0\} Kbps'}" />
-															<Setter Property="ToolTip.Placement" Value="Top" />
-															<Setter Property="ToolTip.VerticalOffset" Value="-10" />
-															<Setter Property="ToolTip.HorizontalOffset" Value="-30" />
-														</Style>
-													</Slider.Styles>
-												</Slider>
-
-												<TextBlock
-													Grid.Column="1"
-													HorizontalAlignment="Right"
-													Text="{Binding AudioSettings.LameBitrate}" />
-
-												<TextBlock
-													Grid.Column="2"
-													Text=" Kbps" />
-
-											</Grid>
-
-											<Grid ColumnDefinitions="*,*">
-
-												<CheckBox
-													Grid.Column="0"
-													IsChecked="{Binding AudioSettings.LameConstantBitrate, Mode=TwoWay}">
-
-													<TextBlock
-														TextWrapping="Wrap"
-														Text="Restrict Encoder to Constant Bitrate?" />
-
-												</CheckBox>
-
-												<CheckBox
-													Grid.Column="1"
-													HorizontalAlignment="Right"
-													IsChecked="{Binding AudioSettings.LameMatchSource, Mode=TwoWay}">
-
-													<TextBlock
-														TextWrapping="Wrap"
-														Text="Match Source Bitrate?" />
-
-												</CheckBox>
-											</Grid>
-										</StackPanel>
-									</controls:GroupBox>
-
-									<controls:GroupBox
-										Margin="5,5,5,0"
-										BorderWidth="1"
-										Label="Quality"
-										IsEnabled="{Binding !AudioSettings.LameTargetBitrate}">
-
-										<Grid
-											ColumnDefinitions="*,*,25"
-											RowDefinitions="*,Auto">
-
-											<Slider
-												Grid.Column="0"
-												Grid.ColumnSpan="2"
-												Value="{Binding AudioSettings.LameVBRQuality, Mode=TwoWay}"
-												Minimum="0"
-												Maximum="9"
-												IsSnapToTickEnabled="True" TickFrequency="1"
-												Ticks="0,1,2,3,4,5,6,7,8,9"
-												TickPlacement="Outside">
-												<Slider.Styles>
-													<Style Selector="Slider /template/ Thumb">
-														<Setter Property="ToolTip.Tip" Value="{Binding $parent[Slider].Value, Mode=OneWay, StringFormat='V\{0:f0\}'}" />
-														<Setter Property="ToolTip.Placement" Value="Top" />
-														<Setter Property="ToolTip.VerticalOffset" Value="-10" />
-														<Setter Property="ToolTip.HorizontalOffset" Value="-30" />
-													</Style>
-												</Slider.Styles>
-											</Slider>
-
-											<StackPanel
-												Grid.Column="2"
-												HorizontalAlignment="Right"
-												Orientation="Horizontal">
-
-												<TextBlock Text="V" />
-												<TextBlock Text="{Binding AudioSettings.LameVBRQuality}" />
-
-											</StackPanel>
-
-											<TextBlock
-												Grid.Column="0"
-												Grid.Row="1"
-												Margin="10,0,0,0"
-												Text="Higher" />
-
-											<TextBlock
-												Grid.Column="1"
-												Grid.Row="1"
-												Margin="0,0,10,0"
-												HorizontalAlignment="Right"
-												Text="Lower" />
-
-										</Grid>
-									</controls:GroupBox>
-
-									<TextBlock
-										Margin="5,5,5,5"
-										Text="Using L.A.M.E encoding engine"
-										FontStyle="Italic" />
-
-								</StackPanel>
-							</controls:GroupBox>
-						</StackPanel>
-
-						<controls:GroupBox
-							Grid.Row="1"
-							Grid.ColumnSpan="2"
-							Margin="5"
-							BorderWidth="1" IsEnabled="{Binding AudioSettings.SplitFilesByChapter}"
-							Label="{Binding AudioSettings.ChapterTitleTemplateText}">
-
-							<Grid ColumnDefinitions="*,Auto">
-
-								<TextBox
-									Grid.Column="0"
-									Margin="0,10,10,10"
-									FontSize="14"
-									IsReadOnly="True"
-									Text="{Binding AudioSettings.ChapterTitleTemplate}" />
-
-								<Button
-									Grid.Column="1"
-									Content="Edit"
-									Height="30"
-									Padding="30,3,30,3"
-									Click="EditChapterTitleTemplateButton_Click" />
-							</Grid>
-						</controls:GroupBox>
-					</Grid>
-				</Border>
-			</TabItem>
 		</TabControl>
 	</Grid>
 </Window>

--- a/Source/LibationAvalonia/Dialogs/SettingsDialog.axaml
+++ b/Source/LibationAvalonia/Dialogs/SettingsDialog.axaml
@@ -2,8 +2,8 @@
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-        mc:Ignorable="d" d:DesignWidth="900" d:DesignHeight="680"
-		MinWidth="900" MinHeight="680"
+        mc:Ignorable="d" d:DesignWidth="850" d:DesignHeight="620"
+		MinWidth="800" MinHeight="620"
         x:Class="LibationAvalonia.Dialogs.SettingsDialog"
         xmlns:controls="clr-namespace:LibationAvalonia.Controls"
         Title="Edit Settings"
@@ -34,378 +34,6 @@
 					<Setter Property="MinHeight" Value="5"/>
 				</Style>
 			</TabControl.Styles>
-			<TabItem>
-
-				<TabItem.Header>
-
-					<TextBlock
-						FontSize="14"
-						VerticalAlignment="Center"
-						Text="Audio File Settings"/>
-
-				</TabItem.Header>
-
-				<Border
-					Grid.Column="0"
-					Grid.Row="0"
-					BorderThickness="2"
-					BorderBrush="{DynamicResource DataGridGridLinesBrush}">
-
-					<Grid
-						RowDefinitions="*,Auto"
-						ColumnDefinitions="*,*">
-
-						<StackPanel
-							Margin="5"
-							Grid.Row="0"
-							Grid.Column="0">
-
-							<CheckBox
-								Margin="0,0,0,5"
-								IsChecked="{Binding AudioSettings.CreateCueSheet, Mode=TwoWay}">
-
-								<TextBlock
-									TextWrapping="Wrap"
-									Text="{Binding AudioSettings.CreateCueSheetText}" />
-
-							</CheckBox>
-
-							<CheckBox
-								Margin="0,0,0,5"
-								IsChecked="{Binding AudioSettings.DownloadCoverArt, Mode=TwoWay}">
-
-								<TextBlock
-									TextWrapping="Wrap"
-									Text="{Binding AudioSettings.DownloadCoverArtText}" />
-
-							</CheckBox>
-
-							<StackPanel Orientation="Horizontal">
-								
-								<CheckBox
-									Margin="0,0,0,5"
-									IsChecked="{Binding AudioSettings.DownloadClipsBookmarks, Mode=TwoWay}">
-
-									<TextBlock
-										TextWrapping="Wrap"
-										Text="Download Clips, Notes and Bookmarks as" />
-
-								</CheckBox>
-								
-								<controls:WheelComboBox
-									Margin="5,0,0,0"
-									IsEnabled="{Binding AudioSettings.DownloadClipsBookmarks}"
-									Items="{Binding AudioSettings.ClipBookmarkFormats}"
-									SelectedItem="{Binding AudioSettings.ClipBookmarkFormat}"/>
-							
-							</StackPanel>
-
-							<CheckBox
-								Margin="0,0,0,5"
-								IsChecked="{Binding AudioSettings.RetainAaxFile, Mode=TwoWay}">
-
-								<TextBlock
-									TextWrapping="Wrap"
-									Text="{Binding AudioSettings.RetainAaxFileText}" />
-
-							</CheckBox>
-
-							<CheckBox
-								Margin="0,0,0,5"
-								IsChecked="{Binding AudioSettings.MergeOpeningAndEndCredits, Mode=TwoWay}">
-
-								<TextBlock
-									TextWrapping="Wrap"
-									Text="{Binding AudioSettings.MergeOpeningEndCreditsText}" />
-
-							</CheckBox>
-
-							<CheckBox
-								Margin="0,0,0,5"
-								IsChecked="{Binding AudioSettings.AllowLibationFixup, Mode=TwoWay}">
-
-								<TextBlock
-									TextWrapping="Wrap"
-									Text="{Binding AudioSettings.AllowLibationFixupText}" />
-							</CheckBox>
-
-							<controls:GroupBox
-								BorderWidth="1"
-								Label="Audiobook Fix-ups"
-								IsEnabled="{Binding AudioSettings.AllowLibationFixup}">
-
-								<StackPanel Orientation="Vertical">
-
-									<CheckBox
-										Margin="0,0,0,5"
-										IsChecked="{Binding AudioSettings.SplitFilesByChapter, Mode=TwoWay}">
-
-										<TextBlock
-											TextWrapping="Wrap"
-											Text="{Binding AudioSettings.SplitFilesByChapterText}" />
-
-									</CheckBox>
-
-									<CheckBox
-										Margin="0,0,0,5"
-										IsChecked="{Binding AudioSettings.StripAudibleBrandAudio, Mode=TwoWay}">
-
-										<TextBlock
-											TextWrapping="Wrap"
-											Text="{Binding AudioSettings.StripAudibleBrandingText}" />
-
-									</CheckBox>
-
-									<CheckBox
-										Margin="0,0,0,5"
-										IsChecked="{Binding AudioSettings.StripUnabridged, Mode=TwoWay}">
-
-										<TextBlock
-											TextWrapping="Wrap"
-											Text="{Binding AudioSettings.StripUnabridgedText}" />
-
-									</CheckBox>
-
-									<RadioButton
-										Margin="0,5,0,5"
-										IsChecked="{Binding !AudioSettings.DecryptToLossy, Mode=TwoWay}">
-
-										<StackPanel >
-											
-											<TextBlock
-											TextWrapping="Wrap"
-											Text="Download my books in the original audio format (Lossless)" />
-											<CheckBox
-												Margin="0,0,0,5"
-												IsEnabled="{Binding !AudioSettings.DecryptToLossy}"
-												IsChecked="{Binding AudioSettings.MoveMoovToBeginning, Mode=TwoWay}">
-
-												<TextBlock
-													TextWrapping="Wrap"
-													Text="{Binding AudioSettings.MoveMoovToBeginningText}" />
-
-											</CheckBox>
-											
-										</StackPanel>
-									</RadioButton>
-
-									<RadioButton
-										Margin="0,5,0,5"
-										IsChecked="{Binding AudioSettings.DecryptToLossy, Mode=TwoWay}">
-
-										<TextBlock
-											TextWrapping="Wrap"
-											Text="Download my books as .MP3 files (transcode if necessary)" />
-
-									</RadioButton>
-								</StackPanel>
-							</controls:GroupBox>
-						</StackPanel>
-
-						<StackPanel
-							Grid.Row="0"
-							Grid.Column="1">
-
-							<controls:GroupBox
-								BorderWidth="1"
-								Label="Mp3 Encoding Options">
-
-								<StackPanel Orientation="Vertical">
-
-									<Grid
-										Margin="5,5,5,0"
-										ColumnDefinitions="Auto,*">
-
-										<controls:GroupBox
-											BorderWidth="1"
-											Grid.Column="0"
-											Label="Target">
-
-											<StackPanel Orientation="Horizontal">
-
-												<RadioButton
-													Margin="10"
-													Content="Bitrate"
-													IsChecked="{Binding AudioSettings.LameTargetBitrate, Mode=TwoWay}"/>
-
-												<RadioButton
-													Margin="10"
-													Content="Quality"
-													IsChecked="{Binding !AudioSettings.LameTargetBitrate, Mode=TwoWay}"/>
-
-											</StackPanel>
-										</controls:GroupBox>
-
-										<CheckBox
-											HorizontalAlignment="Right"
-											Grid.Column="1"
-											IsChecked="{Binding AudioSettings.LameDownsampleMono, Mode=TwoWay}">
-
-											<TextBlock
-												TextWrapping="Wrap"
-												Text="Downsample to mono? (Recommended)" />
-
-										</CheckBox>
-									</Grid>
-
-									<controls:GroupBox
-										Margin="5,5,5,0"
-										BorderWidth="1"
-										Label="Bitrate"
-										IsEnabled="{Binding AudioSettings.LameTargetBitrate}" >
-
-										<StackPanel>
-
-											<Grid ColumnDefinitions="*,25,Auto">
-
-												<Slider
-													Grid.Column="0"
-													IsEnabled="{Binding !AudioSettings.LameMatchSource}"
-													Value="{Binding AudioSettings.LameBitrate, Mode=TwoWay}"
-													Minimum="16"
-													Maximum="320"
-													IsSnapToTickEnabled="True" TickFrequency="16"
-													Ticks="16,32,48,64,80,96,112,128,144,160,176,192,208,224,240,256,272,288,304,320"
-													TickPlacement="Outside">
-
-													<Slider.Styles>
-														<Style Selector="Slider /template/ Thumb">
-															<Setter Property="ToolTip.Tip" Value="{Binding $parent[Slider].Value, Mode=OneWay, StringFormat='\{0:f0\} Kbps'}" />
-															<Setter Property="ToolTip.Placement" Value="Top" />
-															<Setter Property="ToolTip.VerticalOffset" Value="-10" />
-															<Setter Property="ToolTip.HorizontalOffset" Value="-30" />
-														</Style>
-													</Slider.Styles>
-												</Slider>
-
-												<TextBlock
-													Grid.Column="1"
-													HorizontalAlignment="Right"
-													Text="{Binding AudioSettings.LameBitrate}" />
-
-												<TextBlock
-													Grid.Column="2"
-													Text=" Kbps" />
-
-											</Grid>
-
-											<Grid ColumnDefinitions="*,*">
-
-												<CheckBox
-													Grid.Column="0"
-													IsChecked="{Binding AudioSettings.LameConstantBitrate, Mode=TwoWay}">
-
-													<TextBlock
-														TextWrapping="Wrap"
-														Text="Restrict Encoder to Constant Bitrate?" />
-
-												</CheckBox>
-
-												<CheckBox
-													Grid.Column="1"
-													HorizontalAlignment="Right"
-													IsChecked="{Binding AudioSettings.LameMatchSource, Mode=TwoWay}">
-
-													<TextBlock
-														TextWrapping="Wrap"
-														Text="Match Source Bitrate?" />
-
-												</CheckBox>
-											</Grid>
-										</StackPanel>
-									</controls:GroupBox>
-
-									<controls:GroupBox
-										Margin="5,5,5,0"
-										BorderWidth="1"
-										Label="Quality"
-										IsEnabled="{Binding !AudioSettings.LameTargetBitrate}">
-
-										<Grid
-											ColumnDefinitions="*,*,25"
-											RowDefinitions="*,Auto">
-
-											<Slider
-												Grid.Column="0"
-												Grid.ColumnSpan="2"
-												Value="{Binding AudioSettings.LameVBRQuality, Mode=TwoWay}"
-												Minimum="0"
-												Maximum="9"
-												IsSnapToTickEnabled="True" TickFrequency="1"
-												Ticks="0,1,2,3,4,5,6,7,8,9"
-												TickPlacement="Outside">
-												<Slider.Styles>
-													<Style Selector="Slider /template/ Thumb">
-														<Setter Property="ToolTip.Tip" Value="{Binding $parent[Slider].Value, Mode=OneWay, StringFormat='V\{0:f0\}'}" />
-														<Setter Property="ToolTip.Placement" Value="Top" />
-														<Setter Property="ToolTip.VerticalOffset" Value="-10" />
-														<Setter Property="ToolTip.HorizontalOffset" Value="-30" />
-													</Style>
-												</Slider.Styles>
-											</Slider>
-
-											<StackPanel
-												Grid.Column="2"
-												HorizontalAlignment="Right"
-												Orientation="Horizontal">
-
-												<TextBlock Text="V" />
-												<TextBlock Text="{Binding AudioSettings.LameVBRQuality}" />
-
-											</StackPanel>
-
-											<TextBlock
-												Grid.Column="0"
-												Grid.Row="1"
-												Margin="10,0,0,0"
-												Text="Higher" />
-
-											<TextBlock
-												Grid.Column="1"
-												Grid.Row="1"
-												Margin="0,0,10,0"
-												HorizontalAlignment="Right"
-												Text="Lower" />
-
-										</Grid>
-									</controls:GroupBox>
-
-									<TextBlock
-										Margin="5,5,5,5"
-										Text="Using L.A.M.E encoding engine"
-										FontStyle="Italic" />
-
-								</StackPanel>
-							</controls:GroupBox>
-						</StackPanel>
-
-						<controls:GroupBox
-							Grid.Row="1"
-							Grid.ColumnSpan="2"
-							Margin="5"
-							BorderWidth="1" IsEnabled="{Binding AudioSettings.SplitFilesByChapter}"
-							Label="{Binding AudioSettings.ChapterTitleTemplateText}">
-
-							<Grid ColumnDefinitions="*,Auto">
-
-								<TextBox
-									Grid.Column="0"
-									Margin="0,10,10,10"
-									FontSize="14"
-									IsReadOnly="True"
-									Text="{Binding AudioSettings.ChapterTitleTemplate}" />
-
-								<Button
-									Grid.Column="1"
-									Content="Edit"
-									Height="30"
-									Padding="30,3,30,3"
-									Click="EditChapterTitleTemplateButton_Click" />
-							</Grid>
-						</controls:GroupBox>
-					</Grid>
-				</Border>
-			</TabItem>
 
 
 			<TabItem>
@@ -488,6 +116,7 @@
 					</Grid>
 				</Border>
 			</TabItem>
+
 
 			<TabItem>
 
@@ -761,6 +390,378 @@
 				</Border>
 			</TabItem>
 
+			<TabItem>
+
+				<TabItem.Header>
+
+					<TextBlock
+						FontSize="14"
+						VerticalAlignment="Center"
+						Text="Audio File Settings"/>
+
+				</TabItem.Header>
+
+				<Border
+					Grid.Column="0"
+					Grid.Row="0"
+					BorderThickness="2"
+					BorderBrush="{DynamicResource DataGridGridLinesBrush}">
+
+					<Grid
+						RowDefinitions="*,Auto"
+						ColumnDefinitions="*,*">
+
+						<StackPanel
+							Margin="5"
+							Grid.Row="0"
+							Grid.Column="0">
+
+							<CheckBox
+								Margin="0,0,0,5"
+								IsChecked="{Binding AudioSettings.CreateCueSheet, Mode=TwoWay}">
+
+								<TextBlock
+									TextWrapping="Wrap"
+									Text="{Binding AudioSettings.CreateCueSheetText}" />
+
+							</CheckBox>
+
+							<CheckBox
+								Margin="0,0,0,5"
+								IsChecked="{Binding AudioSettings.DownloadCoverArt, Mode=TwoWay}">
+
+								<TextBlock
+									TextWrapping="Wrap"
+									Text="{Binding AudioSettings.DownloadCoverArtText}" />
+
+							</CheckBox>
+
+							<StackPanel Orientation="Horizontal">
+								
+								<CheckBox
+									Margin="0,0,0,5"
+									IsChecked="{Binding AudioSettings.DownloadClipsBookmarks, Mode=TwoWay}">
+
+									<TextBlock
+										TextWrapping="Wrap"
+										Text="Download Clips, Notes and Bookmarks as" />
+
+								</CheckBox>
+								
+								<controls:WheelComboBox
+									Margin="5,0,0,0"
+									IsEnabled="{Binding AudioSettings.DownloadClipsBookmarks}"
+									Items="{Binding AudioSettings.ClipBookmarkFormats}"
+									SelectedItem="{Binding AudioSettings.ClipBookmarkFormat}"/>
+							
+							</StackPanel>
+
+							<CheckBox
+								Margin="0,0,0,5"
+								IsChecked="{Binding AudioSettings.RetainAaxFile, Mode=TwoWay}">
+
+								<TextBlock
+									TextWrapping="Wrap"
+									Text="{Binding AudioSettings.RetainAaxFileText}" />
+
+							</CheckBox>
+
+							<CheckBox
+								Margin="0,0,0,5"
+								IsChecked="{Binding AudioSettings.MergeOpeningAndEndCredits, Mode=TwoWay}">
+
+								<TextBlock
+									TextWrapping="Wrap"
+									Text="{Binding AudioSettings.MergeOpeningEndCreditsText}" />
+
+							</CheckBox>
+
+							<CheckBox
+								Margin="0,0,0,5"
+								IsChecked="{Binding AudioSettings.AllowLibationFixup, Mode=TwoWay}">
+
+								<TextBlock
+									TextWrapping="Wrap"
+									Text="{Binding AudioSettings.AllowLibationFixupText}" />
+							</CheckBox>
+
+							<controls:GroupBox
+								BorderWidth="1"
+								Label="Audiobook Fix-ups"
+								IsEnabled="{Binding AudioSettings.AllowLibationFixup}">
+
+								<StackPanel Orientation="Vertical">
+
+									<CheckBox
+										Margin="0,0,0,5"
+										IsChecked="{Binding AudioSettings.SplitFilesByChapter, Mode=TwoWay}">
+
+										<TextBlock
+											TextWrapping="Wrap"
+											Text="{Binding AudioSettings.SplitFilesByChapterText}" />
+
+									</CheckBox>
+
+									<CheckBox
+										Margin="0,0,0,5"
+										IsChecked="{Binding AudioSettings.StripAudibleBrandAudio, Mode=TwoWay}">
+
+										<TextBlock
+											TextWrapping="Wrap"
+											Text="{Binding AudioSettings.StripAudibleBrandingText}" />
+
+									</CheckBox>
+
+									<CheckBox
+										Margin="0,0,0,5"
+										IsChecked="{Binding AudioSettings.StripUnabridged, Mode=TwoWay}">
+
+										<TextBlock
+											TextWrapping="Wrap"
+											Text="{Binding AudioSettings.StripUnabridgedText}" />
+
+									</CheckBox>
+
+									<RadioButton
+										Margin="0,5,0,5"
+										IsChecked="{Binding !AudioSettings.DecryptToLossy, Mode=TwoWay}">
+
+										<StackPanel >
+
+											<TextBlock
+												TextWrapping="Wrap"
+												Text="Download my books in the original audio format (Lossless)" />
+											<CheckBox
+												Margin="0,0,0,5"
+												IsEnabled="{Binding !AudioSettings.DecryptToLossy}"
+												IsChecked="{Binding AudioSettings.MoveMoovToBeginning, Mode=TwoWay}">
+
+												<TextBlock
+													TextWrapping="Wrap"
+													Text="{Binding AudioSettings.MoveMoovToBeginningText}" />
+
+											</CheckBox>
+
+										</StackPanel>
+									</RadioButton>
+
+									<RadioButton
+										Margin="0,5,0,5"
+										IsChecked="{Binding AudioSettings.DecryptToLossy, Mode=TwoWay}">
+
+										<TextBlock
+											TextWrapping="Wrap"
+											Text="Download my books as .MP3 files (transcode if necessary)" />
+
+									</RadioButton>
+								</StackPanel>
+							</controls:GroupBox>
+						</StackPanel>
+
+						<StackPanel
+							Grid.Row="0"
+							Grid.Column="1">
+
+							<controls:GroupBox
+								BorderWidth="1"
+								Label="Mp3 Encoding Options">
+
+								<StackPanel Orientation="Vertical">
+
+									<Grid
+										Margin="5,5,5,0"
+										ColumnDefinitions="Auto,*">
+
+										<controls:GroupBox
+											BorderWidth="1"
+											Grid.Column="0"
+											Label="Target">
+
+											<StackPanel Orientation="Horizontal">
+
+												<RadioButton
+													Margin="10"
+													Content="Bitrate"
+													IsChecked="{Binding AudioSettings.LameTargetBitrate, Mode=TwoWay}"/>
+
+												<RadioButton
+													Margin="10"
+													Content="Quality"
+													IsChecked="{Binding !AudioSettings.LameTargetBitrate, Mode=TwoWay}"/>
+
+											</StackPanel>
+										</controls:GroupBox>
+
+										<CheckBox
+											HorizontalAlignment="Right"
+											Grid.Column="1"
+											IsChecked="{Binding AudioSettings.LameDownsampleMono, Mode=TwoWay}">
+
+											<TextBlock
+												TextWrapping="Wrap"
+												Text="Downsample to mono? (Recommended)" />
+
+										</CheckBox>
+									</Grid>
+
+									<controls:GroupBox
+										Margin="5,5,5,0"
+										BorderWidth="1"
+										Label="Bitrate"
+										IsEnabled="{Binding AudioSettings.LameTargetBitrate}" >
+
+										<StackPanel>
+
+											<Grid ColumnDefinitions="*,25,Auto">
+
+												<Slider
+													Grid.Column="0"
+													IsEnabled="{Binding !AudioSettings.LameMatchSource}"
+													Value="{Binding AudioSettings.LameBitrate, Mode=TwoWay}"
+													Minimum="16"
+													Maximum="320"
+													IsSnapToTickEnabled="True" TickFrequency="16"
+													Ticks="16,32,48,64,80,96,112,128,144,160,176,192,208,224,240,256,272,288,304,320"
+													TickPlacement="Outside">
+
+													<Slider.Styles>
+														<Style Selector="Slider /template/ Thumb">
+															<Setter Property="ToolTip.Tip" Value="{Binding $parent[Slider].Value, Mode=OneWay, StringFormat='\{0:f0\} Kbps'}" />
+															<Setter Property="ToolTip.Placement" Value="Top" />
+															<Setter Property="ToolTip.VerticalOffset" Value="-10" />
+															<Setter Property="ToolTip.HorizontalOffset" Value="-30" />
+														</Style>
+													</Slider.Styles>
+												</Slider>
+
+												<TextBlock
+													Grid.Column="1"
+													HorizontalAlignment="Right"
+													Text="{Binding AudioSettings.LameBitrate}" />
+
+												<TextBlock
+													Grid.Column="2"
+													Text=" Kbps" />
+
+											</Grid>
+
+											<Grid ColumnDefinitions="*,*">
+
+												<CheckBox
+													Grid.Column="0"
+													IsChecked="{Binding AudioSettings.LameConstantBitrate, Mode=TwoWay}">
+
+													<TextBlock
+														TextWrapping="Wrap"
+														Text="Restrict Encoder to Constant Bitrate?" />
+
+												</CheckBox>
+
+												<CheckBox
+													Grid.Column="1"
+													HorizontalAlignment="Right"
+													IsChecked="{Binding AudioSettings.LameMatchSource, Mode=TwoWay}">
+
+													<TextBlock
+														TextWrapping="Wrap"
+														Text="Match Source Bitrate?" />
+
+												</CheckBox>
+											</Grid>
+										</StackPanel>
+									</controls:GroupBox>
+
+									<controls:GroupBox
+										Margin="5,5,5,0"
+										BorderWidth="1"
+										Label="Quality"
+										IsEnabled="{Binding !AudioSettings.LameTargetBitrate}">
+
+										<Grid
+											ColumnDefinitions="*,*,25"
+											RowDefinitions="*,Auto">
+
+											<Slider
+												Grid.Column="0"
+												Grid.ColumnSpan="2"
+												Value="{Binding AudioSettings.LameVBRQuality, Mode=TwoWay}"
+												Minimum="0"
+												Maximum="9"
+												IsSnapToTickEnabled="True" TickFrequency="1"
+												Ticks="0,1,2,3,4,5,6,7,8,9"
+												TickPlacement="Outside">
+												<Slider.Styles>
+													<Style Selector="Slider /template/ Thumb">
+														<Setter Property="ToolTip.Tip" Value="{Binding $parent[Slider].Value, Mode=OneWay, StringFormat='V\{0:f0\}'}" />
+														<Setter Property="ToolTip.Placement" Value="Top" />
+														<Setter Property="ToolTip.VerticalOffset" Value="-10" />
+														<Setter Property="ToolTip.HorizontalOffset" Value="-30" />
+													</Style>
+												</Slider.Styles>
+											</Slider>
+
+											<StackPanel
+												Grid.Column="2"
+												HorizontalAlignment="Right"
+												Orientation="Horizontal">
+
+												<TextBlock Text="V" />
+												<TextBlock Text="{Binding AudioSettings.LameVBRQuality}" />
+
+											</StackPanel>
+
+											<TextBlock
+												Grid.Column="0"
+												Grid.Row="1"
+												Margin="10,0,0,0"
+												Text="Higher" />
+
+											<TextBlock
+												Grid.Column="1"
+												Grid.Row="1"
+												Margin="0,0,10,0"
+												HorizontalAlignment="Right"
+												Text="Lower" />
+
+										</Grid>
+									</controls:GroupBox>
+
+									<TextBlock
+										Margin="5,5,5,5"
+										Text="Using L.A.M.E encoding engine"
+										FontStyle="Italic" />
+
+								</StackPanel>
+							</controls:GroupBox>
+						</StackPanel>
+
+						<controls:GroupBox
+							Grid.Row="1"
+							Grid.ColumnSpan="2"
+							Margin="5"
+							BorderWidth="1" IsEnabled="{Binding AudioSettings.SplitFilesByChapter}"
+							Label="{Binding AudioSettings.ChapterTitleTemplateText}">
+
+							<Grid ColumnDefinitions="*,Auto">
+
+								<TextBox
+									Grid.Column="0"
+									Margin="0,10,10,10"
+									FontSize="14"
+									IsReadOnly="True"
+									Text="{Binding AudioSettings.ChapterTitleTemplate}" />
+
+								<Button
+									Grid.Column="1"
+									Content="Edit"
+									Height="30"
+									Padding="30,3,30,3"
+									Click="EditChapterTitleTemplateButton_Click" />
+							</Grid>
+						</controls:GroupBox>
+					</Grid>
+				</Border>
+			</TabItem>
 		</TabControl>
 	</Grid>
 </Window>

--- a/Source/LibationAvalonia/Dialogs/SettingsDialog.axaml.cs
+++ b/Source/LibationAvalonia/Dialogs/SettingsDialog.axaml.cs
@@ -383,6 +383,7 @@ namespace LibationAvalonia.Dialogs
 	{
 
 		private bool _downloadClipsBookmarks;
+		private bool _decryptToLossy;
 		private bool _splitFilesByChapter;
 		private bool _allowLibationFixup;
 		private bool _lameTargetBitrate;
@@ -390,8 +391,6 @@ namespace LibationAvalonia.Dialogs
 		private int _lameBitrate;
 		private int _lameVBRQuality;
 		private string _chapterTitleTemplate;
-
-		public bool IsMp3Supported => Configuration.IsLinux || Configuration.IsWindows;
 
 		public AudioSettings(Configuration config)
 		{
@@ -411,6 +410,7 @@ namespace LibationAvalonia.Dialogs
 			StripUnabridged = config.StripUnabridged;
 			ChapterTitleTemplate = config.ChapterTitleTemplate;
 			DecryptToLossy = config.DecryptToLossy;
+			MoveMoovToBeginning = config.MoveMoovToBeginning;
 			LameTargetBitrate = config.LameTargetBitrate;
 			LameDownsampleMono = config.LameDownsampleMono;
 			LameConstantBitrate = config.LameConstantBitrate;
@@ -433,6 +433,7 @@ namespace LibationAvalonia.Dialogs
 			config.StripUnabridged = StripUnabridged;
 			config.ChapterTitleTemplate = ChapterTitleTemplate;
 			config.DecryptToLossy = DecryptToLossy;
+			config.MoveMoovToBeginning = MoveMoovToBeginning;
 			config.LameTargetBitrate = LameTargetBitrate;
 			config.LameDownsampleMono = LameDownsampleMono;
 			config.LameConstantBitrate = LameConstantBitrate;
@@ -453,6 +454,7 @@ namespace LibationAvalonia.Dialogs
 		public string StripAudibleBrandingText { get; } = Configuration.GetDescription(nameof(Configuration.StripAudibleBrandAudio));
 		public string StripUnabridgedText { get; } = Configuration.GetDescription(nameof(Configuration.StripUnabridged));
 		public string ChapterTitleTemplateText { get; } = Configuration.GetDescription(nameof(Configuration.ChapterTitleTemplate));
+		public string MoveMoovToBeginningText { get; } = Configuration.GetDescription(nameof(Configuration.MoveMoovToBeginning));
 
 		public bool CreateCueSheet { get; set; }
 		public bool DownloadCoverArt { get; set; }
@@ -462,7 +464,8 @@ namespace LibationAvalonia.Dialogs
 		public bool MergeOpeningAndEndCredits { get; set; }
 		public bool StripAudibleBrandAudio { get; set; }
 		public bool StripUnabridged { get; set; }
-		public bool DecryptToLossy { get; set; }
+		public bool DecryptToLossy { get => _decryptToLossy; set => this.RaiseAndSetIfChanged(ref _decryptToLossy, value); }
+		public bool MoveMoovToBeginning { get; set; }
 
 		public bool LameDownsampleMono { get; set; } = Design.IsDesignMode;
 		public bool LameConstantBitrate { get; set; } = Design.IsDesignMode;

--- a/Source/LibationFileManager/Configuration.PersistentSettings.cs
+++ b/Source/LibationFileManager/Configuration.PersistentSettings.cs
@@ -115,6 +115,9 @@ namespace LibationFileManager
 		[Description("Decrypt to lossy format?")]
 		public bool DecryptToLossy { get => GetNonString(defaultValue: false); set => SetNonString(value); }
 
+		[Description("Move the mp4 moov atom to the beginning of the file?")]
+		public bool MoveMoovToBeginning { get => GetNonString(defaultValue: false); set => SetNonString(value); }
+
 		[Description("Lame encoder target. true = Bitrate, false = Quality")]
 		public bool LameTargetBitrate { get => GetNonString(defaultValue: false); set => SetNonString(value); }
 

--- a/Source/LibationFileManager/Templates.cs
+++ b/Source/LibationFileManager/Templates.cs
@@ -107,9 +107,9 @@ namespace LibationFileManager
 			.GetFilePath(fileExtension).PathWithoutPrefix;
 
 		public const string DEFAULT_DATE_FORMAT = "yyyy-MM-dd";
-		private static Regex fileDateTagRegex { get; } = new Regex(@"<file\s*?date\s*?(?:\[([^\[\]]*?)\]){0,1}\s*?>", RegexOptions.Compiled | RegexOptions.IgnoreCase);
-		private static Regex dateAddedTagRegex { get; } = new Regex(@"<date\s*?added\s*?(?:\[([^\[\]]*?)\]){0,1}\s*?>", RegexOptions.Compiled | RegexOptions.IgnoreCase);
-		private static Regex datePublishedTagRegex { get; } = new Regex(@"<pub\s*?date\s*?(?:\[([^\[\]]*?)\]){0,1}\s*?>", RegexOptions.Compiled | RegexOptions.IgnoreCase);
+		private static Regex fileDateTagRegex { get; } = new Regex(@"<file\s*?date\s*?(?:\[([^\[\]]*?)\]\s*?)?>", RegexOptions.Compiled | RegexOptions.IgnoreCase);
+		private static Regex dateAddedTagRegex { get; } = new Regex(@"<date\s*?added\s*?(?:\[([^\[\]]*?)\]\s*?)?>", RegexOptions.Compiled | RegexOptions.IgnoreCase);
+		private static Regex datePublishedTagRegex { get; } = new Regex(@"<pub\s*?date\s*?(?:\[([^\[\]]*?)\]\s*?)?>", RegexOptions.Compiled | RegexOptions.IgnoreCase);
 		private static Regex ifSeriesRegex { get; } = new Regex("<if series->(.*?)<-if series>", RegexOptions.Compiled | RegexOptions.IgnoreCase);
 
 		internal static FileNamingTemplate getFileNamingTemplate(LibraryBookDto libraryBookDto, string template, string dirFullPath, string extension, ReplacementCharacters replacements)

--- a/Source/LibationWinForms/Dialogs/SettingsDialog.AudioSettings.cs
+++ b/Source/LibationWinForms/Dialogs/SettingsDialog.AudioSettings.cs
@@ -16,6 +16,7 @@ namespace LibationWinForms.Dialogs
 			this.mergeOpeningEndCreditsCbox.Text = desc(nameof(config.MergeOpeningAndEndCredits));
 			this.stripAudibleBrandingCbox.Text = desc(nameof(config.StripAudibleBrandAudio));
 			this.stripUnabridgedCbox.Text = desc(nameof(config.StripUnabridged));
+			this.moveMoovAtomCbox.Text = desc(nameof(config.MoveMoovToBeginning));
 
 			clipsBookmarksFormatCb.Items.AddRange(
 				new object[]
@@ -37,6 +38,7 @@ namespace LibationWinForms.Dialogs
 			stripAudibleBrandingCbox.Checked = config.StripAudibleBrandAudio;
 			convertLosslessRb.Checked = !config.DecryptToLossy;
 			convertLossyRb.Checked = config.DecryptToLossy;
+			moveMoovAtomCbox.Checked = config.MoveMoovToBeginning;
 
 			lameTargetBitrateRb.Checked = config.LameTargetBitrate;
 			lameTargetQualityRb.Checked = !config.LameTargetBitrate;
@@ -70,6 +72,7 @@ namespace LibationWinForms.Dialogs
 			config.StripUnabridged = stripUnabridgedCbox.Checked;
 			config.StripAudibleBrandAudio = stripAudibleBrandingCbox.Checked;
 			config.DecryptToLossy = convertLossyRb.Checked;
+			config.MoveMoovToBeginning = moveMoovAtomCbox.Checked;
 
 			config.LameTargetBitrate = lameTargetBitrateRb.Checked;
 			config.LameDownsampleMono = lameDownsampleMonoCbox.Checked;
@@ -107,6 +110,7 @@ namespace LibationWinForms.Dialogs
 
 		private void convertFormatRb_CheckedChanged(object sender, EventArgs e)
 		{
+			moveMoovAtomCbox.Enabled = convertLosslessRb.Checked;
 			lameTargetRb_CheckedChanged(sender, e);
 			LameMatchSourceBRCbox_CheckedChanged(sender, e);
 		}

--- a/Source/LibationWinForms/Dialogs/SettingsDialog.Designer.cs
+++ b/Source/LibationWinForms/Dialogs/SettingsDialog.Designer.cs
@@ -76,6 +76,7 @@
 			this.clipsBookmarksFormatCb = new System.Windows.Forms.ComboBox();
 			this.downloadClipsBookmarksCbox = new System.Windows.Forms.CheckBox();
 			this.audiobookFixupsGb = new System.Windows.Forms.GroupBox();
+			this.moveMoovAtomCbox = new System.Windows.Forms.CheckBox();
 			this.stripUnabridgedCbox = new System.Windows.Forms.CheckBox();
 			this.chapterTitleTemplateGb = new System.Windows.Forms.GroupBox();
 			this.chapterTitleTemplateBtn = new System.Windows.Forms.Button();
@@ -294,7 +295,7 @@
 			// convertLossyRb
 			// 
 			this.convertLossyRb.AutoSize = true;
-			this.convertLossyRb.Location = new System.Drawing.Point(13, 136);
+			this.convertLossyRb.Location = new System.Drawing.Point(13, 158);
 			this.convertLossyRb.Name = "convertLossyRb";
 			this.convertLossyRb.Size = new System.Drawing.Size(329, 19);
 			this.convertLossyRb.TabIndex = 12;
@@ -675,6 +676,7 @@
 			// 
 			// audiobookFixupsGb
 			// 
+			this.audiobookFixupsGb.Controls.Add(this.moveMoovAtomCbox);
 			this.audiobookFixupsGb.Controls.Add(this.splitFilesByChapterCbox);
 			this.audiobookFixupsGb.Controls.Add(this.stripUnabridgedCbox);
 			this.audiobookFixupsGb.Controls.Add(this.convertLosslessRb);
@@ -682,10 +684,20 @@
 			this.audiobookFixupsGb.Controls.Add(this.stripAudibleBrandingCbox);
 			this.audiobookFixupsGb.Location = new System.Drawing.Point(6, 169);
 			this.audiobookFixupsGb.Name = "audiobookFixupsGb";
-			this.audiobookFixupsGb.Size = new System.Drawing.Size(403, 160);
+			this.audiobookFixupsGb.Size = new System.Drawing.Size(403, 185);
 			this.audiobookFixupsGb.TabIndex = 19;
 			this.audiobookFixupsGb.TabStop = false;
 			this.audiobookFixupsGb.Text = "Audiobook Fix-ups";
+			// 
+			// moveMoovAtomCbox
+			// 
+			this.moveMoovAtomCbox.AutoSize = true;
+			this.moveMoovAtomCbox.Location = new System.Drawing.Point(23, 133);
+			this.moveMoovAtomCbox.Name = "moveMoovAtomCbox";
+			this.moveMoovAtomCbox.Size = new System.Drawing.Size(188, 19);
+			this.moveMoovAtomCbox.TabIndex = 14;
+			this.moveMoovAtomCbox.Text = "[MoveMoovToBeginning desc]";
+			this.moveMoovAtomCbox.UseVisualStyleBackColor = true;
 			// 
 			// stripUnabridgedCbox
 			// 
@@ -701,7 +713,7 @@
 			// 
 			this.chapterTitleTemplateGb.Controls.Add(this.chapterTitleTemplateBtn);
 			this.chapterTitleTemplateGb.Controls.Add(this.chapterTitleTemplateTb);
-			this.chapterTitleTemplateGb.Location = new System.Drawing.Point(6, 335);
+			this.chapterTitleTemplateGb.Location = new System.Drawing.Point(6, 360);
 			this.chapterTitleTemplateGb.Name = "chapterTitleTemplateGb";
 			this.chapterTitleTemplateGb.Size = new System.Drawing.Size(842, 54);
 			this.chapterTitleTemplateGb.TabIndex = 18;
@@ -738,7 +750,7 @@
 			this.lameOptionsGb.Controls.Add(this.groupBox2);
 			this.lameOptionsGb.Location = new System.Drawing.Point(415, 6);
 			this.lameOptionsGb.Name = "lameOptionsGb";
-			this.lameOptionsGb.Size = new System.Drawing.Size(433, 323);
+			this.lameOptionsGb.Size = new System.Drawing.Size(433, 348);
 			this.lameOptionsGb.TabIndex = 14;
 			this.lameOptionsGb.TabStop = false;
 			this.lameOptionsGb.Text = "Mp3 Encoding Options";
@@ -1240,5 +1252,6 @@
         private System.Windows.Forms.CheckBox useCoverAsFolderIconCb;
 		private System.Windows.Forms.ComboBox clipsBookmarksFormatCb;
 		private System.Windows.Forms.CheckBox downloadClipsBookmarksCbox;
+		private System.Windows.Forms.CheckBox moveMoovAtomCbox;
 	}
 }

--- a/Source/_Tests/LibationFileManager.Tests/TemplatesTests.cs
+++ b/Source/_Tests/LibationFileManager.Tests/TemplatesTests.cs
@@ -153,6 +153,7 @@ namespace TemplatesTests
 		[DataRow("<filedate[h]>", @"C:\foo\bar", ".m4b", @"C:\foo\bar\＜filedate[h]＞.m4b")]
 		[DataRow("< filedate[yyyy]>", @"C:\foo\bar", ".m4b", @"C:\foo\bar\＜ filedate[yyyy]＞.m4b")]
 		[DataRow("<filedate[yyyy][]>", @"C:\foo\bar", ".m4b", @"C:\foo\bar\＜filedate[yyyy][]＞.m4b")]
+		[DataRow("<filedate[[yyyy]]>", @"C:\foo\bar", ".m4b", @"C:\foo\bar\＜filedate[[yyyy]]＞.m4b")]
 		[DataRow("<filedate[yyyy[]]>", @"C:\foo\bar", ".m4b", @"C:\foo\bar\＜filedate[yyyy[]]＞.m4b")]
 		[DataRow("<filedate yyyy]>", @"C:\foo\bar", ".m4b", @"C:\foo\bar\＜filedate yyyy]＞.m4b")]
 		[DataRow("<filedate ]yyyy]>", @"C:\foo\bar", ".m4b", @"C:\foo\bar\＜filedate ]yyyy]＞.m4b")]


### PR DESCRIPTION
#459 is fixed. I also upgraded AAXClean because there was a really weird bug that would only present itself when using the nuget package. When cancelling an mp3 conversion, System.Stream threw a ExecutionEngineException. According to the docs, that's not even used anymore in .net. I don't know the problem, but upgrading NAudio.Lame_SA from net5.0 to net6.0 fixed it.


I also added the option to move the moov atom to the beginning of the file.