### PR TITLE
Improve library scan speed and Track and display book availability

### DIFF
--- a/Source/ApplicationServices/LibraryCommands.cs
+++ b/Source/ApplicationServices/LibraryCommands.cs
@@ -467,6 +467,7 @@ namespace ApplicationServices
 
             var results = libraryBooks
                 .AsParallel()
+                .Where(lb => !lb.AbsentFromLastScan)
                 .Select(lb => Liberated_Status(lb.Book))
                 .ToList();
             var booksFullyBackedUp = results.Count(r => r == LiberatedStatus.Liberated);

--- a/Source/ApplicationServices/LibraryExporter.cs
+++ b/Source/ApplicationServices/LibraryExporter.cs
@@ -106,6 +106,12 @@ namespace ApplicationServices
 
 		[Name("Language")]
         public string Language { get; set; }
+
+		[Name("LastDownloaded")]
+		public DateTime? LastDownloaded { get; set; }
+
+		[Name("LastDownloadedVersion")]
+        public string LastDownloadedVersion { get; set; }
     }
 	public static class LibToDtos
 	{
@@ -140,7 +146,10 @@ namespace ApplicationServices
 				PdfStatus = a.Book.UserDefinedItem.PdfStatus.ToString(),
 				ContentType = a.Book.ContentType.ToString(),
 				AudioFormat = a.Book.AudioFormat.ToString(),
-				Language = a.Book.Language
+				Language = a.Book.Language,
+				LastDownloaded = a.Book.UserDefinedItem.LastDownloaded,
+				LastDownloadedVersion = a.Book.UserDefinedItem.LastDownloadedVersion?.ToString() ?? "",
+
 			}).ToList();
 	}
 	public static class LibraryExporter
@@ -212,7 +221,9 @@ namespace ApplicationServices
 				nameof(ExportDto.PdfStatus),
 				nameof(ExportDto.ContentType),
 				nameof(ExportDto.AudioFormat),
-                nameof(ExportDto.Language)
+                nameof(ExportDto.Language),
+                nameof(ExportDto.LastDownloaded),
+                nameof(ExportDto.LastDownloadedVersion),
             };
 			var col = 0;
 			foreach (var c in columns)
@@ -238,9 +249,9 @@ namespace ApplicationServices
 
 				row.CreateCell(col++).SetCellValue(dto.Account);
 
-				var dateAddedCell = row.CreateCell(col++);
-				dateAddedCell.CellStyle = dateStyle;
-				dateAddedCell.SetCellValue(dto.DateAdded);
+				var dateCell = row.CreateCell(col++);
+				dateCell.CellStyle = dateStyle;
+				dateCell.SetCellValue(dto.DateAdded);
 
 				row.CreateCell(col++).SetCellValue(dto.AudibleProductId);
 				row.CreateCell(col++).SetCellValue(dto.Locale);
@@ -280,6 +291,15 @@ namespace ApplicationServices
 				row.CreateCell(col++).SetCellValue(dto.ContentType);
                 row.CreateCell(col++).SetCellValue(dto.AudioFormat);
                 row.CreateCell(col++).SetCellValue(dto.Language);
+
+				if (dto.LastDownloaded.HasValue)
+				{
+					dateCell = row.CreateCell(col);
+					dateCell.CellStyle = dateStyle;
+					dateCell.SetCellValue(dto.LastDownloaded.Value);
+				}
+
+                row.CreateCell(++col).SetCellValue(dto.LastDownloadedVersion);
 
                 rowIndex++;
 			}

--- a/Source/AudibleUtilities/ApiExtended.cs
+++ b/Source/AudibleUtilities/ApiExtended.cs
@@ -2,8 +2,9 @@
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
-using System.Threading;
+using System.Threading.Channels;
 using System.Threading.Tasks;
+using System.Diagnostics;
 using AudibleApi;
 using AudibleApi.Common;
 using Dinah.Core;
@@ -18,6 +19,9 @@ namespace AudibleUtilities
 	public class ApiExtended
 	{
 		public Api Api { get; private set; }
+
+		private const int MaxConcurrency = 10;
+		private const int BatchSize = 50;
 
 		private ApiExtended(Api api) => Api = api;
 
@@ -85,35 +89,49 @@ namespace AudibleUtilities
 
 		private async Task<List<Item>> getItemsAsync(LibraryOptions libraryOptions, bool importEpisodes)
 		{
-			var items = new List<Item>();
-
 			Serilog.Log.Logger.Debug("Beginning library scan.");
 
-			List<Task<List<Item>>> getChildEpisodesTasks = new();
+			var episodeChannel = Channel.CreateBounded<Task<List<Item>>>(
+				new BoundedChannelOptions(1)
+				{
+					SingleReader = true,
+					SingleWriter = false,
+					FullMode = BoundedChannelFullMode.Wait
+				});
 
-			int count = 0, maxConcurrentEpisodeScans = 5;
-			using SemaphoreSlim concurrencySemaphore = new(maxConcurrentEpisodeScans);
+			int count = 0;
+			List<Item> items = new();
+			List<Item> seriesItems = new();
 
-			await foreach (var item in Api.GetLibraryItemAsyncEnumerable(libraryOptions))
+			var sw = Stopwatch.StartNew();
+
+			await foreach (var item in Api.GetLibraryItemAsyncEnumerable(libraryOptions, BatchSize, MaxConcurrency))
 			{
 				if ((item.IsEpisodes || item.IsSeriesParent) && importEpisodes)
-				{
-					//Get child episodes asynchronously and await all at the end
-					getChildEpisodesTasks.Add(getChildEpisodesAsync(concurrencySemaphore, item));
-				}
+					seriesItems.Add(item);
 				else if (!item.IsEpisodes && !item.IsSeriesParent)
 					items.Add(item);
 
 				count++;
 			}
 
-			Serilog.Log.Logger.Debug("Library scan complete. Found {count} books and series. Waiting on {getChildEpisodesTasksCount} series episode scans to complete.", count, getChildEpisodesTasks.Count);
+			Serilog.Log.Logger.Debug("Library scan complete. Found {count} books and series. Waiting on series episode scans to complete.", count);
+			Serilog.Log.Logger.Debug("Beginning episode scan.");
 
-			//await and add all episodes from all parents
-			foreach (var epList in await Task.WhenAll(getChildEpisodesTasks))
-				items.AddRange(epList);
+			count = 0;
+			var episodeDlTask = scanAllSeries(seriesItems, episodeChannel.Writer);
 
-			Serilog.Log.Logger.Debug("Completed library scan.");
+			await foreach (var ep in getAllEpisodesAsync(episodeChannel.Reader, MaxConcurrency))
+			{
+				items.Add(ep);
+				count++;
+			}
+
+			await episodeDlTask;
+
+			sw.Stop();
+			Serilog.Log.Logger.Debug("Episode scan complete. Found {count} episodes and series.", count);
+			Serilog.Log.Logger.Debug($"Completed library scan in {sw.Elapsed.TotalMilliseconds:F0} ms.");
 
 #if DEBUG
 			//// this will not work for multi accounts
@@ -146,165 +164,164 @@ namespace AudibleUtilities
 
 		#region episodes and podcasts
 
-		private async Task<List<Item>> getChildEpisodesAsync(SemaphoreSlim concurrencySemaphore, Item parent)
+		private async IAsyncEnumerable<Item> getAllEpisodesAsync(ChannelReader<Task<List<Item>>> allEpisodes, int maxConcurrency)
 		{
-			await concurrencySemaphore.WaitAsync();
+			List<Task<List<Item>>> concurentGets = new();
 
+			for (int i = 0; i < maxConcurrency && await allEpisodes.WaitToReadAsync(); i++)
+				concurentGets.Add(await allEpisodes.ReadAsync());
+
+			while (concurentGets.Count > 0)
+			{
+				var completed = await Task.WhenAny(concurentGets);
+				concurentGets.Remove(completed);
+
+				if (await allEpisodes.WaitToReadAsync())
+					concurentGets.Add(await allEpisodes.ReadAsync());
+
+				foreach (var item in completed.Result)
+					yield return item;
+			}
+		}
+
+		private async Task scanAllSeries(IEnumerable<Item> seriesItems, ChannelWriter<Task<List<Item>>> allEpisodes)
+		{
 			try
 			{
-				Serilog.Log.Logger.Debug("Beginning episode scan for {parent}", parent);
+				List<Task> episodeScanTasks = new();
 
-				List<Item> children;
-
-				if (parent.IsEpisodes)
+				foreach (var item in seriesItems)
 				{
-					//The 'parent' is a single episode that was added to the library.
-					//Get the episode's parent and add it to the database.
+					if (item.IsEpisodes)
+						await allEpisodes.WriteAsync(getEpisodeParentAsync(item));
+					else if (item.IsSeriesParent)
+						episodeScanTasks.Add(getParentEpisodesAsync(allEpisodes, item));
+				}
 
-					Serilog.Log.Logger.Debug("Supplied Parent is an episode. Beginning parent scan for {parent}", parent);
+				await Task.WhenAll(episodeScanTasks);
+			}
+			finally { allEpisodes.Complete(); }
+		}
 
-					children = new() { parent };
+		private async Task<List<Item>> getEpisodeParentAsync(Item episode)
+		{
+			//Item is a single episode that was added to the library.
+			//Get the episode's parent and add it to the database.
 
-					var parentAsins = parent.Relationships
-						.Where(r => r.RelationshipToProduct == RelationshipToProduct.Parent)
-						.Select(p => p.Asin);
+			Serilog.Log.Logger.Debug("Supplied Parent is an episode. Beginning parent scan for {parent}", episode);
 
-					var seriesParents = await Api.GetCatalogProductsAsync(parentAsins, CatalogOptions.ResponseGroupOptions.ALL_OPTIONS);
+			List<Item> children = new() { episode };
 
-					int numSeriesParents = seriesParents.Count(p => p.IsSeriesParent);
-					if (numSeriesParents != 1)
-					{
-						//There should only ever be 1 top-level parent per episode. If not, log
-						//so we can figure out what to do about those special cases, and don't
-						//import the episode.
-						JsonSerializerSettings Settings = new()
-						{
-							MetadataPropertyHandling = MetadataPropertyHandling.Ignore,
-							DateParseHandling = DateParseHandling.None,
-							Converters =
-							{
-								new IsoDateTimeConverter { DateTimeStyles = DateTimeStyles.AssumeUniversal }
-							},
-						};
-						Serilog.Log.Logger.Error($"Found {numSeriesParents} parents for {parent.Asin}\r\nEpisode Product:\r\n{JsonConvert.SerializeObject(parent, Formatting.None, Settings)}");
-						return new List<Item>();
+			var parentAsins = episode.Relationships
+				.Where(r => r.RelationshipToProduct == RelationshipToProduct.Parent)
+				.Select(p => p.Asin);
+
+			var seriesParents = await Api.GetCatalogProductsAsync(parentAsins, CatalogOptions.ResponseGroupOptions.ALL_OPTIONS);
+
+			int numSeriesParents = seriesParents.Count(p => p.IsSeriesParent);
+			if (numSeriesParents != 1)
+			{
+				//There should only ever be 1 top-level parent per episode. If not, log
+				//so we can figure out what to do about those special cases, and don't
+				//import the episode.
+				JsonSerializerSettings Settings = new()
+				{
+					MetadataPropertyHandling = MetadataPropertyHandling.Ignore,
+					DateParseHandling = DateParseHandling.None,
+					Converters = {
+						new IsoDateTimeConverter { DateTimeStyles = DateTimeStyles.AssumeUniversal }
 					}
+				};
+				Serilog.Log.Logger.Error($"Found {numSeriesParents} parents for {episode.Asin}\r\nEpisode Product:\r\n{JsonConvert.SerializeObject(episode, Formatting.None, Settings)}");
+				return new();
+			}
 
-					var realParent = seriesParents.Single(p => p.IsSeriesParent);
-					realParent.PurchaseDate = parent.PurchaseDate;
+			var parent = seriesParents.Single(p => p.IsSeriesParent);
+			parent.PurchaseDate = episode.PurchaseDate;
 
-					Serilog.Log.Logger.Debug("Completed parent scan for {parent}", parent); 
-					parent = realParent;
-				}
-				else
+			setSeries(parent, children);
+			children.Add(parent);
+
+			Serilog.Log.Logger.Debug("Completed parent scan for {episode}", episode);
+
+			return children;
+		}
+
+		private async Task getParentEpisodesAsync(ChannelWriter<Task<List<Item>>> channel, Item parent)
+		{
+			Serilog.Log.Logger.Debug("Beginning episode scan for {parent}", parent);
+
+			var episodeIds = parent.Relationships
+				.Where(r => r.RelationshipToProduct == RelationshipToProduct.Child && r.RelationshipType == RelationshipType.Episode)
+				.Select(r => r.Asin);
+
+			for (int batchNum = 0; episodeIds.Any(); batchNum++)
+			{
+				var batch = episodeIds.Take(BatchSize);
+
+				await channel.WriteAsync(getEpisodeBatchAsync(batchNum, parent, batch));
+
+				episodeIds = episodeIds.Skip(BatchSize);
+			}
+		}
+
+		private async Task<List<Item>> getEpisodeBatchAsync(int batchNum, Item parent, IEnumerable<string> childrenIds)
+		{
+			try
+			{
+				List<Item> episodeBatch = await Api.GetCatalogProductsAsync(childrenIds, CatalogOptions.ResponseGroupOptions.ALL_OPTIONS);
+
+				setSeries(parent, episodeBatch);
+
+				if (batchNum == 0)
+					episodeBatch.Add(parent);
+
+				Serilog.Log.Logger.Debug($"Batch {batchNum}: {episodeBatch.Count} results\t({{parent}})", parent);
+
+				return episodeBatch;
+			}
+			catch (Exception ex)
+			{
+				Serilog.Log.Logger.Error(ex, "Error fetching batch of episodes. {@DebugInfo}", new
 				{
-					children = await getEpisodeChildrenAsync(parent);
-					if (!children.Any())
-						return new();
-				}
+					ParentId = parent.Asin,
+					ParentTitle = parent.Title,
+					BatchNumber = batchNum,
+					ChildIdBatch = childrenIds
+				});
+				throw;
+			}
+		}
 
-				//A series parent will always have exactly 1 Series
-				parent.Series = new Series[]
+		private static void setSeries(Item parent, IEnumerable<Item> children)
+		{
+			//A series parent will always have exactly 1 Series
+			parent.Series = new[]
+			{
+				new Series
+				{
+					Asin = parent.Asin,
+					Sequence = "-1",
+					Title = parent.TitleWithSubtitle
+				}
+			};
+
+			foreach (var child in children)
+			{
+				// use parent's 'DateAdded'. DateAdded is just a convenience prop for: PurchaseDate.UtcDateTime
+				child.PurchaseDate = parent.PurchaseDate;
+				// parent is essentially a series
+				child.Series = new[]
 				{
 					new Series
 					{
 						Asin = parent.Asin,
-						Sequence = "-1",
+						// This should properly be Single() not FirstOrDefault(), but FirstOrDefault is defensive for malformed data from audible
+						Sequence = parent.Relationships.FirstOrDefault(r => r.Asin == child.Asin)?.Sort?.ToString() ?? "0",
 						Title = parent.TitleWithSubtitle
 					}
 				};
-
-				foreach (var child in children)
-				{
-					// use parent's 'DateAdded'. DateAdded is just a convenience prop for: PurchaseDate.UtcDateTime
-					child.PurchaseDate = parent.PurchaseDate;
-					// parent is essentially a series
-					child.Series = new Series[]
-					{
-						new Series
-						{
-							Asin = parent.Asin,
-							// This should properly be Single() not FirstOrDefault(), but FirstOrDefault is defensive for malformed data from audible
-							Sequence = parent.Relationships.FirstOrDefault(r => r.Asin == child.Asin)?.Sort?.ToString() ?? "0",
-							Title = parent.TitleWithSubtitle
-						}
-					};
-				}
-
-				children.Add(parent);
-
-				Serilog.Log.Logger.Debug("Completed episode scan for {parent}", parent);
-
-				return children;
 			}
-			finally
-			{
-				concurrencySemaphore.Release();
-			}
-		}
-
-		private async Task<List<Item>> getEpisodeChildrenAsync(Item parent)
-		{
-			var childrenIds = parent.Relationships
-				.Where(r => r.RelationshipToProduct == RelationshipToProduct.Child && r.RelationshipType == RelationshipType.Episode)
-				.Select(r => r.Asin)
-				.ToList();
-
-			// fetch children in batches
-			const int batchSize = 20;
-
-			var results = new List<Item>();
-
-			for (var i = 1; ; i++)
-			{
-				var idBatch = childrenIds.Skip((i - 1) * batchSize).Take(batchSize).ToList();
-				if (!idBatch.Any())
-					break;
-
-				List<Item> childrenBatch;
-				try
-				{
-					childrenBatch = await Api.GetCatalogProductsAsync(idBatch, CatalogOptions.ResponseGroupOptions.ALL_OPTIONS);
-#if DEBUG
-					//var childrenBatchDebug = childrenBatch.Select(i => i.ToJson()).Aggregate((a, b) => $"{a}\r\n\r\n{b}");
-					//System.IO.File.WriteAllText($"children of {parent.Asin}.json", childrenBatchDebug);
-#endif
-				}
-				catch (Exception ex)
-				{
-					Serilog.Log.Logger.Error(ex, "Error fetching batch of episodes. {@DebugInfo}", new
-					{
-						ParentId = parent.Asin,
-						ParentTitle = parent.Title,
-						BatchNumber = i,
-						ChildIdBatch = idBatch
-					});
-					throw;
-				}
-
-				Serilog.Log.Logger.Debug($"Batch {i}: {childrenBatch.Count} results\t({{parent}})", parent);
-				// the service returned no results. probably indicates an error. stop running batches
-				if (!childrenBatch.Any())
-					break;
-
-				results.AddRange(childrenBatch);
-			}
-
-			Serilog.Log.Logger.Debug("Parent episodes/podcasts series. Children found. {@DebugInfo}", new
-			{
-				ParentId = parent.Asin,
-				ParentTitle = parent.Title,
-				ChildCount = childrenIds.Count
-			});
-
-			if (childrenIds.Count != results.Count)
-			{
-				var ex = new ApplicationException($"Mis-match: Children defined by parent={childrenIds.Count}. Children returned by batches={results.Count}");
-				Serilog.Log.Logger.Error(ex, "{parent} - Quantity of series episodes defined by parent does not match quantity returned by batch fetching.", parent);
-				throw ex;
-			}
-
-			return results;
 		}
 		#endregion
 	}

--- a/Source/AudibleUtilities/ApiExtended.cs
+++ b/Source/AudibleUtilities/ApiExtended.cs
@@ -97,7 +97,7 @@ namespace AudibleUtilities
 
 			var sw = Stopwatch.StartNew();
 
-			//Scan the library for all added books, and add ay episode-type items to seriesItems to be scanned for episodes/parents
+			//Scan the library for all added books, and add any episode-type items to seriesItems to be scanned for episodes/parents
 			await foreach (var item in Api.GetLibraryItemAsyncEnumerable(libraryOptions, BatchSize, MaxConcurrency))
 			{
 				if ((item.IsEpisodes || item.IsSeriesParent) && importEpisodes)
@@ -124,8 +124,8 @@ namespace AudibleUtilities
 			//This method blocks until episodeChannel.Writer is closed by scanAllSeries()
 			await foreach (var ep in getAllEpisodesAsync(episodeChannel.Reader))
 			{
-				items.Add(ep);
-				count++;
+				items.AddRange(ep);
+				count += ep.Count;
 			}
 
 			//Be sure to await the scanAllSeries Task so that any exceptions are thrown
@@ -172,7 +172,7 @@ namespace AudibleUtilities
 		/// the Items are yielded, that task is removed from the list, and a new get task is read from
 		/// the channel.
 		/// </summary>
-		private async IAsyncEnumerable<Item> getAllEpisodesAsync(ChannelReader<Task<List<Item>>> channel)
+		private async IAsyncEnumerable<List<Item>> getAllEpisodesAsync(ChannelReader<Task<List<Item>>> channel)
 		{
 			List<Task<List<Item>>> concurentGets = new();
 
@@ -187,8 +187,7 @@ namespace AudibleUtilities
 				if (await channel.WaitToReadAsync())
 					concurentGets.Add(await channel.ReadAsync());
 
-				foreach (var item in completed.Result)
-					yield return item;
+				yield return completed.Result;
 			}
 		}
 

--- a/Source/DataLayer/EfClasses/LibraryBook.cs
+++ b/Source/DataLayer/EfClasses/LibraryBook.cs
@@ -12,6 +12,7 @@ namespace DataLayer
         public string Account { get; private set; }
 
         public bool IsDeleted { get; set; }
+        public bool AbsentFromLastScan { get; set; }
 
         private LibraryBook() { }
         public LibraryBook(Book book, DateTime dateAdded, string account)

--- a/Source/DataLayer/Migrations/20230308013410_AddAbsentFromLastScan.Designer.cs
+++ b/Source/DataLayer/Migrations/20230308013410_AddAbsentFromLastScan.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using DataLayer;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -10,9 +11,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace DataLayer.Migrations
 {
     [DbContext(typeof(LibationContext))]
-    partial class LibationContextModelSnapshot : ModelSnapshot
+    [Migration("20230308013410_AddAbsentFromLastScan")]
+    partial class AddAbsentFromLastScan
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder.HasAnnotation("ProductVersion", "7.0.3");

--- a/Source/DataLayer/Migrations/20230308013410_AddAbsentFromLastScan.cs
+++ b/Source/DataLayer/Migrations/20230308013410_AddAbsentFromLastScan.cs
@@ -1,0 +1,29 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace DataLayer.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddAbsentFromLastScan : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<bool>(
+                name: "AbsentFromLastScan",
+                table: "LibraryBooks",
+                type: "INTEGER",
+                nullable: false,
+                defaultValue: false);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "AbsentFromLastScan",
+                table: "LibraryBooks");
+        }
+    }
+}

--- a/Source/DataLayer/QueryObjects/LibraryBookQueries.cs
+++ b/Source/DataLayer/QueryObjects/LibraryBookQueries.cs
@@ -107,8 +107,9 @@ namespace DataLayer
             => bookList
                 .Where(
                     lb =>
-                        lb.Book.UserDefinedItem.BookStatus is LiberatedStatus.NotLiberated or LiberatedStatus.PartialDownload
-                        || lb.Book.UserDefinedItem.PdfStatus is LiberatedStatus.NotLiberated or LiberatedStatus.PartialDownload
+                        !lb.AbsentFromLastScan &&
+                        (lb.Book.UserDefinedItem.BookStatus is LiberatedStatus.NotLiberated or LiberatedStatus.PartialDownload
+                        || lb.Book.UserDefinedItem.PdfStatus is LiberatedStatus.NotLiberated or LiberatedStatus.PartialDownload)
                     );
     }
 }

--- a/Source/DtoImporterService/ImportItem.cs
+++ b/Source/DtoImporterService/ImportItem.cs
@@ -8,5 +8,7 @@ namespace DtoImporterService
 		public Item DtoItem { get; set; }
 		public string AccountId { get; set; }
 		public string LocaleName { get; set; }
+		public override string ToString()
+			=> DtoItem is null ? base.ToString() : $"[{DtoItem.ProductId}] {DtoItem.Title}";
 	}
 }

--- a/Source/DtoImporterService/LibraryBookImporter.cs
+++ b/Source/DtoImporterService/LibraryBookImporter.cs
@@ -94,6 +94,6 @@ namespace DtoImporterService
 		//confidence that it won't yield many/any false positives.
 		private static bool isPlusTitleUnavailable(ImportItem item)
 			=> item.DtoItem.IsAyce is true
-			&& !item.DtoItem.Plans.Any(p => p.PlanName.ContainsInsensitive("Minerva") || p.PlanName.ContainsInsensitive("Free"));
+			&& item.DtoItem.Plans?.Any(p => p.PlanName.ContainsInsensitive("Minerva") || p.PlanName.ContainsInsensitive("Free")) is not true;
 	}
 }

--- a/Source/DtoImporterService/LibraryBookImporter.cs
+++ b/Source/DtoImporterService/LibraryBookImporter.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using AudibleUtilities;
 using DataLayer;
+using Dinah.Core;
 using Dinah.Core.Collections.Generic;
 
 namespace DtoImporterService
@@ -40,9 +41,8 @@ namespace DtoImporterService
 			//
 			// CURRENT SOLUTION: don't re-insert
 
-			var currentLibraryProductIds = DbContext.LibraryBooks.Select(l => l.Book.AudibleProductId).ToList();
 			var newItems = importItems
-				.Where(dto => !currentLibraryProductIds.Contains(dto.DtoItem.ProductId))
+				.ExceptBy(DbContext.LibraryBooks.Select(lb => lb.Book.AudibleProductId), imp => imp.DtoItem.ProductId)
 				.ToList();
 
 			// if 2 accounts try to import the same book in the same transaction: error since we're only tracking and pulling by asin.
@@ -55,7 +55,11 @@ namespace DtoImporterService
 				var libraryBook = new LibraryBook(
 					bookImporter.Cache[newItem.DtoItem.ProductId],
 					newItem.DtoItem.DateAdded,
-					newItem.AccountId);
+					newItem.AccountId)
+				{
+					AbsentFromLastScan = isPlusTitleUnavailable(newItem)
+				};
+
 				try
 				{
 					DbContext.LibraryBooks.Add(libraryBook);
@@ -66,8 +70,30 @@ namespace DtoImporterService
 				}
 			}
 
+			//If an existing Book wasn't found in the import, the owning LibraryBook's Book will be null. 
+			foreach (var nullBook in DbContext.LibraryBooks.AsEnumerable().Where(lb => lb.Book is null))
+				nullBook.AbsentFromLastScan = true;
+
+			//Join importItems on LibraryBooks before iterating over LibraryBooks to avoid
+			//quadratic complexity caused by searching all of importItems for each LibraryBook.
+			//Join uses hashing, so complexity should approach O(N) instead of O(N^2).
+			var items_lbs
+			   = importItems
+			   .Join(DbContext.LibraryBooks, o => (o.AccountId, o.DtoItem.ProductId), i => (i.Account, i.Book?.AudibleProductId), (o, i) => (o, i));
+
+			foreach ((ImportItem item, LibraryBook lb) in items_lbs)
+				lb.AbsentFromLastScan = isPlusTitleUnavailable(item);
+
 			var qtyNew = hash.Count;
 			return qtyNew;
 		}
+
+
+		//This SEEMS to work to detect plus titles which are no longer available.
+		//I have my doubts it won't yield false negatives, but I have more
+		//confidence that it won't yield many/any false positives.
+		private static bool isPlusTitleUnavailable(ImportItem item)
+			=> item.DtoItem.IsAyce is true
+			&& !item.DtoItem.Plans.Any(p => p.PlanName.ContainsInsensitive("Minerva") || p.PlanName.ContainsInsensitive("Free"));
 	}
 }

--- a/Source/LibationAvalonia/Assets/LibationStyles.xaml
+++ b/Source/LibationAvalonia/Assets/LibationStyles.xaml
@@ -8,6 +8,8 @@
 		<SolidColorBrush x:Key="ProcessQueueBookCancelledBrush" Color="Khaki" />
 		<SolidColorBrush x:Key="ProcessQueueBookDefaultBrush" Color="{StaticResource SystemAltHighColor}" />
 		<SolidColorBrush x:Key="ProcessQueueBookBorderBrush" Color="Gray" />
+		<SolidColorBrush x:Key="DisabledGrayBrush" Color="#60D3D3D3" />
+		
 	</Styles.Resources>
 	<Style Selector="TextBox[IsReadOnly=true]">
 		<Setter Property="Background" Value="LightGray" />

--- a/Source/LibationAvalonia/Dialogs/ImageDisplayDialog.axaml.cs
+++ b/Source/LibationAvalonia/Dialogs/ImageDisplayDialog.axaml.cs
@@ -1,8 +1,5 @@
-using Avalonia;
-using Avalonia.Controls;
 using Avalonia.Markup.Xaml;
 using Avalonia.Media.Imaging;
-using Avalonia.Platform;
 using System;
 using System.ComponentModel;
 using System.IO;
@@ -16,22 +13,7 @@ namespace LibationAvalonia.Dialogs
 		public string PictureFileName { get; set; }
 		public string BookSaveDirectory { get; set; }
 
-		private byte[] _coverBytes;
-		public byte[] CoverBytes
-		{
-			get => _coverBytes;
-			set
-			{
-				_coverBytes = value;
-				var ms = new MemoryStream(_coverBytes);
-				ms.Position = 0;
-				_bitmapHolder.CoverImage = new Bitmap(ms);
-			}
-		}
-
-
 		private readonly BitmapHolder _bitmapHolder = new BitmapHolder();
-
 
 		public ImageDisplayDialog()
 		{
@@ -43,6 +25,21 @@ namespace LibationAvalonia.Dialogs
 		private void InitializeComponent()
 		{
 			AvaloniaXamlLoader.Load(this);
+		}
+
+		public void SetCoverBytes(byte[] cover)
+		{
+			try
+			{
+				var ms = new MemoryStream(cover);
+				_bitmapHolder.CoverImage = new Bitmap(ms);
+			}
+			catch (Exception ex)
+			{
+				Serilog.Log.Logger.Error(ex, "Error loading cover art for {file}", PictureFileName);
+				using var ms = App.OpenAsset("img-coverart-prod-unavailable_500x500.jpg");
+				_bitmapHolder.CoverImage = new Bitmap(ms);				
+			}
 		}
 
 		public async void SaveImage_Clicked(object sender, Avalonia.Interactivity.RoutedEventArgs e)
@@ -70,7 +67,7 @@ namespace LibationAvalonia.Dialogs
 
 			try
 			{
-				File.WriteAllBytes(uri.LocalPath, CoverBytes);
+				_bitmapHolder.CoverImage.Save(uri.LocalPath);
 			}
 			catch (Exception ex)
 			{

--- a/Source/LibationAvalonia/ViewModels/GridEntry.cs
+++ b/Source/LibationAvalonia/ViewModels/GridEntry.cs
@@ -78,7 +78,6 @@ namespace LibationAvalonia.ViewModels
 		public abstract bool? Remove { get; set; }
 		public abstract LiberateButtonStatus Liberate { get; }
 		public abstract BookTags BookTags { get; }
-		public abstract bool IsSeries { get; }
 		public abstract bool IsEpisode { get; }
 		public abstract bool IsBook { get; }
 		public IBrush BackgroundBrush => IsEpisode ? App.SeriesEntryGridBackgroundBrush : Brushes.Transparent;

--- a/Source/LibationAvalonia/ViewModels/GridEntry.cs
+++ b/Source/LibationAvalonia/ViewModels/GridEntry.cs
@@ -1,5 +1,6 @@
 ﻿using ApplicationServices;
 using Avalonia.Media;
+using Avalonia.Media.Imaging;
 using DataLayer;
 using Dinah.Core;
 using FileLiberator;
@@ -139,8 +140,7 @@ namespace LibationAvalonia.ViewModels
 				PictureStorage.PictureCached += PictureStorage_PictureCached;
 
 			// Mutable property. Set the field so PropertyChanged isn't fired.
-			using var ms = new System.IO.MemoryStream(picture);
-			_cover = new Avalonia.Media.Imaging.Bitmap(ms);
+			_cover = loadImage(picture);
 		}
 
 		private void PictureStorage_PictureCached(object sender, PictureCachedEventArgs e)
@@ -156,11 +156,27 @@ namespace LibationAvalonia.ViewModels
             // logic validation
             if (e.Definition.PictureId == Book.PictureId)
 			{
-				using var ms = new System.IO.MemoryStream(e.Picture);
-				Cover = new Avalonia.Media.Imaging.Bitmap(ms);
+				Cover = loadImage(e.Picture);
 				PictureStorage.PictureCached -= PictureStorage_PictureCached;
 			}
 		}
+
+		private Bitmap loadImage(byte[] picture)
+		{
+			try
+			{
+				using var ms = new System.IO.MemoryStream(picture);
+				return new Bitmap(ms);
+			}
+			catch (Exception ex)
+			{
+				Serilog.Log.Logger.Error(ex, "Error loading cover art for {Book}", Book);
+				return DefaultImage;
+			}
+		}
+
+		private static Bitmap _defaultImage;
+		private static Bitmap DefaultImage => _defaultImage ??= new Bitmap(App.OpenAsset("img-coverart-prod-unavailable_80x80.jpg"));
 
 		#endregion
 

--- a/Source/LibationAvalonia/ViewModels/LibraryBookEntry.cs
+++ b/Source/LibationAvalonia/ViewModels/LibraryBookEntry.cs
@@ -44,13 +44,12 @@ namespace LibationAvalonia.ViewModels
 					_pdfStatus = LibraryCommands.Pdf_Status(LibraryBook.Book);
 					lastStatusUpdate = DateTime.Now;
 				}
-				return new LiberateButtonStatus(IsSeries) { BookStatus = _bookStatus, PdfStatus = _pdfStatus };
+				return new LiberateButtonStatus(isSeries: false, LibraryBook.AbsentFromLastScan) { BookStatus = _bookStatus, PdfStatus = _pdfStatus };
 			}
 		}
 
 		public override BookTags BookTags => new() { Tags = string.Join("\r\n", Book.UserDefinedItem.TagsEnumerated) };
 
-		public override bool IsSeries => false;
 		public override bool IsEpisode => Parent is not null;
 		public override bool IsBook => Parent is null;
 
@@ -93,6 +92,7 @@ namespace LibationAvalonia.ViewModels
 			SeriesIndex = Book.SeriesLink.FirstOrDefault()?.Index ?? 0;
 
 			this.RaisePropertyChanged(nameof(MyRating));
+			this.RaisePropertyChanged(nameof(Liberate));
 			UserDefinedItem.ItemChanged += UserDefinedItem_ItemChanged;
 		}
 

--- a/Source/LibationAvalonia/ViewModels/MainWindowViewModel.cs
+++ b/Source/LibationAvalonia/ViewModels/MainWindowViewModel.cs
@@ -1,6 +1,4 @@
 ﻿using ApplicationServices;
-using Avalonia.Media.Imaging;
-using Dinah.Core;
 using LibationFileManager;
 using ReactiveUI;
 
@@ -167,18 +165,6 @@ namespace LibationAvalonia.ViewModels
 			{
 				this.RaiseAndSetIfChanged(ref _libraryStats, value);
 
-				var backupsCountText
-					= !LibraryStats.HasBookResults ? "No books. Begin by importing your library"
-					: !LibraryStats.HasPendingBooks ? $"All {"book".PluralizeWithCount(LibraryStats.booksFullyBackedUp)} backed up"
-					: $"BACKUPS: No progress: {LibraryStats.booksNoProgress}  In process: {LibraryStats.booksDownloadedOnly}  Fully backed up: {LibraryStats.booksFullyBackedUp} {(LibraryStats.booksError > 0 ? $"  Errors : {LibraryStats.booksError}" : "")}";
-
-				var pdfCountText
-					= !LibraryStats.HasPdfResults ? ""
-					: LibraryStats.pdfsNotDownloaded == 0 ? $"  |  All {LibraryStats.pdfsDownloaded} PDFs downloaded"
-					: $"  |  PDFs: NOT d/l'ed: {LibraryStats.pdfsNotDownloaded} Downloaded: {LibraryStats.pdfsDownloaded}";
-
-				StatusCountText = backupsCountText + pdfCountText;
-
 				BookBackupsToolStripText
 					= LibraryStats.HasPendingBooks
 					? $"Begin _Book and PDF Backups: {LibraryStats.PendingBooks} remaining"
@@ -189,19 +175,15 @@ namespace LibationAvalonia.ViewModels
 					? $"Begin _PDF Only Backups: {LibraryStats.pdfsNotDownloaded} remaining"
 					: "All PDFs have been downloaded";
 
-				this.RaisePropertyChanged(nameof(StatusCountText));
 				this.RaisePropertyChanged(nameof(BookBackupsToolStripText));
 				this.RaisePropertyChanged(nameof(PdfBackupsToolStripText));
 			}
 		}
 
-		/// <summary> Bottom-left library statistics display text </summary>
-		public string StatusCountText { get; private set; } = "[Calculating backed up book quantities]  |  [Calculating backed up PDFs]";
 		/// <summary> The "Begin Book and PDF Backup" menu item header text </summary>
 		public string BookBackupsToolStripText { get; private set; } = "Begin _Book and PDF Backups: 0";
 		/// <summary> The "Begin PDF Only Backup" menu item header text </summary>
 		public string PdfBackupsToolStripText { get; private set; } = "Begin _PDF Only Backups: 0";
-
 
 
 		/// <summary> The number of books visible in the Products Display that have not yet been liberated </summary>

--- a/Source/LibationAvalonia/ViewModels/SeriesEntry.cs
+++ b/Source/LibationAvalonia/ViewModels/SeriesEntry.cs
@@ -46,7 +46,6 @@ namespace LibationAvalonia.ViewModels
 		public override LiberateButtonStatus Liberate { get; }
 		public override BookTags BookTags { get; } = new();
 
-		public override bool IsSeries => true;
 		public override bool IsEpisode => false;
 		public override bool IsBook => false;
 
@@ -54,7 +53,7 @@ namespace LibationAvalonia.ViewModels
 
 		public SeriesEntry(LibraryBook parent, IEnumerable<LibraryBook> children)
 		{
-			Liberate = new LiberateButtonStatus(IsSeries);
+			Liberate = new LiberateButtonStatus(isSeries: true, isAbsent: false);
 			SeriesIndex = -1;
 
 			Children = children

--- a/Source/LibationAvalonia/Views/MainWindow.VisibleBooks.cs
+++ b/Source/LibationAvalonia/Views/MainWindow.VisibleBooks.cs
@@ -154,10 +154,9 @@ namespace LibationAvalonia.Views
 			await Dispatcher.UIThread.InvokeAsync(setLiberatedVisibleMenuItem);
 		}
 		void setLiberatedVisibleMenuItem()
-			=> _viewModel.VisibleNotLiberated
-				= _viewModel.ProductsDisplay
-				.GetVisibleBookEntries()
-				.Where(lb => !lb.AbsentFromLastScan)
-				.Count(lb => lb.Book.UserDefinedItem.BookStatus == LiberatedStatus.NotLiberated);
+		{
+			var libraryStats = LibraryCommands.GetCounts(_viewModel.ProductsDisplay.GetVisibleBookEntries());
+			_viewModel.VisibleNotLiberated = libraryStats.PendingBooks;
+		}
 	}
 }

--- a/Source/LibationAvalonia/Views/MainWindow.VisibleBooks.cs
+++ b/Source/LibationAvalonia/Views/MainWindow.VisibleBooks.cs
@@ -157,6 +157,7 @@ namespace LibationAvalonia.Views
 			=> _viewModel.VisibleNotLiberated
 				= _viewModel.ProductsDisplay
 				.GetVisibleBookEntries()
+				.Where(lb => !lb.AbsentFromLastScan)
 				.Count(lb => lb.Book.UserDefinedItem.BookStatus == LiberatedStatus.NotLiberated);
 	}
 }

--- a/Source/LibationAvalonia/Views/MainWindow.axaml
+++ b/Source/LibationAvalonia/Views/MainWindow.axaml
@@ -209,7 +209,7 @@
 				<TextBlock FontSize="14" Grid.Column="0" Text="Upgrading:" VerticalAlignment="Center" IsVisible="{Binding DownloadProgress, Converter={x:Static ObjectConverters.IsNotNull}}" />
 				<ProgressBar Grid.Column="1" Margin="5,0,10,0" VerticalAlignment="Stretch" Width="100" Value="{Binding DownloadProgress}" IsVisible="{Binding DownloadProgress, Converter={x:Static ObjectConverters.IsNotNull}}"/>
 				<TextBlock FontSize="14" Grid.Column="2" Text="{Binding VisibleCountText}" VerticalAlignment="Center" />
-				<TextBlock FontSize="14" Grid.Column="3" Text="{Binding StatusCountText}" VerticalAlignment="Center" />		
+				<TextBlock FontSize="14" Grid.Column="3" Text="{Binding LibraryStats.StatusString}" VerticalAlignment="Center" />		
 			</Grid>
 		</Grid>
 	</Border>

--- a/Source/LibationAvalonia/Views/ProductsDisplay.axaml
+++ b/Source/LibationAvalonia/Views/ProductsDisplay.axaml
@@ -61,9 +61,13 @@
 				<controls:DataGridTemplateColumnExt CanUserSort="True" Width="75" Header="Liberate" SortMemberPath="Liberate" ClipboardContentBinding="{Binding Liberate.ToolTip}">
 					<DataGridTemplateColumn.CellTemplate>
 						<DataTemplate>
-							<Button Opacity="{Binding Opacity}" Padding="0" HorizontalAlignment="Stretch" VerticalAlignment="Stretch" Click="LiberateButton_Click" ToolTip.Tip="{Binding Liberate.ToolTip}">
-								<Image Source="{Binding Liberate.Image}" Stretch="None" />
-							</Button>
+							<Panel ToolTip.Tip="{Binding Liberate.ToolTip}">
+								<Button Opacity="{Binding Opacity}" Padding="0" HorizontalAlignment="Stretch" VerticalAlignment="Stretch" Click="LiberateButton_Click" IsVisible="{Binding !Liberate.IsUnavailable}">
+									<Image Source="{Binding Liberate.Image}" Stretch="None" />
+								</Button>
+								<Image Source="{Binding Liberate.Image}" Stretch="None" IsVisible="{Binding Liberate.IsUnavailable}"/>
+								<Panel Background="{StaticResource DisabledGrayBrush}" IsVisible="{Binding Liberate.IsUnavailable}" />
+							</Panel>
 						</DataTemplate>
 					</DataGridTemplateColumn.CellTemplate>
 				</controls:DataGridTemplateColumnExt>

--- a/Source/LibationAvalonia/Views/ProductsDisplay.axaml.cs
+++ b/Source/LibationAvalonia/Views/ProductsDisplay.axaml.cs
@@ -34,7 +34,7 @@ namespace LibationAvalonia.Views
 				List<LibraryBook> sampleEntries = new()
 				{
 					//context.GetLibraryBook_Flat_NoTracking("B00DCD0OXU"),
-					context.GetLibraryBook_Flat_NoTracking("B017V4IM1G"),
+					context.GetLibraryBook_Flat_NoTracking("B002V8H7G4"),
 					context.GetLibraryBook_Flat_NoTracking("B017V4IWVG"),
 					context.GetLibraryBook_Flat_NoTracking("B017V4JA2Q"),
 					context.GetLibraryBook_Flat_NoTracking("B017V4NUPO"),
@@ -84,7 +84,7 @@ namespace LibationAvalonia.Views
 			{
 				var entry = args.GridEntry;
 
-                if (entry.IsSeries)
+                if (entry.Liberate.IsSeries)
 					return;
 
                 var setDownloadMenuItem = new MenuItem()
@@ -135,7 +135,7 @@ namespace LibationAvalonia.Views
 				var convertToMp3MenuItem = new MenuItem
 				{
 					Header = "_Convert to Mp3",
-					IsEnabled = entry.Book.UserDefinedItem.BookStatus != LiberatedStatus.NotLiberated
+					IsEnabled = entry.Book.UserDefinedItem.BookStatus is LiberatedStatus.Liberated 
 				};
 				convertToMp3MenuItem.Click += (_, _) => ConvertToMp3Clicked?.Invoke(this, entry.LibraryBook);
 

--- a/Source/LibationAvalonia/Views/ProductsDisplay.axaml.cs
+++ b/Source/LibationAvalonia/Views/ProductsDisplay.axaml.cs
@@ -31,17 +31,22 @@ namespace LibationAvalonia.Views
 			if (Design.IsDesignMode)
 			{
 				using var context = DbContexts.GetContext();
-				List<LibraryBook> sampleEntries = new()
+				List<LibraryBook> sampleEntries;
+				try
 				{
-					//context.GetLibraryBook_Flat_NoTracking("B00DCD0OXU"),
-					context.GetLibraryBook_Flat_NoTracking("B002V8H7G4"),
-					context.GetLibraryBook_Flat_NoTracking("B017V4IWVG"),
-					context.GetLibraryBook_Flat_NoTracking("B017V4JA2Q"),
-					context.GetLibraryBook_Flat_NoTracking("B017V4NUPO"),
-					context.GetLibraryBook_Flat_NoTracking("B017V4NMX4"),
-					context.GetLibraryBook_Flat_NoTracking("B017V4NOZ0"),
-					context.GetLibraryBook_Flat_NoTracking("B017WJ5ZK6")
-				};
+					sampleEntries = new()
+					{
+						//context.GetLibraryBook_Flat_NoTracking("B00DCD0OXU"),try{
+						context.GetLibraryBook_Flat_NoTracking("B017WJ5ZK6"),
+						context.GetLibraryBook_Flat_NoTracking("B017V4IWVG"),
+						context.GetLibraryBook_Flat_NoTracking("B017V4JA2Q"),
+						context.GetLibraryBook_Flat_NoTracking("B017V4NUPO"),
+						context.GetLibraryBook_Flat_NoTracking("B017V4NMX4"),
+						context.GetLibraryBook_Flat_NoTracking("B017V4NOZ0"),
+						context.GetLibraryBook_Flat_NoTracking("B017WJ5ZK6")
+					};
+				}
+				catch { sampleEntries = new(); }
 
 				var pdvm = new ProductsDisplayViewModel();
 				pdvm.BindToGrid(sampleEntries);

--- a/Source/LibationAvalonia/Views/ProductsDisplay.axaml.cs
+++ b/Source/LibationAvalonia/Views/ProductsDisplay.axaml.cs
@@ -327,7 +327,7 @@ namespace LibationAvalonia.Views
 			void PictureCached(object sender, PictureCachedEventArgs e)
 			{
 				if (e.Definition.PictureId == picDef.PictureId)
-					imageDisplayDialog.CoverBytes = e.Picture;
+					imageDisplayDialog.SetCoverBytes(e.Picture);
 
 				PictureStorage.PictureCached -= PictureCached;
 			}
@@ -342,7 +342,7 @@ namespace LibationAvalonia.Views
 			imageDisplayDialog.BookSaveDirectory = AudibleFileStorage.Audio.GetDestinationDirectory(gEntry.LibraryBook);
 			imageDisplayDialog.PictureFileName = System.IO.Path.GetFileName(AudibleFileStorage.Audio.GetBooksDirectoryFilename(gEntry.LibraryBook, ".jpg"));
 			imageDisplayDialog.Title = windowTitle;
-			imageDisplayDialog.CoverBytes = initialImageBts;
+			imageDisplayDialog.SetCoverBytes(initialImageBts);
 
 			if (!isDefault)
 				PictureStorage.PictureCached -= PictureCached;

--- a/Source/LibationUiBase/IcoEncoder.cs
+++ b/Source/LibationUiBase/IcoEncoder.cs
@@ -1,0 +1,52 @@
+﻿using SixLabors.ImageSharp.PixelFormats;
+using SixLabors.ImageSharp;
+using System;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using SixLabors.ImageSharp.Formats;
+
+namespace LibationUiBase
+{
+	public class IcoEncoder : IImageEncoder
+	{
+		public bool SkipMetadata { get; init; } = true;
+
+		public void Encode<TPixel>(Image<TPixel> image, Stream stream) where TPixel : unmanaged, IPixel<TPixel>
+		{
+			// https://stackoverflow.com/a/21389253
+
+			using var ms = new MemoryStream();
+			//Knowing the image size ahead of time removes the
+			//requirement of the output stream to support seeking.
+			image.SaveAsPng(ms);
+
+			//Disposing of the BinaryWriter disposes the soutput stream. Let the caller clean up.
+			var bw = new BinaryWriter(stream);
+
+			// Header
+			bw.Write((short)0);   // 0-1 : reserved
+			bw.Write((short)1);   // 2-3 : 1=ico, 2=cur
+			bw.Write((short)1);   // 4-5 : number of images
+
+			// Image directory
+			var w = image.Width;
+			if (w >= 256) w = 0;
+			bw.Write((byte)w);                      // 0 : width of image
+			var h = image.Height;
+			if (h >= 256) h = 0;
+			bw.Write((byte)h);                      // 1 : height of image
+			bw.Write((byte)0);                      // 2 : number of colors in palette
+			bw.Write((byte)0);                      // 3 : reserved
+			bw.Write((short)0);                     // 4 : number of color planes
+			bw.Write((short)0);                     // 6 : bits per pixel
+			bw.Write((int)ms.Position);             // 8 : image size
+			bw.Write((int)stream.Position + 4);     // 12: offset of image data
+			ms.Position = 0;
+			ms.CopyTo(stream);                      // Image data
+		}
+
+		public Task EncodeAsync<TPixel>(Image<TPixel> image, Stream stream, CancellationToken cancellationToken) where TPixel : unmanaged, IPixel<TPixel>
+			=> throw new NotImplementedException();
+	}
+}

--- a/Source/LibationWinForms/Form1.BackupCounts.cs
+++ b/Source/LibationWinForms/Form1.BackupCounts.cs
@@ -13,7 +13,6 @@ namespace LibationWinForms
 			// init formattable
 			beginBookBackupsToolStripMenuItem.Format(0);
 			beginPdfBackupsToolStripMenuItem.Format(0);
-			pdfsCountsLbl.Text = "|  [Calculating backed up PDFs]";
 
 			Load += setBackupCounts;
             LibraryCommands.LibrarySizeChanged += setBackupCounts;
@@ -21,9 +20,8 @@ namespace LibationWinForms
 
 			updateCountsBw.DoWork += UpdateCountsBw_DoWork;
 			updateCountsBw.RunWorkerCompleted += exportMenuEnable;
-			updateCountsBw.RunWorkerCompleted += updateBottomBookNumbers;
+			updateCountsBw.RunWorkerCompleted += updateBottomStats;
 			updateCountsBw.RunWorkerCompleted += update_BeginBookBackups_menuItem;
-			updateCountsBw.RunWorkerCompleted += updateBottomPdfNumbers;
 			updateCountsBw.RunWorkerCompleted += udpate_BeginPdfOnlyBackups_menuItem;
 		}
 
@@ -52,27 +50,13 @@ namespace LibationWinForms
 			Invoke(() => exportLibraryToolStripMenuItem.Enabled = libraryStats.HasBookResults);
 		}
 
-		// this cannot be cleanly be FormattableToolStripMenuItem because of the optional "Errors" text
-		private const string backupsCountsLbl_Format = "BACKUPS: No progress: {0}  In process: {1}  Fully backed up: {2}";
-
-		private void updateBottomBookNumbers(object _, System.ComponentModel.RunWorkerCompletedEventArgs e)
+		private void updateBottomStats(object _, System.ComponentModel.RunWorkerCompletedEventArgs e)
 		{
 			var libraryStats = e.Result as LibraryCommands.LibraryStats;
-
-			var formatString
-				= !libraryStats.HasBookResults ? "No books. Begin by importing your library"
-				: libraryStats.booksError > 0 ? backupsCountsLbl_Format + "  Errors: {3}"
-				: libraryStats.HasPendingBooks ? backupsCountsLbl_Format
-				: $"All {"book".PluralizeWithCount(libraryStats.booksFullyBackedUp)} backed up";
-			var statusStripText = string.Format(formatString,
-				libraryStats.booksNoProgress,
-				libraryStats.booksDownloadedOnly,
-				libraryStats.booksFullyBackedUp,
-				libraryStats.booksError);
-			statusStrip1.UIThreadAsync(() => backupsCountsLbl.Text = statusStripText);
+			statusStrip1.UIThreadAsync(() => backupsCountsLbl.Text = libraryStats.StatusString);
 		}
 
-		// update 'begin book backups' menu item
+		// update 'begin book and pdf backups' menu item
 		private void update_BeginBookBackups_menuItem(object _, System.ComponentModel.RunWorkerCompletedEventArgs e)
 		{
 			var libraryStats = e.Result as LibraryCommands.LibraryStats;
@@ -86,18 +70,6 @@ namespace LibationWinForms
 				beginBookBackupsToolStripMenuItem.Format(menuItemText);
 				beginBookBackupsToolStripMenuItem.Enabled = libraryStats.HasPendingBooks;
 			});
-		}
-
-		private void updateBottomPdfNumbers(object _, System.ComponentModel.RunWorkerCompletedEventArgs e)
-		{
-			var libraryStats = e.Result as LibraryCommands.LibraryStats;
-
-			// don't need to assign the output of Format(). It just makes this logic cleaner
-			var statusStripText
-				= !libraryStats.HasPdfResults ? ""
-				: libraryStats.pdfsNotDownloaded > 0 ? pdfsCountsLbl.Format(libraryStats.pdfsNotDownloaded, libraryStats.pdfsDownloaded)
-				: $"|  All {libraryStats.pdfsDownloaded} PDFs downloaded";
-			statusStrip1.UIThreadAsync(() => pdfsCountsLbl.Text = statusStripText);
 		}
 
 		// update 'begin pdf only backups' menu item

--- a/Source/LibationWinForms/Form1.Designer.cs
+++ b/Source/LibationWinForms/Form1.Designer.cs
@@ -77,7 +77,6 @@
 			this.visibleCountLbl = new LibationWinForms.FormattableToolStripStatusLabel();
             this.springLbl = new System.Windows.Forms.ToolStripStatusLabel();
             this.backupsCountsLbl = new System.Windows.Forms.ToolStripStatusLabel();
-            this.pdfsCountsLbl = new LibationWinForms.FormattableToolStripStatusLabel();
             this.addQuickFilterBtn = new System.Windows.Forms.Button();
             this.splitContainer1 = new System.Windows.Forms.SplitContainer();
             this.panel1 = new System.Windows.Forms.Panel();
@@ -426,8 +425,7 @@
             this.upgradePb,
 			this.visibleCountLbl,
             this.springLbl,
-            this.backupsCountsLbl,
-            this.pdfsCountsLbl});
+            this.backupsCountsLbl});
             this.statusStrip1.Location = new System.Drawing.Point(0, 618);
             this.statusStrip1.Name = "statusStrip1";
             this.statusStrip1.Padding = new System.Windows.Forms.Padding(1, 0, 16, 0);
@@ -465,13 +463,6 @@
             this.backupsCountsLbl.Name = "backupsCountsLbl";
             this.backupsCountsLbl.Size = new System.Drawing.Size(218, 17);
             this.backupsCountsLbl.Text = "[Calculating backed up book quantities]";
-            // 
-            // pdfsCountsLbl
-            // 
-            this.pdfsCountsLbl.FormatText = "|  PDFs: NOT d/l\'ed: {0}  Downloaded: {1}";
-            this.pdfsCountsLbl.Name = "pdfsCountsLbl";
-            this.pdfsCountsLbl.Size = new System.Drawing.Size(218, 17);
-            this.pdfsCountsLbl.Text = "|  PDFs: NOT d/l\'ed: {0}  Downloaded: {1}";
             // 
             // addQuickFilterBtn
             // 
@@ -649,7 +640,6 @@
 		private System.Windows.Forms.ToolStripMenuItem liberateToolStripMenuItem;
 		private System.Windows.Forms.ToolStripStatusLabel backupsCountsLbl;
 		private LibationWinForms.FormattableToolStripMenuItem beginBookBackupsToolStripMenuItem;
-		private LibationWinForms.FormattableToolStripStatusLabel pdfsCountsLbl;
 		private LibationWinForms.FormattableToolStripMenuItem beginPdfBackupsToolStripMenuItem;
 		private System.Windows.Forms.TextBox filterSearchTb;
 		private System.Windows.Forms.Button filterBtn;

--- a/Source/LibationWinForms/Form1.VisibleBooks.cs
+++ b/Source/LibationWinForms/Form1.VisibleBooks.cs
@@ -27,7 +27,7 @@ namespace LibationWinForms
 			=> await Task.Run(setLiberatedVisibleMenuItem);
 		void setLiberatedVisibleMenuItem()
 		{
-			var notLiberated = productsDisplay.GetVisible().Count(lb => lb.Book.UserDefinedItem.BookStatus == DataLayer.LiberatedStatus.NotLiberated);
+			var notLiberated = productsDisplay.GetVisible().Count(lb => lb.Book.UserDefinedItem.BookStatus == LiberatedStatus.NotLiberated && !lb.AbsentFromLastScan);
 			this.UIThreadSync(() =>
 			{
 				if (notLiberated > 0)

--- a/Source/LibationWinForms/Form1.VisibleBooks.cs
+++ b/Source/LibationWinForms/Form1.VisibleBooks.cs
@@ -27,25 +27,22 @@ namespace LibationWinForms
 			=> await Task.Run(setLiberatedVisibleMenuItem);
 		void setLiberatedVisibleMenuItem()
 		{
-			var notLiberated = productsDisplay.GetVisible().Count(lb => lb.Book.UserDefinedItem.BookStatus == LiberatedStatus.NotLiberated && !lb.AbsentFromLastScan);
+			var libraryStats = LibraryCommands.GetCounts(productsDisplay.GetVisible());
 			this.UIThreadSync(() =>
 			{
-				if (notLiberated > 0)
+				if (libraryStats.HasPendingBooks)
 				{
-					liberateVisibleToolStripMenuItem_VisibleBooksMenu.Format(notLiberated);
-					liberateVisibleToolStripMenuItem_VisibleBooksMenu.Enabled = true;
-
-					liberateVisibleToolStripMenuItem_LiberateMenu.Format(notLiberated);
-					liberateVisibleToolStripMenuItem_LiberateMenu.Enabled = true;
+					liberateVisibleToolStripMenuItem_VisibleBooksMenu.Format(libraryStats.PendingBooks);
+					liberateVisibleToolStripMenuItem_LiberateMenu.Format(libraryStats.PendingBooks);
 				}
 				else
 				{
 					liberateVisibleToolStripMenuItem_VisibleBooksMenu.Text = "All visible books are liberated";
-					liberateVisibleToolStripMenuItem_VisibleBooksMenu.Enabled = false;
-
 					liberateVisibleToolStripMenuItem_LiberateMenu.Text = "All visible books are liberated";
-					liberateVisibleToolStripMenuItem_LiberateMenu.Enabled = false;
 				}
+
+				liberateVisibleToolStripMenuItem_VisibleBooksMenu.Enabled = libraryStats.HasPendingBooks;
+				liberateVisibleToolStripMenuItem_LiberateMenu.Enabled = libraryStats.HasPendingBooks;
 			});
 		}
 
@@ -180,9 +177,6 @@ namespace LibationWinForms
 			// top menu strip
 			visibleBooksToolStripMenuItem.Format(qty);
 			visibleBooksToolStripMenuItem.Enabled = qty > 0;
-
-			//Not used for anything?
-			var notLiberatedCount = productsDisplay.GetVisible().Count(lb => lb.Book.UserDefinedItem.BookStatus == DataLayer.LiberatedStatus.NotLiberated);
 			
 			await Task.Run(setLiberatedVisibleMenuItem);
 		}

--- a/Source/LibationWinForms/GridView/GridEntry.cs
+++ b/Source/LibationWinForms/GridView/GridEntry.cs
@@ -138,7 +138,7 @@ namespace LibationWinForms.GridView
 				PictureStorage.PictureCached += PictureStorage_PictureCached;
 
 			// Mutable property. Set the field so PropertyChanged isn't fired.
-			_cover = ImageReader.ToImage(picture);
+			_cover = loadImage(picture);
 		}
 
 		private void PictureStorage_PictureCached(object sender, PictureCachedEventArgs e)
@@ -154,8 +154,22 @@ namespace LibationWinForms.GridView
             // logic validation
             if (e.Definition.PictureId == Book.PictureId)
 			{
-				Cover = ImageReader.ToImage(e.Picture);
+				Cover = loadImage(e.Picture);
 				PictureStorage.PictureCached -= PictureStorage_PictureCached;
+			}
+		}
+
+
+		private Image loadImage(byte[] picture)
+		{
+			try
+			{
+				return ImageReader.ToImage(picture);
+			}
+			catch (Exception ex)
+			{
+				Serilog.Log.Logger.Error(ex, "Error loading cover art for {Book}", Book);
+				return Properties.Resources.default_cover_80x80;
 			}
 		}
 

--- a/Source/LibationWinForms/GridView/ImageDisplay.cs
+++ b/Source/LibationWinForms/GridView/ImageDisplay.cs
@@ -9,16 +9,25 @@ namespace LibationWinForms.GridView
 	{
 		public string PictureFileName { get; set; }
 		public string BookSaveDirectory { get; set; }
-		public byte[] CoverPicture { get => _coverBytes; set => pictureBox1.Image = Dinah.Core.WindowsDesktop.Drawing.ImageReader.ToImage(_coverBytes = value); }
-
-		private byte[] _coverBytes;
-
 
 		public ImageDisplay()
 		{
 			InitializeComponent();
 			lastWidth = Width;
 			lastHeight = Height;
+		}
+
+		public void SetCoverArt(byte[] cover)
+		{
+			try
+			{
+				pictureBox1.Image = Dinah.Core.WindowsDesktop.Drawing.ImageReader.ToImage(cover);
+			}
+			catch (Exception ex)
+			{
+				Serilog.Log.Logger.Error(ex, "Error loading cover art for {file}", PictureFileName);
+				pictureBox1.Image = Properties.Resources.default_cover_500x500;
+			}
 		}
 
 		#region Make the form's aspect ratio always match the picture's aspect ratio.
@@ -106,7 +115,7 @@ namespace LibationWinForms.GridView
 
 			try
 			{
-				File.WriteAllBytes(saveFileDialog.FileName, CoverPicture);
+				pictureBox1.Image.Save(saveFileDialog.FileName);
 			}
 			catch (Exception ex)
 			{

--- a/Source/LibationWinForms/GridView/LiberateButtonStatus.cs
+++ b/Source/LibationWinForms/GridView/LiberateButtonStatus.cs
@@ -8,7 +8,15 @@ namespace LibationWinForms.GridView
 		public LiberatedStatus BookStatus { get; set; }
 		public LiberatedStatus? PdfStatus { get; set; }
 		public bool Expanded { get; set; }
-		public bool IsSeries { get; init; }
+		public bool IsSeries { get; }
+		private bool IsAbsent { get; }
+		public bool IsUnavailable => !IsSeries & IsAbsent & (BookStatus is not LiberatedStatus.Liberated || PdfStatus is not null and not LiberatedStatus.Liberated);
+
+		public LiberateButtonStatus(bool isSeries, bool isAbsent)
+		{
+			IsSeries = isSeries;
+			IsAbsent = isAbsent;
+		}
 
 		/// <summary>
 		/// Defines the Liberate column's sorting behavior
@@ -20,6 +28,8 @@ namespace LibationWinForms.GridView
 			if (IsSeries && !second.IsSeries) return -1;
 			else if (!IsSeries && second.IsSeries) return 1;
 			else if (IsSeries && second.IsSeries) return 0;
+			else if (IsUnavailable && !second.IsUnavailable) return 1;
+			else if (!IsUnavailable && second.IsUnavailable) return -1;
 			else if (BookStatus == LiberatedStatus.Liberated && second.BookStatus != LiberatedStatus.Liberated) return -1;
 			else if (BookStatus != LiberatedStatus.Liberated && second.BookStatus == LiberatedStatus.Liberated) return 1;
 			else return BookStatus.CompareTo(second.BookStatus);

--- a/Source/LibationWinForms/GridView/LiberateDataGridViewImageButtonColumn.cs
+++ b/Source/LibationWinForms/GridView/LiberateDataGridViewImageButtonColumn.cs
@@ -17,11 +17,14 @@ namespace LibationWinForms.GridView
 	internal class LiberateDataGridViewImageButtonCell : DataGridViewImageButtonCell
 	{
 		private static readonly Color SERIES_BG_COLOR = Color.FromArgb(230, 255, 230);
+		private static readonly Brush DISABLED_GRAY = new SolidBrush(Color.FromArgb(0x60, Color.LightGray));
 		protected override void Paint(Graphics graphics, Rectangle clipBounds, Rectangle cellBounds, int rowIndex, DataGridViewElementStates elementState, object value, object formattedValue, string errorText, DataGridViewCellStyle cellStyle, DataGridViewAdvancedBorderStyle advancedBorderStyle, DataGridViewPaintParts paintParts)
 		{
 			if (value is LiberateButtonStatus status)
 			{
-				if (status.BookStatus is LiberatedStatus.Error)
+
+				if (status.BookStatus is LiberatedStatus.Error || status.IsUnavailable)
+					//Don't paint the button graphic
 					paintParts ^= DataGridViewPaintParts.ContentBackground | DataGridViewPaintParts.ContentForeground | DataGridViewPaintParts.SelectionBackground;
 
 				if (rowIndex >= 0 && DataGridView.GetBoundItem<GridEntry>(rowIndex) is LibraryBookEntry lbEntry && lbEntry.Parent is not null)
@@ -41,7 +44,14 @@ namespace LibationWinForms.GridView
 
 					DrawButtonImage(graphics, buttonImage, cellBounds);
 
-					ToolTipText = mouseoverText;
+					if (status.IsUnavailable)
+					{
+						//Create the "disabled" look by painting a transparent gray box over the buttom image.
+						graphics.FillRectangle(DISABLED_GRAY, cellBounds);
+						ToolTipText = "This book cannot be downloaded\r\nbecause it wasn't found during\r\nthe most recent library scan";
+					}
+					else
+						ToolTipText = mouseoverText;
 				}
 			}
 		}

--- a/Source/LibationWinForms/GridView/LibraryBookEntry.cs
+++ b/Source/LibationWinForms/GridView/LibraryBookEntry.cs
@@ -52,7 +52,7 @@ namespace LibationWinForms.GridView
 					_pdfStatus = LibraryCommands.Pdf_Status(LibraryBook.Book);
 					lastStatusUpdate = DateTime.Now;
 				}
-				return new LiberateButtonStatus { BookStatus = _bookStatus, PdfStatus = _pdfStatus, IsSeries = false };
+				return new LiberateButtonStatus(isSeries: false, LibraryBook.AbsentFromLastScan) { BookStatus = _bookStatus, PdfStatus = _pdfStatus };
 			}
 		}
 		public override string DisplayTags => string.Join("\r\n", Book.UserDefinedItem.TagsEnumerated);

--- a/Source/LibationWinForms/GridView/ProductsDisplay.cs
+++ b/Source/LibationWinForms/GridView/ProductsDisplay.cs
@@ -200,7 +200,8 @@ namespace LibationWinForms.GridView
 
 		private void productsGrid_LiberateClicked(LibraryBookEntry liveGridEntry)
 		{
-			if (liveGridEntry.LibraryBook.Book.UserDefinedItem.BookStatus is not LiberatedStatus.Error)
+			if (liveGridEntry.LibraryBook.Book.UserDefinedItem.BookStatus is not LiberatedStatus.Error
+				&& !liveGridEntry.Liberate.IsUnavailable)
 				LiberateClicked?.Invoke(this, liveGridEntry.LibraryBook);
 		}
 

--- a/Source/LibationWinForms/GridView/ProductsDisplay.cs
+++ b/Source/LibationWinForms/GridView/ProductsDisplay.cs
@@ -39,7 +39,7 @@ namespace LibationWinForms.GridView
 			void PictureCached(object sender, PictureCachedEventArgs e)
 			{
 				if (e.Definition.PictureId == picDef.PictureId)
-					imageDisplay.CoverPicture = e.Picture;
+					imageDisplay.SetCoverArt(e.Picture);
 
 				PictureStorage.PictureCached -= PictureCached;
 			}
@@ -51,7 +51,7 @@ namespace LibationWinForms.GridView
 
 			if (imageDisplay is null || imageDisplay.IsDisposed || !imageDisplay.Visible)
 			{
-				imageDisplay = new GridView.ImageDisplay();
+				imageDisplay = new ImageDisplay();
 				imageDisplay.RestoreSizeAndLocation(Configuration.Instance);
 				imageDisplay.FormClosed += (_, _) => imageDisplay.SaveSizeAndLocation(Configuration.Instance);
 			}
@@ -59,7 +59,7 @@ namespace LibationWinForms.GridView
 			imageDisplay.BookSaveDirectory = AudibleFileStorage.Audio.GetDestinationDirectory(liveGridEntry.LibraryBook);
 			imageDisplay.PictureFileName = System.IO.Path.GetFileName(AudibleFileStorage.Audio.GetBooksDirectoryFilename(liveGridEntry.LibraryBook, ".jpg"));
 			imageDisplay.Text = windowTitle;
-			imageDisplay.CoverPicture = initialImageBts;
+			imageDisplay.SetCoverArt(initialImageBts);
 			if (!isDefault)
 				PictureStorage.PictureCached -= PictureCached;
 

--- a/Source/LibationWinForms/GridView/ProductsGrid.cs
+++ b/Source/LibationWinForms/GridView/ProductsGrid.cs
@@ -180,7 +180,7 @@ namespace LibationWinForms.GridView
 			var convertToMp3MenuItem = new ToolStripMenuItem
 			{
 				Text = "&Convert to Mp3",
-				Enabled = entry.Book.UserDefinedItem.BookStatus != LiberatedStatus.NotLiberated
+				Enabled = entry.Book.UserDefinedItem.BookStatus is LiberatedStatus.Liberated
 			};
 			convertToMp3MenuItem.Click += (_, e) => ConvertToMp3Clicked?.Invoke(entry as LibraryBookEntry);
 

--- a/Source/LibationWinForms/GridView/SeriesEntry.cs
+++ b/Source/LibationWinForms/GridView/SeriesEntry.cs
@@ -62,7 +62,7 @@ namespace LibationWinForms.GridView
 
 		private SeriesEntry(LibraryBook parent)
 		{
-			Liberate = new LiberateButtonStatus { IsSeries = true };
+			Liberate = new LiberateButtonStatus(isSeries: true, isAbsent: false);
 			SeriesIndex = -1;
 			LibraryBook = parent;
 			LoadCover();

--- a/Source/LoadByOS/WindowsConfigApp/FolderIcon.cs
+++ b/Source/LoadByOS/WindowsConfigApp/FolderIcon.cs
@@ -1,45 +1,17 @@
-﻿using SixLabors.ImageSharp;
-using SixLabors.ImageSharp.Formats.Png;
+﻿using LibationUiBase;
+using SixLabors.ImageSharp;
 using System;
 using System.IO;
-using System.Runtime.InteropServices;
 
 namespace WindowsConfigApp
-{
+{	
 	internal static partial class FolderIcon
 	{
-		// https://stackoverflow.com/a/21389253
+		static readonly IcoEncoder IcoEncoder = new();
 		public static byte[] ToIcon(this Image img)
 		{
-			using var ms = new MemoryStream();
-			using var bw = new BinaryWriter(ms);
-			// Header
-			bw.Write((short)0);   // 0-1 : reserved
-			bw.Write((short)1);   // 2-3 : 1=ico, 2=cur
-			bw.Write((short)1);   // 4-5 : number of images
-								  // Image directory
-			var w = img.Width;
-			if (w >= 256) w = 0;
-			bw.Write((byte)w);    // 0 : width of image
-			var h = img.Height;
-			if (h >= 256) h = 0;
-			bw.Write((byte)h);    // 1 : height of image
-			bw.Write((byte)0);    // 2 : number of colors in palette
-			bw.Write((byte)0);    // 3 : reserved
-			bw.Write((short)0);   // 4 : number of color planes
-			bw.Write((short)0);   // 6 : bits per pixel
-			var sizeHere = ms.Position;
-			bw.Write((int)0);     // 8 : image size
-			var start = (int)ms.Position + 4;
-			bw.Write(start);      // 12: offset of image data
-								  // Image data
-			img.Save(ms, new PngEncoder());
-			var imageSize = (int)ms.Position - start;
-			ms.Seek(sizeHere, SeekOrigin.Begin);
-			bw.Write(imageSize);
-			ms.Seek(0, SeekOrigin.Begin);
-
-			// And load it
+			using var ms = new MemoryStream();			
+			img.Save(ms, IcoEncoder);			
 			return ms.ToArray();
 		}
 
@@ -57,8 +29,6 @@ namespace WindowsConfigApp
 					File.Delete(text);
 				}
 			}
-
-			refresh();
 		}
 
 		// https://github.com/dimuththarindu/FIC-Folder-Icon-Changer/blob/master/project/FIC/Classes/IconCustomizer.cs
@@ -70,7 +40,6 @@ namespace WindowsConfigApp
 		{
 			var desktop_ini = Path.Combine(dir, "desktop.ini");
 			var Icon_ico = Path.Combine(dir, "Icon.ico");
-			var hidden = Path.Combine(dir, ".hidden");
 
 			//deleting existing files
 			DeleteIcon(dir);
@@ -79,28 +48,14 @@ namespace WindowsConfigApp
 			File.WriteAllBytes(Icon_ico, icon);
 
 			//writing configuration file
-			string[] desktopLines = { "[.ShellClassInfo]", "IconResource=Icon.ico,0", "[ViewState]", "Mode=", "Vid=", $"FolderType={folderType}" };
+			string[] desktopLines = { "[.ShellClassInfo]", "ConfirmFileOp=0", "IconResource=Icon.ico,0", "[ViewState]", "Mode=", "Vid=", $"FolderType={folderType}" };
 			File.WriteAllLines(desktop_ini, desktopLines);
 
-			//configure file 2            
-			string[] hiddenLines = { "desktop.ini", "Icon.ico" };
-			File.WriteAllLines(hidden, hiddenLines);
+			File.SetAttributes(desktop_ini, File.GetAttributes(desktop_ini) | FileAttributes.Hidden | FileAttributes.ReadOnly);
+			File.SetAttributes(Icon_ico, File.GetAttributes(Icon_ico) | FileAttributes.Hidden | FileAttributes.ReadOnly);
 
-			//making system files
-			File.SetAttributes(desktop_ini, File.GetAttributes(desktop_ini) | FileAttributes.Hidden | FileAttributes.System | FileAttributes.ReadOnly);
-			File.SetAttributes(Icon_ico, File.GetAttributes(Icon_ico) | FileAttributes.Hidden | FileAttributes.System | FileAttributes.ReadOnly);
-			File.SetAttributes(hidden, File.GetAttributes(hidden) | FileAttributes.Hidden | FileAttributes.System | FileAttributes.ReadOnly);
-
-			// this strangely completes the process. also hides these 3 hidden system files, even if "show hidden items" is checked
-			File.SetAttributes(dir, File.GetAttributes(dir) | FileAttributes.ReadOnly);
-
-			refresh();
+			//https://learn.microsoft.com/en-us/windows/win32/shell/how-to-customize-folders-with-desktop-ini
+			File.SetAttributes(dir, File.GetAttributes(dir) | FileAttributes.System);
 		}
-
-		private static void refresh() => SHChangeNotify(0x08000000, 0x0000, 0, 0); //SHCNE_ASSOCCHANGED SHCNF_IDLIST
-
-
-		[DllImport("shell32.dll", SetLastError = true)]
-		private static extern void SHChangeNotify(int wEventId, int uFlags, nint dwItem1, nint dwItem2);
 	}
 }

--- a/Source/LoadByOS/WindowsConfigApp/WinInterop.cs
+++ b/Source/LoadByOS/WindowsConfigApp/WinInterop.cs
@@ -14,19 +14,9 @@ namespace WindowsConfigApp
 
         public void SetFolderIcon(string image, string directory)
         {
-            string iconPath = null;
-
-            try
-            {
-				var icon = Image.Load(image).ToIcon();
-				new DirectoryInfo(directory)?.SetIcon(icon, "Music");
-            }
-            finally
-            {
-                if (File.Exists(iconPath))
-                    File.Delete(iconPath);
-            }
-        }
+			var icon = Image.Load(image).ToIcon();
+			new DirectoryInfo(directory)?.SetIcon(icon, "Music");
+		}
 
         public void DeleteFolderIcon(string directory)
             => new DirectoryInfo(directory)?.DeleteIcon();


### PR DESCRIPTION
Again, changes are broken up by commits (except for "Improve library scan performance" which is split in half because I forgot to pull in a merge).

# [Add last downloaded info to exports](https://github.com/rmcrackan/Libation/commit/cdb27ef712d7e23cace8d885dac27c1a8ec16d73)

You'd asked for this in my last PR

# [Improve library scan performance](https://github.com/rmcrackan/Libation/pull/524/files#diff-86df73cf7abdd921714ff352ba3bb2279ca9909ecdb4357e47f3d5e7cb3d6aa1)

This change is split across 3 commits, but only [ApiExtended.cs](https://github.com/rmcrackan/Libation/pull/524/files#diff-86df73cf7abdd921714ff352ba3bb2279ca9909ecdb4357e47f3d5e7cb3d6aa1) was changed.

Episode fetching was poorly batched. All episodes of a series were fetched synchronously in the same Task, so some podcasts with hundreds of episodes would bog down the scan. Now, Episode retrieval is done in batches of no more than 50, dramatically increasing scan speeds for users with large podcasts (my library scan speed increased by 60%).

Also notice that MaxConcurrency has increased from 5 to 10. Actual max concurrency prior to this change was actually 15. That's because AudibleApi's library scan had a concurrency limit of 10, and Libation would simultaneously download episodes with a max concurrency of 5. Now, episode scanning only begins after the Api has completed scanning the library.

# [Add AbsentFromLastScan](https://github.com/rmcrackan/Libation/commit/f6dcc0db1db8fca42c76d42f288b5494ea54afd1)

I decided on `AbsentFromLastScan` instead of `PresentInLastScan` to maintain default behavior immediately after a user migrates (since  post-migration values will be default false).

# [Show AbsentFromLastScan book status in grid](https://github.com/rmcrackan/Libation/commit/3ebd4ce24381df4fa01e7716a6bea440dfa87700)

If a book (or pdf) is not liberated and `AbsentFromLastScan ` is true, the grid button does nothing and the button image is grayed. Additionally, these absent books are excluded from unliberated counts and are not queued for download.

Solved #269

# [Fix #523](https://github.com/rmcrackan/Libation/pull/524/commits/e76f99ff28bb8bc19f71ec87761061ec839f9bb1)

If cover art fails to load, load the default image instead.

