### PR TITLE
Use old activation bytes if present.

### DIFF
--- a/Source/AaxDecrypter/AaxcDownloadConvertBase.cs
+++ b/Source/AaxDecrypter/AaxcDownloadConvertBase.cs
@@ -32,7 +32,11 @@ namespace AaxDecrypter
 		protected bool Step_GetMetadata()
 		{
 			AaxFile = new AaxFile(InputFileStream);
-			AaxFile.SetDecryptionKey(DownloadOptions.AudibleKey, DownloadOptions.AudibleIV);
+
+			if (DownloadOptions.AudibleKey?.Length == 8 && DownloadOptions.AudibleIV is null)
+				AaxFile.SetDecryptionKey(DownloadOptions.AudibleKey);
+			else
+				AaxFile.SetDecryptionKey(DownloadOptions.AudibleKey, DownloadOptions.AudibleIV);
 
 			if (DownloadOptions.StripUnabridged)
 			{

--- a/Source/AaxDecrypter/AudiobookDownloadBase.cs
+++ b/Source/AaxDecrypter/AudiobookDownloadBase.cs
@@ -182,7 +182,6 @@ namespace AaxDecrypter
 			FileUtility.SaferDelete(jsonDownloadState);
 
 			if (!string.IsNullOrEmpty(DownloadOptions.AudibleKey) &&
-				!string.IsNullOrEmpty(DownloadOptions.AudibleIV) &&
 				DownloadOptions.RetainEncryptedFile)
 			{
 				string aaxPath = Path.ChangeExtension(tempFilePath, ".aax");

--- a/Source/AudibleUtilities/AudibleUtilities.csproj
+++ b/Source/AudibleUtilities/AudibleUtilities.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AudibleApi" Version="8.3.0.1" />
+    <PackageReference Include="AudibleApi" Version="8.4.0.1" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This change is all that's needed to use the new aax fallback method in https://github.com/rmcrackan/AudibleApi/pull/45