### PR TITLE
Serilog log to zip file

### DIFF
--- a/Source/AppScaffolding/AppScaffolding.csproj
+++ b/Source/AppScaffolding/AppScaffolding.csproj
@@ -5,7 +5,8 @@
     <Version>10.1.0.1</Version>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Octokit" Version="5.0.2" />
+    <PackageReference Include="Octokit" Version="5.0.4" />
+    <PackageReference Include="Serilog.Sinks.ZipFile" Version="1.0.1" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\ApplicationServices\ApplicationServices.csproj" />

--- a/Source/AppScaffolding/LibationScaffolding.cs
+++ b/Source/AppScaffolding/LibationScaffolding.cs
@@ -118,8 +118,15 @@ namespace AppScaffolding
 
 		private static void ensureSerilogConfig(Configuration config)
 		{
-			if (config.GetObject("Serilog") is not null)
+			if (config.GetObject("Serilog") is JObject serilog)
+			{
+				if (serilog["WriteTo"] is JArray sinks && sinks.FirstOrDefault(s => s["Name"].Value<string>() is "File") is JToken fileSink)
+				{
+					fileSink["Name"] = "ZipFile";
+					config.SetNonString(serilog.DeepClone(), "Serilog");
+				}
 				return;
+			}
 
 			var serilogObj = new JObject
 			{
@@ -129,7 +136,7 @@ namespace AppScaffolding
 						// new JObject { {"Name", "Console" } }, // this has caused more problems than it's solved
 						new JObject
 						{
-							{ "Name", "File" },
+							{ "Name", "ZipFile" },
 							{ "Args",
 								new JObject
 								{

--- a/Source/AudibleUtilities/AudibleUtilities.csproj
+++ b/Source/AudibleUtilities/AudibleUtilities.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AudibleApi" Version="8.2.3.1" />
+    <PackageReference Include="AudibleApi" Version="8.3.0.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Source/FileManager/BackgroundFileSystem.cs
+++ b/Source/FileManager/BackgroundFileSystem.cs
@@ -147,7 +147,8 @@ namespace FileManager
         private void AddPath(LongPath path)
         {
             path = path.LongPathName;
-            if (!File.Exists(path) && !Directory.Exists(path))
+            //Temporary files created when updating the db will disappear before their attributes can be read.
+            if (Path.GetFileName(path).Contains("LibationContext.db") || !File.Exists(path) && !Directory.Exists(path))
                 return;
             if (File.GetAttributes(path).HasFlag(FileAttributes.Directory))
                 AddUniqueFiles(FileUtility.SaferEnumerateFiles(path, SearchPattern, SearchOption));

--- a/Source/LibationAvalonia/Dialogs/Login/LoginChoiceEagerDialog.axaml
+++ b/Source/LibationAvalonia/Dialogs/Login/LoginChoiceEagerDialog.axaml
@@ -2,9 +2,9 @@
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-        mc:Ignorable="d" d:DesignWidth="350" d:DesignHeight="200"
-		MinWidth="350" MinHeight="200"
-		Width="350" Height="200"
+        mc:Ignorable="d" d:DesignWidth="360" d:DesignHeight="200"
+		MinWidth="370" MinHeight="200"
+		Width="370" Height="200"
 		WindowStartupLocation="CenterOwner"
 		xmlns:controls="clr-namespace:LibationAvalonia.Controls"
         x:Class="LibationAvalonia.Dialogs.Login.LoginChoiceEagerDialog"
@@ -60,7 +60,7 @@
 
 			<controls:LinkLabel
 				Tapped="ExternalLoginLink_Tapped"
-				Text="Or click here to log in with your browser." />
+				Text="Trouble logging in? Click here to log in with your browser." />
 			
 			<TextBlock
 				TextWrapping="Wrap"

--- a/Source/LibationWinForms/Dialogs/Login/LoginChoiceEagerDialog.Designer.cs
+++ b/Source/LibationWinForms/Dialogs/Login/LoginChoiceEagerDialog.Designer.cs
@@ -28,123 +28,120 @@
 		/// </summary>
 		private void InitializeComponent()
 		{
-			this.passwordLbl = new System.Windows.Forms.Label();
-			this.passwordTb = new System.Windows.Forms.TextBox();
-			this.submitBtn = new System.Windows.Forms.Button();
-			this.localeLbl = new System.Windows.Forms.Label();
-			this.usernameLbl = new System.Windows.Forms.Label();
-			this.externalLoginLink = new System.Windows.Forms.LinkLabel();
-			this.externalLoginLbl2 = new System.Windows.Forms.Label();
-			this.externalLoginLbl1 = new System.Windows.Forms.Label();
-			this.SuspendLayout();
+			passwordLbl = new System.Windows.Forms.Label();
+			passwordTb = new System.Windows.Forms.TextBox();
+			submitBtn = new System.Windows.Forms.Button();
+			localeLbl = new System.Windows.Forms.Label();
+			usernameLbl = new System.Windows.Forms.Label();
+			externalLoginLink = new System.Windows.Forms.LinkLabel();
+			externalLoginLbl2 = new System.Windows.Forms.Label();
+			externalLoginLbl1 = new System.Windows.Forms.Label();
+			SuspendLayout();
 			// 
 			// passwordLbl
 			// 
-			this.passwordLbl.AutoSize = true;
-			this.passwordLbl.Location = new System.Drawing.Point(14, 47);
-			this.passwordLbl.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
-			this.passwordLbl.Name = "passwordLbl";
-			this.passwordLbl.Size = new System.Drawing.Size(57, 15);
-			this.passwordLbl.TabIndex = 2;
-			this.passwordLbl.Text = "Password";
+			passwordLbl.AutoSize = true;
+			passwordLbl.Location = new System.Drawing.Point(14, 47);
+			passwordLbl.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+			passwordLbl.Name = "passwordLbl";
+			passwordLbl.Size = new System.Drawing.Size(57, 15);
+			passwordLbl.TabIndex = 2;
+			passwordLbl.Text = "Password";
 			// 
 			// passwordTb
 			// 
-			this.passwordTb.Location = new System.Drawing.Point(83, 44);
-			this.passwordTb.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
-			this.passwordTb.Name = "passwordTb";
-			this.passwordTb.PasswordChar = '*';
-			this.passwordTb.Size = new System.Drawing.Size(233, 23);
-			this.passwordTb.TabIndex = 3;
+			passwordTb.Location = new System.Drawing.Point(83, 44);
+			passwordTb.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+			passwordTb.Name = "passwordTb";
+			passwordTb.PasswordChar = '*';
+			passwordTb.Size = new System.Drawing.Size(233, 23);
+			passwordTb.TabIndex = 3;
 			// 
 			// submitBtn
 			// 
-			this.submitBtn.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
-			this.submitBtn.Location = new System.Drawing.Point(293, 176);
-			this.submitBtn.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
-			this.submitBtn.Name = "submitBtn";
-			this.submitBtn.Size = new System.Drawing.Size(88, 27);
-			this.submitBtn.TabIndex = 7;
-			this.submitBtn.Text = "Submit";
-			this.submitBtn.UseVisualStyleBackColor = true;
-			this.submitBtn.Click += new System.EventHandler(this.submitBtn_Click);
+			submitBtn.Anchor = System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right;
+			submitBtn.Location = new System.Drawing.Point(293, 176);
+			submitBtn.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+			submitBtn.Name = "submitBtn";
+			submitBtn.Size = new System.Drawing.Size(88, 27);
+			submitBtn.TabIndex = 7;
+			submitBtn.Text = "Submit";
+			submitBtn.UseVisualStyleBackColor = true;
+			submitBtn.Click += submitBtn_Click;
 			// 
 			// localeLbl
 			// 
-			this.localeLbl.AutoSize = true;
-			this.localeLbl.Location = new System.Drawing.Point(14, 10);
-			this.localeLbl.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
-			this.localeLbl.Name = "localeLbl";
-			this.localeLbl.Size = new System.Drawing.Size(61, 15);
-			this.localeLbl.TabIndex = 0;
-			this.localeLbl.Text = "Locale: {0}";
+			localeLbl.AutoSize = true;
+			localeLbl.Location = new System.Drawing.Point(14, 10);
+			localeLbl.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+			localeLbl.Name = "localeLbl";
+			localeLbl.Size = new System.Drawing.Size(61, 15);
+			localeLbl.TabIndex = 0;
+			localeLbl.Text = "Locale: {0}";
 			// 
 			// usernameLbl
 			// 
-			this.usernameLbl.AutoSize = true;
-			this.usernameLbl.Location = new System.Drawing.Point(14, 25);
-			this.usernameLbl.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
-			this.usernameLbl.Name = "usernameLbl";
-			this.usernameLbl.Size = new System.Drawing.Size(80, 15);
-			this.usernameLbl.TabIndex = 1;
-			this.usernameLbl.Text = "Username: {0}";
+			usernameLbl.AutoSize = true;
+			usernameLbl.Location = new System.Drawing.Point(14, 25);
+			usernameLbl.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+			usernameLbl.Name = "usernameLbl";
+			usernameLbl.Size = new System.Drawing.Size(80, 15);
+			usernameLbl.TabIndex = 1;
+			usernameLbl.Text = "Username: {0}";
 			// 
 			// externalLoginLink
 			// 
-			this.externalLoginLink.AutoSize = true;
-			this.externalLoginLink.Location = new System.Drawing.Point(14, 93);
-			this.externalLoginLink.Name = "externalLoginLink";
-			this.externalLoginLink.Size = new System.Drawing.Size(107, 15);
-			this.externalLoginLink.TabIndex = 4;
-			this.externalLoginLink.TabStop = true;
-			this.externalLoginLink.Text = "Or click here to log";
-			this.externalLoginLink.LinkClicked += new System.Windows.Forms.LinkLabelLinkClickedEventHandler(this.externalLoginLink_LinkClicked);
+			externalLoginLink.AutoSize = true;
+			externalLoginLink.Location = new System.Drawing.Point(14, 93);
+			externalLoginLink.Name = "externalLoginLink";
+			externalLoginLink.Size = new System.Drawing.Size(166, 15);
+			externalLoginLink.TabIndex = 4;
+			externalLoginLink.TabStop = true;
+			externalLoginLink.Text = "Trouble Logging in? Click here";
+			externalLoginLink.LinkClicked += externalLoginLink_LinkClicked;
 			// 
 			// externalLoginLbl2
 			// 
-			this.externalLoginLbl2.AutoSize = true;
-			this.externalLoginLbl2.Location = new System.Drawing.Point(14, 108);
-			this.externalLoginLbl2.Name = "externalLoginLbl2";
-			this.externalLoginLbl2.Size = new System.Drawing.Size(352, 45);
-			this.externalLoginLbl2.TabIndex = 6;
-			this.externalLoginLbl2.Text = "This more advanced login is recommended if you\'re experiencing\r\nerrors logging in" +
-    " the conventional way above or if you\'re not\r\ncomfortable typing your password h" +
-    "ere.";
+			externalLoginLbl2.AutoSize = true;
+			externalLoginLbl2.Location = new System.Drawing.Point(14, 108);
+			externalLoginLbl2.Name = "externalLoginLbl2";
+			externalLoginLbl2.Size = new System.Drawing.Size(352, 45);
+			externalLoginLbl2.TabIndex = 6;
+			externalLoginLbl2.Text = "This more advanced login is recommended if you're experiencing\r\nerrors logging in the conventional way above or if you're not\r\ncomfortable typing your password here.";
 			// 
 			// externalLoginLbl1
 			// 
-			this.externalLoginLbl1.AutoSize = true;
-			this.externalLoginLbl1.Location = new System.Drawing.Point(83, 93);
-			this.externalLoginLbl1.Name = "externalLoginLbl1";
-			this.externalLoginLbl1.Size = new System.Drawing.Size(158, 15);
-			this.externalLoginLbl1.TabIndex = 5;
-			this.externalLoginLbl1.Text = "to log in using your browser.";
+			externalLoginLbl1.AutoSize = true;
+			externalLoginLbl1.Location = new System.Drawing.Point(177, 93);
+			externalLoginLbl1.Name = "externalLoginLbl1";
+			externalLoginLbl1.Size = new System.Drawing.Size(158, 15);
+			externalLoginLbl1.TabIndex = 5;
+			externalLoginLbl1.Text = "to log in using your browser.";
 			// 
 			// LoginChoiceEagerDialog
 			// 
-			this.AcceptButton = this.submitBtn;
-			this.AutoScaleDimensions = new System.Drawing.SizeF(7F, 15F);
-			this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-			this.ClientSize = new System.Drawing.Size(394, 216);
-			this.Controls.Add(this.externalLoginLbl2);
-			this.Controls.Add(this.externalLoginLbl1);
-			this.Controls.Add(this.externalLoginLink);
-			this.Controls.Add(this.usernameLbl);
-			this.Controls.Add(this.localeLbl);
-			this.Controls.Add(this.submitBtn);
-			this.Controls.Add(this.passwordLbl);
-			this.Controls.Add(this.passwordTb);
-			this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedDialog;
-			this.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
-			this.MaximizeBox = false;
-			this.MinimizeBox = false;
-			this.Name = "LoginChoiceEagerDialog";
-			this.ShowIcon = false;
-			this.StartPosition = System.Windows.Forms.FormStartPosition.CenterParent;
-			this.Text = "Audible Login";
-			this.ResumeLayout(false);
-			this.PerformLayout();
-
+			AcceptButton = submitBtn;
+			AutoScaleDimensions = new System.Drawing.SizeF(7F, 15F);
+			AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+			ClientSize = new System.Drawing.Size(394, 216);
+			Controls.Add(externalLoginLbl2);
+			Controls.Add(externalLoginLbl1);
+			Controls.Add(externalLoginLink);
+			Controls.Add(usernameLbl);
+			Controls.Add(localeLbl);
+			Controls.Add(submitBtn);
+			Controls.Add(passwordLbl);
+			Controls.Add(passwordTb);
+			FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedDialog;
+			Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+			MaximizeBox = false;
+			MinimizeBox = false;
+			Name = "LoginChoiceEagerDialog";
+			ShowIcon = false;
+			StartPosition = System.Windows.Forms.FormStartPosition.CenterParent;
+			Text = "Audible Login";
+			ResumeLayout(false);
+			PerformLayout();
 		}
 
 		#endregion


### PR DESCRIPTION
This is really cool. I created a new sink for serilog, [Serilog.Sinks.ZipFile](https://github.com/Mbucari/serilog-sinks-zipfile/tree/master/src/Serilog.Sinks.ZipFile), to directly into a zip file.
From the outside it behaves exactly like `Serilog.Sinks.File`. Naming, filename increments, rolling intervals, etc. The difference are:

- The log text is created as a file inside the zip file (with no compression to improve logging performance)
- Supplemental files can be added [as described in the docs](https://github.com/Mbucari/serilog-sinks-zipfile#logging-files-into-the-zip)


The zip is saved after each log event is written.