### PR TITLE
Add better AYCL detection and add verbose library scan logging

### DIFF
--- a/Source/AudibleUtilities/ApiExtended.cs
+++ b/Source/AudibleUtilities/ApiExtended.cs
@@ -135,14 +135,6 @@ namespace AudibleUtilities
 			Serilog.Log.Logger.Debug("Episode scan complete. Found {count} episodes and series.", count);
 			Serilog.Log.Logger.Debug($"Completed library scan in {sw.Elapsed.TotalMilliseconds:F0} ms.");
 
-#if DEBUG
-			//// this will not work for multi accounts
-			//var library_json = "library.json";
-			//library_json = System.IO.Path.GetFullPath(library_json);
-			//if (System.IO.File.Exists(library_json))
-			//    items = AudibleApi.Common.Converter.FromJson<List<Item>>(System.IO.File.ReadAllText(library_json));
-			//System.IO.File.WriteAllText(library_json, AudibleApi.Common.Converter.ToJson(items));
-#endif
 			var validators = new List<IValidator>();
 			validators.AddRange(getValidators());
 			foreach (var v in validators)

--- a/Source/DataLayer/EfClasses/Rating.cs
+++ b/Source/DataLayer/EfClasses/Rating.cs
@@ -5,7 +5,7 @@ using Dinah.Core;
 namespace DataLayer
 {
     /// <summary>Parameterless ctor and setters should be used by EF only. Everything else should treat it as immutable</summary>
-    public class Rating : ValueObject_Static<Rating>
+    public class Rating : ValueObject_Static<Rating>, IComparable<Rating>, IComparable
     {
         public float OverallRating { get; private set; }
         public float PerformanceRating { get; private set; }
@@ -38,6 +38,16 @@ namespace DataLayer
             yield return StoryRating;
         }
 
-		public override string ToString() => $"Overall={OverallRating} Perf={PerformanceRating} Story={StoryRating}";
-	}
+        public override string ToString() => $"Overall={OverallRating} Perf={PerformanceRating} Story={StoryRating}";
+
+        public int CompareTo(Rating other)
+        {
+            var compare = OverallRating.CompareTo(other.OverallRating);
+            if (compare != 0) return compare;
+            compare = PerformanceRating.CompareTo(other.PerformanceRating);
+            if (compare != 0) return compare;
+            return StoryRating.CompareTo(other.StoryRating);
+        }
+        public int CompareTo(object obj) => obj is Rating second ? CompareTo(second) : -1;
+    }
 }

--- a/Source/DataLayer/EfClasses/UserDefinedItem.cs
+++ b/Source/DataLayer/EfClasses/UserDefinedItem.cs
@@ -122,7 +122,11 @@ namespace DataLayer
         public Rating Rating { get; private set; } = new Rating(0, 0, 0);
 
         public void UpdateRating(float overallRating, float performanceRating, float storyRating)
-            => Rating.Update(overallRating, performanceRating, storyRating);
+        {
+            var changed = Rating.OverallRating != overallRating || Rating.PerformanceRating != performanceRating || Rating.StoryRating != storyRating;
+			Rating.Update(overallRating, performanceRating, storyRating);
+            if (changed) OnItemChanged(nameof(Rating));
+		}
         #endregion
 
         #region LiberatedStatuses

--- a/Source/FileManager/LogArchiver.cs
+++ b/Source/FileManager/LogArchiver.cs
@@ -1,0 +1,67 @@
+﻿using Dinah.Core;
+using Newtonsoft.Json.Linq;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.IO.Compression;
+using System.Linq;
+using System.Text;
+
+namespace FileManager
+{
+	public class LogArchiver : IDisposable
+	{
+		public Encoding Encoding { get; set; }
+		public string FileName { get; }
+		private readonly ZipArchive archive;
+
+		public LogArchiver(string filename) : this(filename, Encoding.UTF8) { }
+		public LogArchiver(string filename, Encoding encoding)
+		{
+			FileName = ArgumentValidator.EnsureNotNull(filename, nameof(filename));
+			Encoding = ArgumentValidator.EnsureNotNull(encoding, nameof(encoding));
+			archive = new ZipArchive(File.Open(FileName, FileMode.OpenOrCreate, FileAccess.ReadWrite, FileShare.ReadWrite), ZipArchiveMode.Update, false, Encoding);
+		}
+
+		public void DeleteOlderThan(DateTime cutoffDate)
+			=> DeleteEntries(archive.Entries.Where(e => e.LastWriteTime < cutoffDate).ToList());
+
+		public void DeleteOldestN(int quantity)
+			=> DeleteEntries(archive.Entries.OrderBy(e => e.LastWriteTime).Take(quantity).ToList());
+		
+		public void DeleteAllButNewestN(int quantity)
+			=> DeleteEntries(archive.Entries.OrderByDescending(e => e.LastWriteTime).Skip(quantity).ToList());
+		
+		private void DeleteEntries(List<ZipArchiveEntry> entries)
+		{
+			foreach (var e in entries)
+				e.Delete();
+		}
+
+		public void AddFile(string name, JObject contents, string comment = null)
+			=> AddFile(name, Encoding.GetBytes(contents.ToString(Newtonsoft.Json.Formatting.Indented)), comment);
+
+		public void AddFile(string name, string contents, string comment = null)
+			=> AddFile(name, Encoding.GetBytes(contents), comment);
+
+		private readonly object lockOob = new();
+
+		public void AddFile(string name, ReadOnlySpan<byte> contents, string comment = null)
+		{
+			ArgumentValidator.EnsureNotNull(name, nameof(name));
+
+			name = ReplacementCharacters.Barebones.ReplaceFilenameChars(name);
+
+			lock (lockOob)
+			{
+				var entry = archive.CreateEntry(name, CompressionLevel.SmallestSize);
+
+				entry.Comment = comment;
+				using var entryStream = entry.Open();
+				entryStream.Write(contents);
+			}
+		}
+
+		public void Dispose() => archive.Dispose();
+	}
+}


### PR DESCRIPTION
I added a new plan name check for Audible plus titles. I also added some a new LogArchive class for compressing log files. If verbose logging is enabled, library scan JSONs are written to "LibraryScans.zip", but only the most recent 10 + #accounts are retained.


EDIT* I also added a new event trigger for when a user changes their rating and made Rating IComparable. I was in the middle of a big refactor when this issue came up, so I had to revert all that. But these don't affect anything so I thought I'd just push them now.