### PR TITLE
Bug fixes and more shared code moved to UI base

### DIFF
--- a/Source/LibationAvalonia/ViewModels/ProductsDisplayViewModel.cs
+++ b/Source/LibationAvalonia/ViewModels/ProductsDisplayViewModel.cs
@@ -322,7 +322,7 @@ namespace LibationAvalonia.ViewModels
 		{
 			var filterResults = SOURCE.FilterEntries(FilterString);
 
-			if (filterResults is not null && (FilteredInGridEntries is null || FilteredInGridEntries.Intersect(filterResults).Count() != FilteredInGridEntries.Count))
+			if (FilteredInGridEntries.SearchSetsDiffer(filterResults))
 			{
 				FilteredInGridEntries = filterResults;
 				await refreshGrid();

--- a/Source/LibationAvalonia/ViewModels/ProductsDisplayViewModel.cs
+++ b/Source/LibationAvalonia/ViewModels/ProductsDisplayViewModel.cs
@@ -23,7 +23,7 @@ namespace LibationAvalonia.ViewModels
 		/// <summary>Backing list of all grid entries</summary>
 		private readonly AvaloniaList<IGridEntry> SOURCE = new();
 		/// <summary>Grid entries included in the filter set. If null, all grid entries are shown</summary>
-		private List<IGridEntry> FilteredInGridEntries;
+		private HashSet<IGridEntry> FilteredInGridEntries;
 		public string FilterString { get; private set; }
 		public DataGridCollectionView GridEntries { get; private set; }
 
@@ -117,7 +117,7 @@ namespace LibationAvalonia.ViewModels
 			}
 
 			//Create the filtered-in list before adding entries to avoid a refresh
-			FilteredInGridEntries = QueryResults(geList.Union(geList.OfType<ISeriesEntry>().SelectMany(s => s.Children)), FilterString);
+			FilteredInGridEntries = geList.Union(geList.OfType<ISeriesEntry>().SelectMany(s => s.Children)).FilterEntries(FilterString);
 			SOURCE.AddRange(geList.OrderByDescending(e => e.DateAdded));
 
 			//Add all children beneath their parent
@@ -301,7 +301,7 @@ namespace LibationAvalonia.ViewModels
 			if (SOURCE.Count == 0)
 				return;
 
-			FilteredInGridEntries = QueryResults(SOURCE, searchString);
+			FilteredInGridEntries = SOURCE.FilterEntries(searchString);
 
 			await refreshGrid();
 		}
@@ -318,23 +318,9 @@ namespace LibationAvalonia.ViewModels
 			return FilteredInGridEntries.Contains(item);
 		}
 
-		private static List<IGridEntry> QueryResults(IEnumerable<IGridEntry> entries, string searchString)
-		{
-			if (string.IsNullOrEmpty(searchString)) return null;
-
-			var searchResultSet = SearchEngineCommands.Search(searchString);
-
-			var booksFilteredIn = entries.BookEntries().Join(searchResultSet.Docs, lbe => lbe.AudibleProductId, d => d.ProductId, (lbe, d) => (IGridEntry)lbe);
-
-			//Find all series containing children that match the search criteria
-			var seriesFilteredIn = entries.SeriesEntries().Where(s => s.Children.Join(searchResultSet.Docs, lbe => lbe.AudibleProductId, d => d.ProductId, (lbe, d) => lbe).Any());
-
-			return booksFilteredIn.Concat(seriesFilteredIn).ToList();
-		}
-
 		private async void SearchEngineCommands_SearchEngineUpdated(object sender, EventArgs e)
 		{
-			var filterResults = QueryResults(SOURCE, FilterString);
+			var filterResults = SOURCE.FilterEntries(FilterString);
 
 			if (filterResults is not null && FilteredInGridEntries.Intersect(filterResults).Count() != FilteredInGridEntries.Count)
 			{

--- a/Source/LibationAvalonia/ViewModels/ProductsDisplayViewModel.cs
+++ b/Source/LibationAvalonia/ViewModels/ProductsDisplayViewModel.cs
@@ -118,7 +118,7 @@ namespace LibationAvalonia.ViewModels
 
 			//Create the filtered-in list before adding entries to avoid a refresh
 			FilteredInGridEntries = geList.Union(geList.OfType<ISeriesEntry>().SelectMany(s => s.Children)).FilterEntries(FilterString);
-			SOURCE.AddRange(geList.OrderByDescending(e => e.DateAdded));
+			SOURCE.AddRange(geList.OrderDescending(new RowComparer(null)));
 
 			//Add all children beneath their parent
 			foreach (var series in SOURCE.OfType<ISeriesEntry>().ToList())

--- a/Source/LibationAvalonia/ViewModels/ProductsDisplayViewModel.cs
+++ b/Source/LibationAvalonia/ViewModels/ProductsDisplayViewModel.cs
@@ -322,7 +322,7 @@ namespace LibationAvalonia.ViewModels
 		{
 			var filterResults = SOURCE.FilterEntries(FilterString);
 
-			if (filterResults is not null && FilteredInGridEntries.Intersect(filterResults).Count() != FilteredInGridEntries.Count)
+			if (filterResults is not null && (FilteredInGridEntries is null || FilteredInGridEntries.Intersect(filterResults).Count() != FilteredInGridEntries.Count))
 			{
 				FilteredInGridEntries = filterResults;
 				await refreshGrid();

--- a/Source/LibationAvalonia/ViewModels/RowComparer.cs
+++ b/Source/LibationAvalonia/ViewModels/RowComparer.cs
@@ -1,25 +1,17 @@
 ﻿using Avalonia.Controls;
 using LibationUiBase.GridView;
-using System.Collections;
-using System.Collections.Generic;
 using System.ComponentModel;
 using System.Reflection;
 
 namespace LibationAvalonia.ViewModels
 {
-	/// <summary>
-	/// This compare class ensures that all top-level grid entries (standalone books or series parents)
-	/// are sorted by PropertyName while all episodes remain immediately beneath their parents and remain
-	/// sorted by series index, ascending. Stable sorting is achieved by comparing the GridEntry.ListIndex
-	/// properties when 2 items compare equal.
-	/// </summary>
-	internal class RowComparer : IComparer, IComparer<IGridEntry>, IComparer<object>
+	internal class RowComparer : RowComparerBase
 	{
 		private static readonly PropertyInfo HeaderCellPi = typeof(DataGridColumn).GetProperty("HeaderCell", BindingFlags.NonPublic | BindingFlags.Instance);
 		private static readonly PropertyInfo CurrentSortingStatePi = typeof(DataGridColumnHeader).GetProperty("CurrentSortingState", BindingFlags.NonPublic | BindingFlags.Instance);
 
-		public DataGridColumn Column { get; init; }
-		public string PropertyName { get; private set; }
+		private DataGridColumn Column { get; init; }
+		public override string PropertyName { get; set; }
 
 		public RowComparer(DataGridColumn column)
 		{
@@ -27,72 +19,8 @@ namespace LibationAvalonia.ViewModels
 			PropertyName = Column.SortMemberPath;
 		}
 
-		public int Compare(object x, object y)
-		{
-			if (x is null && y is not null) return -1;
-			if (x is not null && y is null) return 1;
-			if (x is null && y is null) return 0;
-
-			var geA = (IGridEntry)x;
-			var geB = (IGridEntry)y;
-
-			var sortDirection = GetSortOrder();
-
-			ISeriesEntry parentA = null;
-			ISeriesEntry parentB = null;
-
-			if (geA is ILibraryBookEntry lbA && lbA.Parent is ISeriesEntry seA)
-				parentA = seA;
-			if (geB is ILibraryBookEntry lbB && lbB.Parent is ISeriesEntry seB)
-				parentB = seB;
-
-			//both a and b are top-level grid entries
-			if (parentA is null && parentB is null)
-				return InternalCompare(geA, geB);
-
-			//a is top-level, b is a child
-			if (parentA is null && parentB is not null)
-			{
-				// b is a child of a, parent is always first
-				if (parentB == geA)
-					return sortDirection is ListSortDirection.Ascending ? -1 : 1;
-				else
-					return InternalCompare(geA, parentB);
-			}
-
-			//a is a child, b is a top-level
-			if (parentA is not null && parentB is null)
-			{
-				// a is a child of b, parent is always first
-				if (parentA == geB)
-					return sortDirection is ListSortDirection.Ascending ? 1 : -1;
-				else
-					return InternalCompare(parentA, geB);
-			}
-
-			//both are children of the same series
-			if (parentA == parentB)
-				return InternalCompare(geA, geB);
-
-			//a and b are children of different series.
-			return InternalCompare(parentA, parentB);
-		}
-
 		//Avalonia doesn't expose the column's CurrentSortingState, so we must get it through reflection
-		private ListSortDirection? GetSortOrder()
+		protected override ListSortDirection? GetSortOrder()
 			=> CurrentSortingStatePi.GetValue(HeaderCellPi.GetValue(Column)) as ListSortDirection?;
-
-		private int InternalCompare(IGridEntry x, IGridEntry y)
-		{
-			var val1 = x.GetMemberValue(PropertyName);
-			var val2 = y.GetMemberValue(PropertyName);
-
-			return x.GetMemberComparer(val1.GetType()).Compare(val1, val2); ;
-		}
-
-		public int Compare(IGridEntry x, IGridEntry y)
-		{
-			return Compare((object)x, y);
-		}
 	}
 }

--- a/Source/LibationAvalonia/ViewModels/RowComparer.cs
+++ b/Source/LibationAvalonia/ViewModels/RowComparer.cs
@@ -16,11 +16,13 @@ namespace LibationAvalonia.ViewModels
 		public RowComparer(DataGridColumn column)
 		{
 			Column = column;
-			PropertyName = Column.SortMemberPath;
+			PropertyName = Column?.SortMemberPath ?? nameof(IGridEntry.DateAdded);
 		}
 
 		//Avalonia doesn't expose the column's CurrentSortingState, so we must get it through reflection
-		protected override ListSortDirection? GetSortOrder()
-			=> CurrentSortingStatePi.GetValue(HeaderCellPi.GetValue(Column)) as ListSortDirection?;
+		protected override ListSortDirection GetSortOrder()
+			=> Column is null ? ListSortDirection.Descending
+			: CurrentSortingStatePi.GetValue(HeaderCellPi.GetValue(Column)) is ListSortDirection lsd ? lsd
+			: ListSortDirection.Descending;
 	}
 }

--- a/Source/LibationUiBase/GridView/EntryStatus.cs
+++ b/Source/LibationUiBase/GridView/EntryStatus.cs
@@ -58,7 +58,7 @@ namespace LibationUiBase.GridView
 		public abstract object BackgroundBrush { get; }
 		public object ButtonImage => GetLiberateIcon();
 		public string ToolTip => GetTooltip();
-		internal Book Book { get; }
+		private Book Book { get; }
 
 		private DateTime lastBookUpdate;
 		private LiberatedStatus bookStatus;

--- a/Source/LibationUiBase/GridView/EntryStatus.cs
+++ b/Source/LibationUiBase/GridView/EntryStatus.cs
@@ -58,7 +58,7 @@ namespace LibationUiBase.GridView
 		public abstract object BackgroundBrush { get; }
 		public object ButtonImage => GetLiberateIcon();
 		public string ToolTip => GetTooltip();
-		protected internal Book Book { get; internal set; }
+		internal Book Book { get; }
 
 		private DateTime lastBookUpdate;
 		private LiberatedStatus bookStatus;

--- a/Source/LibationUiBase/GridView/GridEntry[TStatus].cs
+++ b/Source/LibationUiBase/GridView/GridEntry[TStatus].cs
@@ -154,9 +154,13 @@ namespace LibationUiBase.GridView
 			if (udi.Book.AudibleProductId != Book.AudibleProductId)
 				return;
 
-			//If UserDefinedItem was changed on a different Book instance (such as when batch liberating via menus),
-			//EntryStatus' Book instance will not have the current DB state.
-			Liberate.Book = udi.Book;
+			if (udi.Book != LibraryBook.Book)
+			{
+				//If UserDefinedItem was changed on a different Book instance (such as when batch liberating via menus),
+				//Liberate.Book and LibraryBook.Book instances will not have the current DB state.
+				Invoke(() => UpdateLibraryBook(new LibraryBook(udi.Book, LibraryBook.DateAdded, LibraryBook.Account)));
+				return;
+			}
 
 			// UDI changed, possibly in a different context/view. Update this viewmodel. Call NotifyPropertyChanged to notify view.
 			// - This method responds to tons of incidental changes. Do not persist to db from here. Committing to db must be a volitional action by the caller, not incidental. Otherwise batch changes would be impossible; we would only have slow one-offs

--- a/Source/LibationUiBase/GridView/GridEntry[TStatus].cs
+++ b/Source/LibationUiBase/GridView/GridEntry[TStatus].cs
@@ -155,7 +155,7 @@ namespace LibationUiBase.GridView
 				return;
 
 			//If UserDefinedItem was changed on a different Book instance (such as when batch liberating via menus),
-			//EntryStatu's Book instance will not have the current DB state.
+			//EntryStatus' Book instance will not have the current DB state.
 			Liberate.Book = udi.Book;
 
 			// UDI changed, possibly in a different context/view. Update this viewmodel. Call NotifyPropertyChanged to notify view.

--- a/Source/LibationUiBase/GridView/QueryExtensions.cs
+++ b/Source/LibationUiBase/GridView/QueryExtensions.cs
@@ -41,6 +41,12 @@ namespace LibationUiBase.GridView
 			}
 		}
 
+		public static bool SearchSetsDiffer(this HashSet<IGridEntry>? searchSet, HashSet<IGridEntry>? otherSet)
+			=> searchSet is null != otherSet is null ||
+					(searchSet is not null &&
+					otherSet is not null &&
+					searchSet.Intersect(otherSet).Count() != searchSet.Count);
+
 		public static HashSet<IGridEntry>? FilterEntries(this IEnumerable<IGridEntry> entries, string searchString)
 		{
 			if (string.IsNullOrEmpty(searchString)) return null;

--- a/Source/LibationUiBase/GridView/QueryExtensions.cs
+++ b/Source/LibationUiBase/GridView/QueryExtensions.cs
@@ -1,4 +1,5 @@
-﻿using DataLayer;
+﻿using ApplicationServices;
+using DataLayer;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -38,6 +39,20 @@ namespace LibationUiBase.GridView
 				Serilog.Log.Error(ex, "Query error in {0}", nameof(FindSeriesParent));
 				return null;
 			}
+		}
+
+		public static HashSet<IGridEntry>? FilterEntries(this IEnumerable<IGridEntry> entries, string searchString)
+		{
+			if (string.IsNullOrEmpty(searchString)) return null;
+
+			var searchResultSet = SearchEngineCommands.Search(searchString);
+
+			var booksFilteredIn = entries.BookEntries().Join(searchResultSet.Docs, lbe => lbe.AudibleProductId, d => d.ProductId, (lbe, d) => (IGridEntry)lbe);
+
+			//Find all series containing children that match the search criteria
+			var seriesFilteredIn = entries.SeriesEntries().Where(s => s.Children.Join(searchResultSet.Docs, lbe => lbe.AudibleProductId, d => d.ProductId, (lbe, d) => lbe).Any());
+
+			return booksFilteredIn.Concat(seriesFilteredIn).ToHashSet();
 		}
 	}
 #nullable disable

--- a/Source/LibationUiBase/GridView/RowComparerBase.cs
+++ b/Source/LibationUiBase/GridView/RowComparerBase.cs
@@ -61,16 +61,10 @@ namespace LibationUiBase.GridView
 			{
 				//Podcast episodes usually all have the same PurchaseDate and DateAdded property:
 				//the date that the series was added to the library. So when sorting by PurchaseDate
-				//and DateAdded, compare SeriesOrder instead.
-				//
-				//Note that DateAdded is not a grid column and users cannot sort by that property.
-				//Entries are only sorted by DateAdded as a default sorting order when no other
-				//sorting column has been chose. We negate the comparison so that episodes are listed
-				//in ascending order.
+				//and DateAdded, compare SeriesOrder instead..
 				return PropertyName switch
 				{
-					nameof(IGridEntry.PurchaseDate) => geA.SeriesOrder.CompareTo(geB.SeriesOrder),
-					nameof(IGridEntry.DateAdded) => geA.SeriesOrder.CompareTo(geB.SeriesOrder) * (GetSortOrder() is ListSortDirection.Descending ? 1 : -1),
+					nameof(IGridEntry.DateAdded) or nameof (IGridEntry.PurchaseDate) => geA.SeriesOrder.CompareTo(geB.SeriesOrder),
 					_ => InternalCompare(geA, geB),
 				};
 			}
@@ -79,7 +73,7 @@ namespace LibationUiBase.GridView
 			return InternalCompare(parentA, parentB);
 		}
 
-		protected abstract ListSortDirection? GetSortOrder();
+		protected abstract ListSortDirection GetSortOrder();
 
 		private int InternalCompare(IGridEntry x, IGridEntry y)
 		{

--- a/Source/LibationUiBase/GridView/RowComparerBase.cs
+++ b/Source/LibationUiBase/GridView/RowComparerBase.cs
@@ -58,7 +58,22 @@ namespace LibationUiBase.GridView
 
 			//both are children of the same series
 			if (parentA == parentB)
-				return InternalCompare(geA, geB);
+			{
+				//Podcast episodes usually all have the same PurchaseDate and DateAdded property:
+				//the date that the series was added to the library. So when sorting by PurchaseDate
+				//and DateAdded, compare SeriesOrder instead.
+				//
+				//Note that DateAdded is not a grid column and users cannot sort by that property.
+				//Entries are only sorted by DateAdded as a default sorting order when no other
+				//sorting column has been chose. We negate the comparison so that episodes are listed
+				//in ascending order.
+				return PropertyName switch
+				{
+					nameof(IGridEntry.PurchaseDate) => geA.SeriesOrder.CompareTo(geB.SeriesOrder),
+					nameof(IGridEntry.DateAdded) => geA.SeriesOrder.CompareTo(geB.SeriesOrder) * (GetSortOrder() is ListSortDirection.Descending ? 1 : -1),
+					_ => InternalCompare(geA, geB),
+				};
+			}
 
 			//a and b are children of different series.
 			return InternalCompare(parentA, parentB);

--- a/Source/LibationUiBase/GridView/RowComparerBase.cs
+++ b/Source/LibationUiBase/GridView/RowComparerBase.cs
@@ -1,0 +1,82 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using System.ComponentModel;
+
+namespace LibationUiBase.GridView
+{
+	/// <summary>
+	/// This compare class ensures that all top-level grid entries (standalone books or series parents)
+	/// are sorted by PropertyName while all episodes remain immediately beneath their parents and remain
+	/// sorted by series index, ascending.
+	/// </summary>
+	public abstract class RowComparerBase : IComparer, IComparer<IGridEntry>, IComparer<object>
+	{
+		public abstract string PropertyName { get; set; }
+
+		public int Compare(object x, object y)
+		{
+			if (x is null && y is not null) return -1;
+			if (x is not null && y is null) return 1;
+			if (x is null && y is null) return 0;
+
+			var geA = (IGridEntry)x;
+			var geB = (IGridEntry)y;
+
+			var sortDirection = GetSortOrder();
+
+			ISeriesEntry parentA = null;
+			ISeriesEntry parentB = null;
+
+			if (geA is ILibraryBookEntry lbA && lbA.Parent is ISeriesEntry seA)
+				parentA = seA;
+			if (geB is ILibraryBookEntry lbB && lbB.Parent is ISeriesEntry seB)
+				parentB = seB;
+
+			//both a and b are top-level grid entries
+			if (parentA is null && parentB is null)
+				return InternalCompare(geA, geB);
+
+			//a is top-level, b is a child
+			if (parentA is null && parentB is not null)
+			{
+				// b is a child of a, parent is always first
+				if (parentB == geA)
+					return sortDirection is ListSortDirection.Ascending ? -1 : 1;
+				else
+					return InternalCompare(geA, parentB);
+			}
+
+			//a is a child, b is a top-level
+			if (parentA is not null && parentB is null)
+			{
+				// a is a child of b, parent is always first
+				if (parentA == geB)
+					return sortDirection is ListSortDirection.Ascending ? 1 : -1;
+				else
+					return InternalCompare(parentA, geB);
+			}
+
+			//both are children of the same series
+			if (parentA == parentB)
+				return InternalCompare(geA, geB);
+
+			//a and b are children of different series.
+			return InternalCompare(parentA, parentB);
+		}
+
+		protected abstract ListSortDirection? GetSortOrder();
+
+		private int InternalCompare(IGridEntry x, IGridEntry y)
+		{
+			var val1 = x.GetMemberValue(PropertyName);
+			var val2 = y.GetMemberValue(PropertyName);
+
+			return x.GetMemberComparer(val1.GetType()).Compare(val1, val2); ;
+		}
+
+		public int Compare(IGridEntry x, IGridEntry y)
+		{
+			return Compare((object)x, y);
+		}
+	}
+}

--- a/Source/LibationUiBase/GridView/SeriesEntry[TStatus].cs
+++ b/Source/LibationUiBase/GridView/SeriesEntry[TStatus].cs
@@ -47,7 +47,7 @@ namespace LibationUiBase.GridView
 
 			Children = children
 				.Select(c => new LibraryBookEntry<TStatus>(c, this))
-				.OrderBy(c => c.SeriesIndex)
+				.OrderByDescending(c => c.SeriesOrder)
 				.ToList<ILibraryBookEntry>();
 
 			UpdateLibraryBook(parent);

--- a/Source/LibationWinForms/GridView/GridEntryBindingList.cs
+++ b/Source/LibationWinForms/GridView/GridEntryBindingList.cs
@@ -56,9 +56,6 @@ namespace LibationWinForms.GridView
 			}
 		}
 
-		/// <summary>When true, itms will not be checked filtered by search criteria on item changed<summary>
-		public bool SuspendFilteringOnUpdate { get; set; }
-
 		protected RowComparer Comparer { get; } = new();
 		protected override bool SupportsSortingCore => true;
 		protected override bool SupportsSearchingCore => true;
@@ -112,7 +109,7 @@ namespace LibationWinForms.GridView
 				foreach (var newRemove in toRemoveEntries)
 				{
 					FilterRemoved.Add(newRemove);
-					Items.Remove(newRemove);
+					base.Remove(newRemove);
 				}
 			}
 
@@ -138,7 +135,7 @@ namespace LibationWinForms.GridView
 						continue;
 
 					FilterRemoved.Remove(addBack);
-					Items.Add(addBack);
+					Add(addBack);
 				}
 			}
 		}
@@ -147,7 +144,7 @@ namespace LibationWinForms.GridView
 		{
 			var filterResults = AllItems().FilterEntries(FilterString);
 
-			if (filterResults is not null && FilteredInGridEntries.Intersect(filterResults).Count() != FilteredInGridEntries.Count)
+			if (filterResults is not null && (FilteredInGridEntries is null || FilteredInGridEntries.Intersect(filterResults).Count() != FilteredInGridEntries.Count))
 			{
 				FilteredInGridEntries = filterResults;
 				refreshEntries();
@@ -181,7 +178,7 @@ namespace LibationWinForms.GridView
 		{
 			var sindex = Items.IndexOf(sEntry);
 
-			foreach (var episode in sEntry.Children.Intersect(FilterRemoved.BookEntries()).ToList())
+			foreach (var episode in Comparer.OrderEntries(sEntry.Children.Intersect(FilterRemoved.BookEntries())).ToList())
 			{
 				if (FilteredInGridEntries?.Contains(episode) ?? true)
 				{

--- a/Source/LibationWinForms/GridView/GridEntryBindingList.cs
+++ b/Source/LibationWinForms/GridView/GridEntryBindingList.cs
@@ -1,5 +1,4 @@
 ﻿using ApplicationServices;
-using Dinah.Core.DataBinding;
 using LibationUiBase.GridView;
 using System;
 using System.Collections.Generic;
@@ -25,6 +24,8 @@ namespace LibationWinForms.GridView
 		public GridEntryBindingList(IEnumerable<IGridEntry> enumeration) : base(new List<IGridEntry>(enumeration))
 		{
 			SearchEngineCommands.SearchEngineUpdated += SearchEngineCommands_SearchEngineUpdated;
+
+			refreshEntries();
 		}
 
 
@@ -216,9 +217,7 @@ namespace LibationWinForms.GridView
 		{
 			var itemsList = (List<IGridEntry>)Items;
 			//User Order/OrderDescending and replace items in list instead of using List.Sort() to achieve stable sorting.
-			var sortedItems
-				= Comparer.SortOrder == ListSortDirection.Ascending ? itemsList.Order(Comparer).ToList()
-				: itemsList.OrderDescending(Comparer).ToList();
+			var sortedItems = Comparer.OrderEntries(itemsList).ToList();
 
 			itemsList.Clear();
 			itemsList.AddRange(sortedItems);

--- a/Source/LibationWinForms/GridView/ProductsGrid.cs
+++ b/Source/LibationWinForms/GridView/ProductsGrid.cs
@@ -195,8 +195,6 @@ namespace LibationWinForms.GridView
 			string existingFilter = syncBindingSource.Filter;
 			Filter(null);
 
-			bindingList.SuspendFilteringOnUpdate = true;
-
 			//Add absent entries to grid, or update existing entry
 
 			var allEntries = bindingList.AllItems().BookEntries();
@@ -218,8 +216,6 @@ namespace LibationWinForms.GridView
 					AddOrUpdateEpisode(libraryBook, existingEntry, seriesEntries, dbBooks);
 				}
 			}
-
-			bindingList.SuspendFilteringOnUpdate = false;
 
 			//Re-apply filter after adding new/updating existing books to capture any changes
 			Filter(existingFilter);

--- a/Source/LibationWinForms/GridView/ProductsGrid.cs
+++ b/Source/LibationWinForms/GridView/ProductsGrid.cs
@@ -181,7 +181,7 @@ namespace LibationWinForms.GridView
 				geList.AddRange(seriesEntry.Children);
 			}
 
-			bindingList = new GridEntryBindingList(geList.OrderByDescending(e => e.DateAdded));
+			bindingList = new GridEntryBindingList(geList);
 			bindingList.CollapseAll();
 			syncBindingSource.DataSource = bindingList;
 			VisibleCountChanged?.Invoke(this, bindingList.GetFilteredInItems().Count());

--- a/Source/LibationWinForms/GridView/RowComparer.cs
+++ b/Source/LibationWinForms/GridView/RowComparer.cs
@@ -1,12 +1,20 @@
 ﻿using LibationUiBase.GridView;
+using System.Collections.Generic;
 using System.ComponentModel;
+using System.Linq;
 
 namespace LibationWinForms.GridView
 {
 	internal class RowComparer : RowComparerBase
 	{
-		public ListSortDirection? SortOrder { get; set; }
-		public override string PropertyName { get; set; }
-		protected override ListSortDirection? GetSortOrder() => SortOrder;
+		public ListSortDirection SortOrder { get; set; } = ListSortDirection.Descending;
+		public override string PropertyName { get; set; } = nameof(IGridEntry.DateAdded);
+		protected override ListSortDirection GetSortOrder() => SortOrder;
+
+		/// <summary>
+		/// Helper method for ordering grid entries
+		/// </summary>
+		public IOrderedEnumerable<IGridEntry> OrderEntries(IEnumerable<IGridEntry> entries)
+			=> SortOrder is ListSortDirection.Descending ? entries.OrderDescending(this) : entries.Order(this);
 	}
 }

--- a/Source/LibationWinForms/GridView/RowComparer.cs
+++ b/Source/LibationWinForms/GridView/RowComparer.cs
@@ -1,0 +1,12 @@
+﻿using LibationUiBase.GridView;
+using System.ComponentModel;
+
+namespace LibationWinForms.GridView
+{
+	internal class RowComparer : RowComparerBase
+	{
+		public ListSortDirection? SortOrder { get; set; }
+		public override string PropertyName { get; set; }
+		protected override ListSortDirection? GetSortOrder() => SortOrder;
+	}
+}


### PR DESCRIPTION
## [Move filter query and RowComparer into UI base](https://github.com/rmcrackan/Libation/commit/666b5d83dfaf0dfa300945e9fc303ecb2a3ee401)

Chardonnay uses a custom comparer for sorting all grid entries (It has to be this way to work with Avalonia's DataGridColumn sorting), but it's darned useful because it takes care of sorting all episodes beneath their parents.

I also moved chardonnay's filter query into UI base.

## [Update GridEntryBindingList to behave move like Chardonnay](https://github.com/rmcrackan/Libation/commit/6800986f258ebbafeac54bd58b2e26233b45fa8f)

Chardonnay was just plain better at sorting/filtering than classic, so I made classic more like chardonnay.

## [Fix #574 (for realsies this time)](https://github.com/rmcrackan/Libation/commit/8a1b375f0dc307e9b7a3dd4d8720b6ab7a8b51db)
Pretty self explanatory. Ensure that the GridEntry's LibraryBook is always fresh.

## [Change episode default sorting to SeriesOrder descending](https://github.com/rmcrackan/Libation/commit/af8e1cd5eff9794f34888177f0f3550818ffdbca)

Episodes are sorted by series index, descending by default.
