### PR TITLE
Bug fixes and performance improvements

### DIFF
--- a/Source/ApplicationServices/LibraryCommands.cs
+++ b/Source/ApplicationServices/LibraryCommands.cs
@@ -213,12 +213,13 @@ namespace ApplicationServices
             if (archiver is not null)
             {
                 var fileName = $"{DateTime.Now:u} {account.MaskedLogEntry}.json";
+                var items = await Task.Run(() => JArray.FromObject(dtoItems.Select(i => i.SourceJson)));
 
 				var scanFile = new JObject
                 {
                     { "Account", account.MaskedLogEntry },
                     { "ScannedDateTime", DateTime.Now.ToString("u") },
-                    { "Items", await Task.Run(() => JArray.FromObject(dtoItems.Select(i => i.SourceJson))) }
+                    { "Items",  items}
                 };
 
 				await archiver.AddFileAsync(fileName, scanFile);

--- a/Source/ApplicationServices/LibraryCommands.cs
+++ b/Source/ApplicationServices/LibraryCommands.cs
@@ -218,7 +218,7 @@ namespace ApplicationServices
                 {
                     { "Account", account.MaskedLogEntry },
                     { "ScannedDateTime", DateTime.Now.ToString("u") },
-                    { "Items", await Task.Run(() => JArray.FromObject(dtoItems)) }
+                    { "Items", await Task.Run(() => JArray.FromObject(dtoItems.Select(i => i.SourceJson))) }
                 };
 
 				await archiver.AddFileAsync(fileName, scanFile);

--- a/Source/AudibleUtilities/AudibleUtilities.csproj
+++ b/Source/AudibleUtilities/AudibleUtilities.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AudibleApi" Version="8.1.0.1" />
+    <PackageReference Include="AudibleApi" Version="8.2.0.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Source/DtoImporterService/LibraryBookImporter.cs
+++ b/Source/DtoImporterService/LibraryBookImporter.cs
@@ -91,29 +91,8 @@ namespace DtoImporterService
 			return qtyNew;
 		}
 
-		/*
-		 * Subscription Plan Names:
-		 * 
-		 * US:	"SpecialBenefit"
-		 * IT:	"Rodizio"
-		 * 
-		 * Audible Plus Plan Names:
-		 * 
-		 * US:	"US Minerva"
-		 * IT:	"Audible-AYCL" 
-		 *
-		 */
-
-
-		//This SEEMS to work to detect plus titles which are no longer available.
-		//I have my doubts it won't yield false negatives, but I have more
-		//confidence that it won't yield many/any false positives.
 		private static bool isPlusTitleUnavailable(ImportItem item)
 			=> item.DtoItem.IsAyce is true
-			&& item.DtoItem.Plans?.Any(p =>
-				p.PlanName.ContainsInsensitive("Minerva") ||
-				p.PlanName.ContainsInsensitive("AYCL") ||
-				p.PlanName.ContainsInsensitive("Free")
-			) is not true;
+			&& item.DtoItem.Plans?.Any(p => p.IsAyce) is not true;
 	}
 }

--- a/Source/LibationAvalonia/AvaloniaUtils.cs
+++ b/Source/LibationAvalonia/AvaloniaUtils.cs
@@ -1,6 +1,8 @@
 ﻿using Avalonia.Controls;
 using Avalonia.Media;
+using Avalonia.Media.Imaging;
 using LibationAvalonia.Dialogs;
+using LibationFileManager;
 using System.Threading.Tasks;
 
 namespace LibationAvalonia
@@ -20,5 +22,21 @@ namespace LibationAvalonia
 			=> dialogWindow.ShowDialog<DialogResult>(owner ?? App.MainWindow);
 
 		public static Window GetParentWindow(this IControl control) => control.VisualRoot as Window;
+
+
+		private static Bitmap defaultImage;
+		public static Bitmap TryLoadImageOrDefault(byte[] picture, PictureSize defaultSize = PictureSize.Native)
+		{
+			try
+			{
+				using var ms = new System.IO.MemoryStream(picture);
+				return new Bitmap(ms);
+			}
+			catch
+			{
+				using var ms = new System.IO.MemoryStream(PictureStorage.GetDefaultImage(defaultSize));
+				return defaultImage ??= new Bitmap(ms);
+			}
+		}
 	}
 }

--- a/Source/LibationAvalonia/Dialogs/BookDetailsDialog.axaml.cs
+++ b/Source/LibationAvalonia/Dialogs/BookDetailsDialog.axaml.cs
@@ -1,5 +1,4 @@
 using ApplicationServices;
-using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Markup.Xaml;
 using Avalonia.Media.Imaging;
@@ -10,7 +9,6 @@ using LibationAvalonia.ViewModels;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Linq;
-using System;
 
 namespace LibationAvalonia.Dialogs
 {
@@ -112,8 +110,7 @@ namespace LibationAvalonia.Dialogs
 
 				//init cover image
 				var picture = PictureStorage.GetPictureSynchronously(new PictureDefinition(libraryBook.Book.PictureId, PictureSize._80x80));
-				using var ms = new System.IO.MemoryStream(picture);
-				Cover = new Bitmap(ms);
+				Cover = AvaloniaUtils.TryLoadImageOrDefault(picture, PictureSize._80x80);
 
 				//init book details
 				DetailsText = @$"

--- a/Source/LibationAvalonia/Dialogs/ImageDisplayDialog.axaml.cs
+++ b/Source/LibationAvalonia/Dialogs/ImageDisplayDialog.axaml.cs
@@ -2,7 +2,6 @@ using Avalonia.Markup.Xaml;
 using Avalonia.Media.Imaging;
 using System;
 using System.ComponentModel;
-using System.IO;
 using ReactiveUI;
 using Avalonia.Platform.Storage;
 
@@ -29,17 +28,7 @@ namespace LibationAvalonia.Dialogs
 
 		public void SetCoverBytes(byte[] cover)
 		{
-			try
-			{
-				var ms = new MemoryStream(cover);
-				_bitmapHolder.CoverImage = new Bitmap(ms);
-			}
-			catch (Exception ex)
-			{
-				Serilog.Log.Logger.Error(ex, "Error loading cover art for {file}", PictureFileName);
-				using var ms = App.OpenAsset("img-coverart-prod-unavailable_500x500.jpg");
-				_bitmapHolder.CoverImage = new Bitmap(ms);				
-			}
+			_bitmapHolder.CoverImage = AvaloniaUtils.TryLoadImageOrDefault(cover);
 		}
 
 		public async void SaveImage_Clicked(object sender, Avalonia.Interactivity.RoutedEventArgs e)

--- a/Source/LibationAvalonia/ViewModels/AvaloniaEntryStatus.cs
+++ b/Source/LibationAvalonia/ViewModels/AvaloniaEntryStatus.cs
@@ -8,28 +8,17 @@ namespace LibationAvalonia.ViewModels
 {
     public class AvaloniaEntryStatus : EntryStatus, IEntryStatus, IComparable
 	{
-		private static Bitmap _defaultImage;
 		public override IBrush BackgroundBrush => IsEpisode ? App.SeriesEntryGridBackgroundBrush : Brushes.Transparent;
 
 		private AvaloniaEntryStatus(LibraryBook libraryBook) : base(libraryBook) { }
 		public static EntryStatus Create(LibraryBook libraryBook) => new AvaloniaEntryStatus(libraryBook);
 
 		protected override Bitmap LoadImage(byte[] picture)
-		{
-			try
-			{
-				using var ms = new System.IO.MemoryStream(picture);
-				return new Bitmap(ms);
-			}
-			catch (Exception ex)
-			{
-				Serilog.Log.Logger.Error(ex, "Error loading cover art for {Book}", Book);
-				return _defaultImage ??= new Bitmap(App.OpenAsset("img-coverart-prod-unavailable_80x80.jpg"));
-			}
-		}
+			=> AvaloniaUtils.TryLoadImageOrDefault(picture, LibationFileManager.PictureSize._80x80);
 
 		protected override Bitmap GetResourceImage(string rescName)
 		{
+			//These images are assest, so assume they will never corrupt.
 			using var stream = App.OpenAsset(rescName + ".png");
 			return new Bitmap(stream);
 		}

--- a/Source/LibationAvalonia/ViewModels/ProcessBookViewModel.cs
+++ b/Source/LibationAvalonia/ViewModels/ProcessBookViewModel.cs
@@ -115,16 +115,14 @@ namespace LibationAvalonia.ViewModels
 				PictureStorage.PictureCached += PictureStorage_PictureCached;
 
 			// Mutable property. Set the field so PropertyChanged isn't fired.
-			using var ms = new System.IO.MemoryStream(picture);
-			_cover = new Bitmap(ms);
+			_cover = AvaloniaUtils.TryLoadImageOrDefault(picture, PictureSize._80x80);
 		}
 
 		private void PictureStorage_PictureCached(object sender, PictureCachedEventArgs e)
 		{
 			if (e.Definition.PictureId == LibraryBook.Book.PictureId)
 			{
-				using var ms = new System.IO.MemoryStream(e.Picture);
-				Cover = new Bitmap(ms);
+				Cover = AvaloniaUtils.TryLoadImageOrDefault(e.Picture, PictureSize._80x80);
 				PictureStorage.PictureCached -= PictureStorage_PictureCached;
 			}
 		}

--- a/Source/LibationAvalonia/ViewModels/ProductsDisplayViewModel.cs
+++ b/Source/LibationAvalonia/ViewModels/ProductsDisplayViewModel.cs
@@ -132,7 +132,7 @@ namespace LibationAvalonia.ViewModels
 			//Add absent entries to grid, or update existing entry
 			var allEntries = SOURCE.BookEntries().ToList();
 			var seriesEntries = SOURCE.SeriesEntries().ToList();
-			var parentedEpisodes = dbBooks.ParentedEpisodes().ToList();
+			var parentedEpisodes = dbBooks.ParentedEpisodes().ToHashSet();
 
 			await Dispatcher.UIThread.InvokeAsync(() =>
 			{
@@ -142,7 +142,7 @@ namespace LibationAvalonia.ViewModels
 
 					if (libraryBook.Book.IsProduct())
 						UpsertBook(libraryBook, existingEntry);
-					else if (parentedEpisodes.Any(lb => lb == libraryBook))
+					else if (parentedEpisodes.Contains(libraryBook))
 						//Only try to add or update is this LibraryBook is a know child of a parent
 						UpsertEpisode(libraryBook, existingEntry, seriesEntries, dbBooks);
 				}

--- a/Source/LibationFileManager/PictureStorage.cs
+++ b/Source/LibationFileManager/PictureStorage.cs
@@ -67,7 +67,7 @@ namespace LibationFileManager
 				}
 
 				DownloadQueue.Add(def);
-				return (true, getDefaultImage(def.Size));
+				return (true, GetDefaultImage(def.Size));
 			}
 		}
 
@@ -96,7 +96,7 @@ namespace LibationFileManager
 
 		public static void SetDefaultImage(PictureSize pictureSize, byte[] bytes)
 			=> defaultImages[pictureSize] = bytes;
-		private static byte[] getDefaultImage(PictureSize size)
+		public static byte[] GetDefaultImage(PictureSize size)
 			=> defaultImages.ContainsKey(size)
 			? defaultImages[size]
 			: new byte[0];
@@ -120,7 +120,7 @@ namespace LibationFileManager
 		private static byte[] downloadBytes(PictureDefinition def)
 		{
 			if (def.PictureId is null)
-				return getDefaultImage(def.Size);
+				return GetDefaultImage(def.Size);
 
 			try
 			{
@@ -135,7 +135,7 @@ namespace LibationFileManager
 			}
 			catch
 			{
-				return getDefaultImage(def.Size);
+				return GetDefaultImage(def.Size);
 			}
 		}
 	}

--- a/Source/LibationWinForms/Dialogs/BookDetailsDialog.cs
+++ b/Source/LibationWinForms/Dialogs/BookDetailsDialog.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Linq;
 using System.Windows.Forms;
 using DataLayer;
@@ -42,7 +41,7 @@ namespace LibationWinForms.Dialogs
 			this.Text = Book.Title;
 
 			(_, var picture) = PictureStorage.GetPicture(new PictureDefinition(Book.PictureId, PictureSize._80x80));
-			this.coverPb.Image = Dinah.Core.WindowsDesktop.Drawing.ImageReader.ToImage(picture);
+			this.coverPb.Image = WinFormsUtil.TryLoadImageOrDefault(picture, PictureSize._80x80);
 
 			var t = @$"
 Title: {Book.Title}

--- a/Source/LibationWinForms/FormSaveExtension.cs
+++ b/Source/LibationWinForms/FormSaveExtension.cs
@@ -2,6 +2,7 @@
 using System.Linq;
 using System.Windows.Forms;
 using LibationFileManager;
+using Microsoft.EntityFrameworkCore.Query.SqlExpressions;
 
 namespace LibationWinForms
 {
@@ -44,20 +45,31 @@ namespace LibationWinForms
 
 			var rect = new Rectangle(x, y, savedState.Width, savedState.Height);
 
-			// is proposed rect on a screen?
-			if (Screen.AllScreens.Any(screen => screen.WorkingArea.Contains(rect)))
+			if (savedState.IsMaximized)
 			{
+				//When a window is maximized, the client rectangle is not on a screen (y is negative).
 				form.StartPosition = FormStartPosition.Manual;
 				form.DesktopBounds = rect;
+
+				// FINAL: for Maximized: start normal state, set size and location, THEN set max state
+				form.WindowState = FormWindowState.Maximized;
 			}
 			else
 			{
-				form.StartPosition = FormStartPosition.WindowsDefaultLocation;
-				form.Size = rect.Size;
-			}
+				// is proposed rect on a screen?
+				if (Screen.AllScreens.Any(screen => screen.WorkingArea.Contains(rect)))
+				{
+					form.StartPosition = FormStartPosition.Manual;
+					form.DesktopBounds = rect;
+				}
+				else
+				{
+					form.StartPosition = FormStartPosition.WindowsDefaultLocation;
+					form.Size = rect.Size;
+				}
 
-			// FINAL: for Maximized: start normal state, set size and location, THEN set max state
-			form.WindowState = savedState.IsMaximized ? FormWindowState.Maximized : FormWindowState.Normal;
+				form.WindowState = FormWindowState.Normal;
+			}
 		}
 
 		public static void SaveSizeAndLocation(this Form form, Configuration config)

--- a/Source/LibationWinForms/GridView/ImageDisplay.cs
+++ b/Source/LibationWinForms/GridView/ImageDisplay.cs
@@ -19,15 +19,7 @@ namespace LibationWinForms.GridView
 
 		public void SetCoverArt(byte[] cover)
 		{
-			try
-			{
-				pictureBox1.Image = Dinah.Core.WindowsDesktop.Drawing.ImageReader.ToImage(cover);
-			}
-			catch (Exception ex)
-			{
-				Serilog.Log.Logger.Error(ex, "Error loading cover art for {file}", PictureFileName);
-				pictureBox1.Image = Properties.Resources.default_cover_500x500;
-			}
+			pictureBox1.Image = WinFormsUtil.TryLoadImageOrDefault(cover);
 		}
 
 		#region Make the form's aspect ratio always match the picture's aspect ratio.

--- a/Source/LibationWinForms/GridView/ProductsGrid.cs
+++ b/Source/LibationWinForms/GridView/ProductsGrid.cs
@@ -265,9 +265,7 @@ namespace LibationWinForms.GridView
 
 			var allEntries = bindingList.AllItems().BookEntries();
 			var seriesEntries = bindingList.AllItems().SeriesEntries().ToList();
-			var parentedEpisodes = dbBooks.ParentedEpisodes().ToList();
-
-			var sw = new Stopwatch();
+			var parentedEpisodes = dbBooks.ParentedEpisodes().ToHashSet();
 
 			foreach (var libraryBook in dbBooks.OrderBy(e => e.DateAdded))
 			{
@@ -278,14 +276,11 @@ namespace LibationWinForms.GridView
 					AddOrUpdateBook(libraryBook, existingEntry);
 					continue;
 				}
-				sw.Start();
-				if (parentedEpisodes.Any(lb => lb == libraryBook))
+				if (parentedEpisodes.Contains(libraryBook))
 				{
-					sw.Stop();
 					//Only try to add or update is this LibraryBook is a know child of a parent
 					AddOrUpdateEpisode(libraryBook, existingEntry, seriesEntries, dbBooks);
 				}
-				sw.Stop();
 			}
 
 			bindingList.SuspendFilteringOnUpdate = false;

--- a/Source/LibationWinForms/GridView/WinFormsEntryStatus.cs
+++ b/Source/LibationWinForms/GridView/WinFormsEntryStatus.cs
@@ -1,7 +1,5 @@
 ﻿using DataLayer;
-using Dinah.Core.WindowsDesktop.Drawing;
 using LibationUiBase.GridView;
-using System;
 using System.Drawing;
 
 namespace LibationWinForms.GridView
@@ -14,23 +12,12 @@ namespace LibationWinForms.GridView
 		private WinFormsEntryStatus(LibraryBook libraryBook) : base(libraryBook) { }
 		public static EntryStatus Create(LibraryBook libraryBook) => new WinFormsEntryStatus(libraryBook);
 
-		protected override object LoadImage(byte[] picture)
-		{
-			try
-			{
-				return ImageReader.ToImage(picture);
-			}
-			catch (Exception ex)
-			{
-				Serilog.Log.Logger.Error(ex, "Error loading cover art for {Book}", Book);
-				return Properties.Resources.default_cover_80x80;
-			}
-		}
+		protected override Image LoadImage(byte[] picture)
+			=> WinFormsUtil.TryLoadImageOrDefault(picture, LibationFileManager.PictureSize._80x80);
 
 		protected override Image GetResourceImage(string rescName)
 		{
 			var image = Properties.Resources.ResourceManager.GetObject(rescName);
-
 			return image as Bitmap;
 		}
 	}

--- a/Source/LibationWinForms/ProcessQueue/ProcessBook.cs
+++ b/Source/LibationWinForms/ProcessQueue/ProcessBook.cs
@@ -12,7 +12,6 @@ using AudibleApi;
 using DataLayer;
 using Dinah.Core;
 using Dinah.Core.ErrorHandling;
-using Dinah.Core.WindowsDesktop.Drawing;
 using FileLiberator;
 using LibationFileManager;
 using LibationUiBase;
@@ -87,7 +86,7 @@ namespace LibationWinForms.ProcessQueue
 
 			if (isDefault)
 				PictureStorage.PictureCached += PictureStorage_PictureCached;
-			_cover = ImageReader.ToImage(picture);
+			_cover = WinFormsUtil.TryLoadImageOrDefault(picture, PictureSize._80x80); ;
 
 		}
 
@@ -95,7 +94,7 @@ namespace LibationWinForms.ProcessQueue
 		{
 			if (e.Definition.PictureId == LibraryBook.Book.PictureId)
 			{
-				Cover = ImageReader.ToImage(e.Picture);
+				Cover = WinFormsUtil.TryLoadImageOrDefault(e.Picture, PictureSize._80x80);
 				PictureStorage.PictureCached -= PictureStorage_PictureCached;
 			}
 		}
@@ -260,7 +259,7 @@ namespace LibationWinForms.ProcessQueue
 
 		private void AudioDecodable_CoverImageDiscovered(object sender, byte[] coverArt)
 		{
-			Cover = ImageReader.ToImage(coverArt);
+			Cover = WinFormsUtil.TryLoadImageOrDefault(coverArt, PictureSize._80x80);
 		}
 
 		#endregion

--- a/Source/LibationWinForms/WinFormsUtil.cs
+++ b/Source/LibationWinForms/WinFormsUtil.cs
@@ -1,0 +1,23 @@
+﻿using Dinah.Core.WindowsDesktop.Drawing;
+using LibationFileManager;
+using System.Drawing;
+
+namespace LibationWinForms
+{
+	internal static class WinFormsUtil
+	{
+		private static Bitmap defaultImage;
+		public static Image TryLoadImageOrDefault(byte[] picture, PictureSize defaultSize = PictureSize.Native)
+		{
+			try
+			{
+				return ImageReader.ToImage(picture);
+			}
+			catch
+			{
+				using var ms = new System.IO.MemoryStream(PictureStorage.GetDefaultImage(defaultSize));
+				return defaultImage ??= new Bitmap(ms);
+			}
+		}
+	}
+}


### PR DESCRIPTION
# [Fix bug where book with corrupt image cannot be queued.](https://github.com/rmcrackan/Libation/commit/5ec01913d51551d0328af41ea71f88fd03a5bf73)

More error handling for corrupted cover images.

# [Fix window restore maximize state on secondary monitor.](https://github.com/rmcrackan/Libation/commit/3f0e6b9ee5c60d415b34d36c085808e6d7652553)

Window position wasn't being restored when Libation was closed from maximized state on a second monitor.

# [Source/LibationAvalonia/ViewModels/ProductsDisplayViewModel.cs](https://github.com/rmcrackan/Libation/commit/eed42bd108d2103e267f7f6843f96378f272fb83#diff-a519b32b5936f9ef0982657ca883d6082f2fcd0567c37f8abfc7add084138972)

Use HashSet to reduce lookup time.

# [Use new AudibleApi methods](https://github.com/rmcrackan/Libation/commit/ec7dd1b54a4ffa6a3b55d7d9bcd3e32a2540291e)

- Write `DtoBase.SourceJson` to the zip archive.
- Redesigned ApiExtended so now all catalog get requests are performed in batches of 50. So Instead of doing one get for a podcast with 1 episode, that 1 episode's asin is added to the request queue and is only requested once the queue reaches 50 items.
