### PR TITLE
Refined Walkthrough

### DIFF
--- a/Source/DtoImporterService/BookImporter.cs
+++ b/Source/DtoImporterService/BookImporter.cs
@@ -46,7 +46,7 @@ namespace DtoImporterService
 			var productIds = importItems
 				.Select(i => i.DtoItem.ProductId)
 				.Distinct()
-				.ToList();
+				.ToHashSet();
 
 			Cache = DbContext.Books
 				.GetBooks(b => productIds.Contains(b.AudibleProductId))

--- a/Source/LibationAvalonia/Dialogs/SettingsDialog.axaml
+++ b/Source/LibationAvalonia/Dialogs/SettingsDialog.axaml
@@ -19,6 +19,7 @@
 			Height="30"
 			Padding="30,3,30,3"
 			Content="Save"
+			Name="saveBtn"
 			Click="SaveButton_Clicked" />
 
 		<TabControl Name="tabControl" Grid.Column="0">

--- a/Source/LibationAvalonia/Walkthrough.cs
+++ b/Source/LibationAvalonia/Walkthrough.cs
@@ -1,102 +1,110 @@
 ﻿using ApplicationServices;
 using AudibleUtilities;
 using Avalonia.Controls;
+using Avalonia.Controls.Presenters;
 using Avalonia.Controls.Primitives;
 using Avalonia.Interactivity;
 using Avalonia.Media;
-using Avalonia.Threading;
+using Avalonia.Styling;
 using Dinah.Core.StepRunner;
 using LibationAvalonia.Dialogs;
 using LibationAvalonia.Views;
-using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using static Avalonia.Threading.Dispatcher;
 
 namespace LibationAvalonia
 {
 	internal class Walkthrough
 	{
-		private static Dictionary<string, string> settingTabMessages = new()
+		private Dictionary<string, string> settingTabMessages = new()
 		{
-			{ "Important Settings", "Change where liberated books are stored."},
-			{ "Import Library", "Change how your library is scanned, imported, and liberated."},
-			{ "Download/Decrypt", "Control how liberated files and folders are named and stored."},
-			{ "Audio File Settings", "Control how audio files are decrypted, including audio format and metadata handling."},
+			{ "Important Settings", "From here you can change where liberated books are stored and how detailed Libation's logs are.\r\n\r\nIf you experience a problem and need help, you'll be asked to provide your log file. In certain circumstances we may need you to reproduce the error with a higher level of logging detail."},
+			{ "Import Library", "In this tab you can change how your library is scanned and imported into Libation, as well as automatic liberation."},
+			{ "Download/Decrypt", "These settings allow you to control how liberated files and folders are named and stored.\r\nYou can customize the 'Naming Templates' to use any number of the audiobook's properties to build a customized file and folder naming format. Learn more about the syntax from the wiki at\r\n\r\nhttps://github.com/rmcrackan/Libation/blob/master/Documentation/NamingTemplates.md"},
+			{ "Audio File Settings", "Control how audio files are decrypted, including audio format and metadata handling.\r\n\r\nIf you choose to split your audiobook into multiple files by chapter marker, you may edit the chapter file 'Naming Template' to control how each chapter file is named."},
 		};
 
+		private static readonly IBrush FlashColor = Brushes.DodgerBlue;
 		private readonly MainWindow MainForm;
 		private readonly AsyncStepSequence sequence = new();
 		public Walkthrough(MainWindow mainForm)
 		{
 			MainForm = mainForm;
-			sequence[nameof(ShowAccountDialog)] = ShowAccountDialog;
-			sequence[nameof(ShowSettingsDialog)] = ShowSettingsDialog;
-			sequence[nameof(ShowAccountScanning)] = ShowAccountScanning;
-			sequence[nameof(ShowSearching)] = ShowSearching;
-			sequence[nameof(ShowQuickFilters)] = ShowQuickFilters;
+			sequence[nameof(ShowAccountDialog)] = () => UIThread.InvokeAsync(ShowAccountDialog);
+			sequence[nameof(ShowSettingsDialog)] = () => UIThread.InvokeAsync(ShowSettingsDialog);
+			sequence[nameof(ShowAccountScanning)] = () => UIThread.InvokeAsync(ShowAccountScanning);
+			sequence[nameof(ShowSearching)] = () => UIThread.InvokeAsync(ShowSearching);
+			sequence[nameof(ShowQuickFilters)] = () => UIThread.InvokeAsync(ShowQuickFilters);
+			sequence[nameof(ShowTourComplete)] = () => UIThread.InvokeAsync(ShowTourComplete);
 		}
 
 		public async Task RunAsync() => await sequence.RunAsync();
 
 		private async Task<bool> ShowAccountDialog()
 		{
-			if (await OkCancelMessageBox("First, add your Audible account(s).", "Add Accounts") is not DialogResult.OK) return false;
+			if (!await ProceedMessageBox("First, add your Audible account(s).", "Add Accounts"))
+				return false;
 
 			await Task.Delay(750);
-			await flashControlAsync(MainForm.settingsToolStripMenuItem);
-			await InvokeAsync(MainForm.settingsToolStripMenuItem.Open);
-			await Task.Delay(500);
-			
-			await flashControlAsync(MainForm.accountsToolStripMenuItem);
-			await InvokeAsync(() => MainForm.accountsToolStripMenuItem.IsSelected = true);
-			await Task.Delay(500);
+			await displayControlAsync(MainForm.settingsToolStripMenuItem);
+			await displayControlAsync(MainForm.accountsToolStripMenuItem);
 
-			var accountSettings = await InvokeAsync(() => new AccountsDialog());
-			accountSettings.Opened += async (_, _) => await MessageBox.Show(accountSettings, "Add your Audible account(s), then save.", "Add an Account");
-			await InvokeAsync(() => accountSettings.ShowDialog(MainForm));
+			var accountSettings = new AccountsDialog();
+			accountSettings.Loaded += async (_, _) => await MessageBox.Show(accountSettings, "Add your Audible account(s), then save.", "Add an Account");
+			await accountSettings.ShowDialog(MainForm);
 			return true;
 		}
 
 		private async Task<bool> ShowSettingsDialog()
 		{
-			if (await OkCancelMessageBox("Next, adjust Libation's settings", "Change Settings") is not DialogResult.OK) return false;
+			if (!await ProceedMessageBox("Next, adjust Libation's settings", "Change Settings"))
+				return false;
 
 			await Task.Delay(750);
-			await flashControlAsync(MainForm.settingsToolStripMenuItem);
-			await InvokeAsync(MainForm.settingsToolStripMenuItem.Open);
-			await Task.Delay(500);
+			await displayControlAsync(MainForm.settingsToolStripMenuItem);
+			await displayControlAsync(MainForm.basicSettingsToolStripMenuItem);
 
-			await flashControlAsync(MainForm.basicSettingsToolStripMenuItem);
-			await InvokeAsync(() => MainForm.basicSettingsToolStripMenuItem.IsSelected = true);
-			await Task.Delay(500);
-
-			var settingsDialog = await InvokeAsync(() => new SettingsDialog());
+			var settingsDialog = await UIThread.InvokeAsync(() => new SettingsDialog());
 
 			var tabsToVisit = settingsDialog.tabControl.Items.OfType<TabItem>().ToList();
 
 			foreach (var tab in tabsToVisit)
 				tab.PropertyChanged += TabControl_PropertyChanged;
 
+			settingsDialog.Loaded += SettingsDialog_Loaded;
 			settingsDialog.Closing += SettingsDialog_FormClosing;
+			settingsDialog.saveBtn.Content = "Next Tab";
 
-			await InvokeAsync(() => settingsDialog.ShowDialog(MainForm));
+			await settingsDialog.ShowDialog(MainForm);
 
 			return true;
 
+			async Task ShowTabPageMessageBoxAsync(TabItem selectedTab)
+			{
+				tabsToVisit.Remove(selectedTab);
+
+				if (!selectedTab.IsVisible || !(selectedTab.Header is TextBlock header && settingTabMessages.ContainsKey(header.Text))) return;
+
+				if (tabsToVisit.Count == 0)
+					settingsDialog.saveBtn.Content = "Save";
+
+				await MessageBox.Show(settingsDialog, settingTabMessages[header.Text], header.Text + " Tab", MessageBoxButtons.OK);
+
+				settingTabMessages.Remove(header.Text);
+			}
+
+			async void SettingsDialog_Loaded(object sender, RoutedEventArgs e)
+			{
+				await ShowTabPageMessageBoxAsync(tabsToVisit[0]);
+			}
+
 			async void TabControl_PropertyChanged(object sender, Avalonia.AvaloniaPropertyChangedEventArgs e)
 			{
-				if (e.Property == TabItem.IsSelectedProperty)
+				if (e.Property == TabItem.IsSelectedProperty && settingsDialog.IsLoaded)
 				{
-					var selectedTab = sender as TabItem;
-
-					tabsToVisit.Remove(selectedTab);
-
-					if (!selectedTab.IsVisible || !(selectedTab.Header is TextBlock header && settingTabMessages.ContainsKey(header.Text))) return;
-
-					await MessageBox.Show(settingsDialog, settingTabMessages[header.Text], header.Text + " Tab", MessageBoxButtons.OK);
-
-					settingTabMessages.Remove(header.Text);
+					await ShowTabPageMessageBoxAsync(sender as TabItem);
 				}
 			}
 
@@ -104,10 +112,7 @@ namespace LibationAvalonia
 			{
 				if (tabsToVisit.Count > 0)
 				{
-					var nextTab = tabsToVisit[0];
-					tabsToVisit.RemoveAt(0);
-
-					settingsDialog.tabControl.SelectedItem = nextTab;
+					settingsDialog.tabControl.SelectedItem = tabsToVisit[0];
 					e.Cancel = true;
 				}
 			}
@@ -115,32 +120,29 @@ namespace LibationAvalonia
 
 		private async Task<bool> ShowAccountScanning()
 		{
-			using var persister = AudibleApiStorage.GetAccountsSettingsPersister();
+			var persister = AudibleApiStorage.GetAccountsSettingsPersister();
 			var count = persister.AccountsSettings.Accounts.Count;
+			persister.Dispose();
 
 			if (count < 1)
 			{
-				await InvokeAsync(() => MessageBox.Show(MainForm, "Add an Audible account, then sync your library through the \"Import\" menu", "Add an Audible Account", MessageBoxButtons.OK, MessageBoxIcon.Information));
+				await MessageBox.Show(MainForm, "Add an Audible account, then sync your library through the 'Import' menu", "Add an Audible Account", MessageBoxButtons.OK, MessageBoxIcon.Information);
 				return false;
 			}
 
 			var accounts = count > 1 ? "accounts" : "account";
 			var library = count > 1 ? "libraries" : "library";
-			if (await OkCancelMessageBox($"Finally, scan your Audible {accounts} to sync your {library} with Libation", $"Scan {accounts}") is not DialogResult.OK) return false;
+			if(! await ProceedMessageBox($"Finally, scan your Audible {accounts} to sync your {library} with Libation.\r\n\r\nIf this is your first time scanning an account, you'll be prompted to enter your account's password to log into your Audible account.", $"Scan {accounts}"))
+				return false;
 
 			var scanItem = count > 1 ? MainForm.scanLibraryOfAllAccountsToolStripMenuItem : MainForm.scanLibraryToolStripMenuItem;
 
 			await Task.Delay(750);
-			await flashControlAsync(MainForm.importToolStripMenuItem);
-			await InvokeAsync(MainForm.importToolStripMenuItem.Open);
-			await Task.Delay(500);
+			await displayControlAsync(MainForm.importToolStripMenuItem);
+			await displayControlAsync(scanItem);
 
-			await flashControlAsync(scanItem);
-			await InvokeAsync(() => scanItem.IsSelected = true);
-			await Task.Delay(500);
-
-			await InvokeAsync(() => scanItem.RaiseEvent(new RoutedEventArgs(MenuItem.ClickEvent)));
-			await InvokeAsync(MainForm.importToolStripMenuItem.Close);
+			scanItem.RaiseEvent(new RoutedEventArgs(MenuItem.ClickEvent));
+			MainForm.importToolStripMenuItem.Close();
 
 			var tcs = new TaskCompletionSource();
 			LibraryCommands.ScanEnd += LibraryCommands_ScanEnd;
@@ -169,61 +171,62 @@ namespace LibationAvalonia
 			var firstAuthor = getFirstAuthor();
 			if (firstAuthor == null) return true;
 
-			if (await OkCancelMessageBox("You can filter the grid entries by searching", "Searching") is not DialogResult.OK) return false;
+			if (!await ProceedMessageBox("You can filter the grid entries by searching", "Searching"))
+				return false;
 
-			await flashControlAsync(MainForm.filterSearchTb);
+			await displayControlAsync(MainForm.filterSearchTb);
 
-			await InvokeAsync(() => MainForm.filterSearchTb.Text = string.Empty);
+			MainForm.filterSearchTb.Text = string.Empty;
 			foreach (var c in firstAuthor)
 			{
-				await InvokeAsync(() => MainForm.filterSearchTb.Text += c);
-				await Task.Delay(200);
+				MainForm.filterSearchTb.Text += c;
+				await Task.Delay(150);
 			}
 
-			await flashControlAsync(MainForm.filterBtn);
-			await InvokeAsync(MainForm.filterBtn.Focus);
-			await Task.Delay(500);
+			await displayControlAsync(MainForm.filterBtn);
 
-			await InvokeAsync(() => MainForm.filterBtn.RaiseEvent(new RoutedEventArgs(Button.ClickEvent)));
+			MainForm.filterBtn.RaiseEvent(new RoutedEventArgs(Button.ClickEvent));
+
 			await Task.Delay(1000);
 
 			await MessageBox.Show(MainForm, "Libation provides a built-in cheat sheet for its query language", "Search Cheat Sheet");
+			
+			await displayControlAsync(MainForm.filterHelpBtn);
 
-			await flashControlAsync(MainForm.filterHelpBtn);
-			var filterHelp = await InvokeAsync(() => new SearchSyntaxDialog());
-			await InvokeAsync(() => filterHelp.ShowDialog(MainForm));
+			var filterHelp = new SearchSyntaxDialog();
+			await filterHelp.ShowDialog(MainForm);
 
 			return true;
 		}
+
 		private async Task<bool> ShowQuickFilters()
 		{
 			var firstAuthor = getFirstAuthor();
 
 			if (firstAuthor == null) return true;
 
-			if (await OkCancelMessageBox("Queries that you perform regularly can be added to 'Quick Filters'", "Quick Filters") is not DialogResult.OK) return false;
+			if (!await ProceedMessageBox("Queries that you perform regularly can be added to 'Quick Filters'", "Quick Filters"))
+				return false;
 
-			await InvokeAsync(() => MainForm.filterSearchTb.Text = firstAuthor);
-
-			await Task.Delay(750);
-			await flashControlAsync(MainForm.addQuickFilterBtn);
-			await InvokeAsync(() => MainForm.addQuickFilterBtn.RaiseEvent(new RoutedEventArgs(Button.ClickEvent)));
-			await Task.Delay(750);
-
-			await flashControlAsync(MainForm.quickFiltersToolStripMenuItem);
-			await InvokeAsync(MainForm.quickFiltersToolStripMenuItem.Open);
-			await Task.Delay(500);
+			MainForm.filterSearchTb.Text = firstAuthor;
 
 			var editQuickFiltersToolStripMenuItem = MainForm.quickFiltersToolStripMenuItem.ItemsSource.OfType<MenuItem>().ElementAt(1);
 
-			await flashControlAsync(editQuickFiltersToolStripMenuItem);
-			await InvokeAsync(() => editQuickFiltersToolStripMenuItem.IsSelected = true);
-			await Task.Delay(500);
+			await Task.Delay(750);
+			await displayControlAsync(MainForm.addQuickFilterBtn);
+			await displayControlAsync(MainForm.quickFiltersToolStripMenuItem);
+			await displayControlAsync(editQuickFiltersToolStripMenuItem);
 
-			var editQuickFilters = await InvokeAsync(() => new EditQuickFilters());
-			editQuickFilters.Opened += async (_, _) => await MessageBox.Show(editQuickFilters, "From here you can edit, delete, and change the order of Quick Filters", "Editing Quick Filters");
-			await InvokeAsync(() => editQuickFilters.ShowDialog(MainForm));
+			var editQuickFilters = new EditQuickFilters();
+			editQuickFilters.Loaded += async (_, _) => await MessageBox.Show(editQuickFilters, "From here you can edit, delete, and change the order of Quick Filters", "Editing Quick Filters");
+			await editQuickFilters.ShowDialog(MainForm);
 
+			return true;
+		}
+
+		private async Task<bool> ShowTourComplete()
+		{
+			await MessageBox.Show(MainForm, "You're now ready to begin using Libation.\r\n\r\nEnjoy!", "Tour Finished");
 			return true;
 		}
 
@@ -233,24 +236,57 @@ namespace LibationAvalonia
 			return books.SelectMany(lb => lb.Book.Authors).FirstOrDefault(a => !string.IsNullOrWhiteSpace(a.Name))?.Name;
 		}
 
-		private async Task flashControlAsync(TemplatedControl control, int flashCount = 3)
+		private async Task displayControlAsync(TemplatedControl control)
 		{
-			var backColor = await InvokeAsync(() => control.Background);
+			await UIThread.InvokeAsync(() => control.IsEnabled = false);
+			await UIThread.InvokeAsync(MainForm.productsDisplay.Focus);
+			await UIThread.InvokeAsync(() => flashControlAsync(control));
+			if (control is MenuItem menuItem) await UIThread.InvokeAsync(menuItem.Open);
+			await Task.Delay(500);
+			await UIThread.InvokeAsync(() => control.IsEnabled = true);
+		}
+
+		private static async Task flashControlAsync(TemplatedControl control, int flashCount = 3)
+		{
 			for (int i = 0; i < flashCount; i++)
 			{
-				await InvokeAsync(() => control.Background = Brushes.Firebrick);
+				control.Styles.Add(disabledStyle);
+				control.Styles.Add(disabledStyle2);
 				await Task.Delay(200);
-				await InvokeAsync(() => control.Background = backColor);
+				control.Styles.Remove(disabledStyle);
+				control.Styles.Remove(disabledStyle2);
+				control.Styles.Add(enabedStyle);
+				control.Styles.Add(enabedStyle2);
+				control.InvalidateVisual();
 				await Task.Delay(200);
+				control.Styles.Remove(enabedStyle);
+				control.Styles.Remove(enabedStyle2);
 			}
 		}
 
-		private Task<T> InvokeAsync<T>(Func<T> func) => Dispatcher.UIThread.InvokeAsync(func);
-		private Task<T> InvokeAsync<T>(Func<Task<T>> func) => Dispatcher.UIThread.InvokeAsync(func);
-		private Task InvokeAsync(Func<Task> action) => Dispatcher.UIThread.InvokeAsync(action);
-		private Task InvokeAsync(Action action) => Dispatcher.UIThread.InvokeAsync(action);
+		private async Task<bool> ProceedMessageBox(string message, string caption)
+			=> await MessageBox.Show(MainForm, message, caption, MessageBoxButtons.OKCancel) is DialogResult.OK;
 
-		private Task<DialogResult> OkCancelMessageBox(string message, string caption)
-			=> InvokeAsync(() => MessageBox.Show(MainForm, message, caption, MessageBoxButtons.OKCancel));
+		private static readonly Setter HighlightSetter = new Setter(Border.BackgroundProperty, FlashColor);
+		private static readonly Setter HighlightSetter2 = new Setter(ContentPresenter.BackgroundProperty, FlashColor);
+		private static readonly Setter TransparentSetter = new Setter(Border.BackgroundProperty, Brushes.Transparent);
+		private static readonly Setter TransparentSetter2 = new Setter(ContentPresenter.BackgroundProperty, Brushes.Transparent);
+
+		private static Selector TemplateSelector = Selectors.Is<TemplatedControl>(null).PropertyEquals(Avalonia.Input.InputElement.IsEnabledProperty, false).Template();
+		private static Selector ContentPresenterSelector = TemplateSelector.Is<ContentPresenter>();
+		private static Selector BorderSelector = TemplateSelector.Is<Border>();
+
+		private static readonly Style disabledStyle = new Style(_ => BorderSelector);
+		private static readonly Style disabledStyle2 = new Style(_ => ContentPresenterSelector);
+		private static readonly Style enabedStyle = new Style(_ => BorderSelector);
+		private static readonly Style enabedStyle2 = new Style(_ => ContentPresenterSelector);
+
+		static Walkthrough()
+		{
+			disabledStyle.Setters.Add(HighlightSetter);
+			disabledStyle2.Setters.Add(HighlightSetter2);
+			enabedStyle.Setters.Add(TransparentSetter);
+			enabedStyle2.Setters.Add(TransparentSetter2);
+		}
 	}
 }

--- a/Source/LibationAvalonia/Walkthrough.cs
+++ b/Source/LibationAvalonia/Walkthrough.cs
@@ -214,6 +214,7 @@ namespace LibationAvalonia
 
 			await Task.Delay(750);
 			await displayControlAsync(MainForm.addQuickFilterBtn);
+			MainForm.addQuickFilterBtn.RaiseEvent(new RoutedEventArgs(Button.ClickEvent));
 			await displayControlAsync(MainForm.quickFiltersToolStripMenuItem);
 			await displayControlAsync(editQuickFiltersToolStripMenuItem);
 

--- a/Source/LibationWinForms/Dialogs/EditQuickFilters.Designer.cs
+++ b/Source/LibationWinForms/Dialogs/EditQuickFilters.Designer.cs
@@ -32,10 +32,10 @@
             this.saveBtn = new System.Windows.Forms.Button();
             this.dataGridView1 = new System.Windows.Forms.DataGridView();
             this.Original = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            this.Delete = new System.Windows.Forms.DataGridViewButtonColumn();
+            this.Delete = new DisableButtonColumn();
             this.Filter = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            this.MoveUp = new System.Windows.Forms.DataGridViewButtonColumn();
-            this.MoveDown = new System.Windows.Forms.DataGridViewButtonColumn();
+            this.MoveUp = new DisableButtonColumn();
+            this.MoveDown = new DisableButtonColumn();
             ((System.ComponentModel.ISupportInitialize)(this.dataGridView1)).BeginInit();
             this.SuspendLayout();
             // 
@@ -145,9 +145,9 @@
         private System.Windows.Forms.Button saveBtn;
         private System.Windows.Forms.DataGridView dataGridView1;
         private System.Windows.Forms.DataGridViewTextBoxColumn Original;
-        private System.Windows.Forms.DataGridViewButtonColumn Delete;
+        private DisableButtonColumn Delete;
         private System.Windows.Forms.DataGridViewTextBoxColumn Filter;
-        private System.Windows.Forms.DataGridViewButtonColumn MoveUp;
-        private System.Windows.Forms.DataGridViewButtonColumn MoveDown;
+        private DisableButtonColumn MoveUp;
+        private DisableButtonColumn MoveDown;
     }
 }

--- a/Source/LibationWinForms/Dialogs/EditQuickFilters.cs
+++ b/Source/LibationWinForms/Dialogs/EditQuickFilters.cs
@@ -93,7 +93,7 @@ namespace LibationWinForms.Dialogs
 			var dgv = (DataGridView)sender;
 
 			var col = dgv.Columns[e.ColumnIndex];
-			if (col is DataGridViewButtonColumn && e.RowIndex >= 0)
+			if (col is DataGridViewButtonColumn && e.RowIndex >= 0 && !dgv.Rows[e.RowIndex].IsNewRow)
 			{
 				var row = dgv.Rows[e.RowIndex];
 				switch (col.Name)

--- a/Source/LibationWinForms/Dialogs/EditQuickFilters.cs
+++ b/Source/LibationWinForms/Dialogs/EditQuickFilters.cs
@@ -1,10 +1,19 @@
 ﻿using System;
+using System.Drawing;
 using System.Linq;
 using System.Windows.Forms;
 using LibationFileManager;
 
 namespace LibationWinForms.Dialogs
 {
+	public class DisableButtonColumn : DataGridViewButtonColumn
+	{
+		public DisableButtonColumn()
+		{
+			CellTemplate = new EditQuickFilters.DisableButtonCell();
+		}
+	}
+
 	public partial class EditQuickFilters : Form
 	{
 		private const string BLACK_UP_POINTING_TRIANGLE = "\u25B2";
@@ -14,6 +23,25 @@ namespace LibationWinForms.Dialogs
 		private const string COL_Filter = nameof(Filter);
 		private const string COL_MoveUp = nameof(MoveUp);
 		private const string COL_MoveDown = nameof(MoveDown);
+
+		internal class DisableButtonCell : DataGridViewButtonCell
+		{
+			protected override void Paint(Graphics graphics, Rectangle clipBounds, Rectangle cellBounds, int rowIndex, DataGridViewElementStates elementState, object value, object formattedValue, string errorText, DataGridViewCellStyle cellStyle, DataGridViewAdvancedBorderStyle advancedBorderStyle, DataGridViewPaintParts paintParts)
+			{
+				if ((OwningColumn.Name == COL_MoveUp && rowIndex == 0)
+					|| (OwningColumn.Name == COL_MoveDown && rowIndex == LastRowIndex)
+					|| OwningRow.IsNewRow)
+				{
+					base.Paint(graphics, clipBounds, cellBounds, rowIndex, elementState, null, null, null, cellStyle, advancedBorderStyle, paintParts ^ (DataGridViewPaintParts.ContentBackground | DataGridViewPaintParts.ContentForeground | DataGridViewPaintParts.SelectionBackground));
+
+					ButtonRenderer.DrawButton(graphics, cellBounds, value as string, cellStyle.Font, false, System.Windows.Forms.VisualStyles.PushButtonState.Disabled);
+				}
+				else
+					base.Paint(graphics, clipBounds, cellBounds, rowIndex, elementState, value, formattedValue, errorText, cellStyle, advancedBorderStyle, paintParts);
+			}
+
+			int LastRowIndex => DataGridView.Rows[^1].IsNewRow ? DataGridView.Rows[^1].Index - 1 : DataGridView.Rows[^1].Index;
+		}
 
 		public EditQuickFilters()
 		{

--- a/Source/LibationWinForms/Dialogs/SettingsDialog.Designer.cs
+++ b/Source/LibationWinForms/Dialogs/SettingsDialog.Designer.cs
@@ -1211,8 +1211,8 @@
 		#endregion
 		private System.Windows.Forms.Label booksLocationDescLbl;
 		private System.Windows.Forms.Label inProgressDescLbl;
-		private System.Windows.Forms.Button saveBtn;
-		private System.Windows.Forms.Button cancelBtn;
+		public System.Windows.Forms.Button saveBtn;
+		public System.Windows.Forms.Button cancelBtn;
 		private System.Windows.Forms.CheckBox allowLibationFixupCbox;
 		private DirectoryOrCustomSelectControl booksSelectControl;
 		private DirectorySelectControl inProgressSelectControl;

--- a/Source/LibationWinForms/Walkthrough.cs
+++ b/Source/LibationWinForms/Walkthrough.cs
@@ -198,6 +198,7 @@ namespace LibationWinForms
 
 			await Task.Delay(750);
 			await displayControlAsync(MainForm.addQuickFilterBtn);
+			MainForm.Invoke(MainForm.addQuickFilterBtn.PerformClick);
 			await displayControlAsync(MainForm.quickFiltersToolStripMenuItem);
 			await displayControlAsync(MainForm.editQuickFiltersToolStripMenuItem);
 


### PR DESCRIPTION
- Flashing menu items and buttons are disabled until they're programmatically clicked (This was an absolute bitch to get working with Avalonia)
- `AccountsSettingsPersister` is disposed before scanning accounts. This should prevent file damage.
- Changed message verbage and added more info to some message boxes.
- Settings Cancel button is hidden, and the "Save" button is changed to "Next Tab" until all 4 tabs have been visited.
- ~~Disabling Quick Filter buttons is damned difficult. We'd have to:~~
  1. ~~Use binding to a custom QuickFilter class instead of DataGridView's internal list~~
  2. ~~Create a custom DataGridViewButtonColumn to override Paint~~
  3. ~~Create a custom BindingList that can change properties of the first and last elements when the collection changes.~~

~~I'm not doing that for such a minor graphical quirk.~~

Scratch that. My head is way too far into mvvm. I think you could just subscribe to the paint event and accomplish the same thing with a lot less code.