### PR TITLE
Overhaul LibationCli and add Download Quality Option

### DIFF
--- a/Source/AaxDecrypter/AaxDecrypter.csproj
+++ b/Source/AaxDecrypter/AaxDecrypter.csproj
@@ -13,7 +13,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-	  <PackageReference Include="AAXClean.Codecs" Version="1.0.4" />
+	  <PackageReference Include="AAXClean.Codecs" Version="1.1.0" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/Source/AaxDecrypter/AaxcDownloadConvertBase.cs
+++ b/Source/AaxDecrypter/AaxcDownloadConvertBase.cs
@@ -51,6 +51,34 @@ namespace AaxDecrypter
 
 				if (!string.IsNullOrWhiteSpace(AaxFile.AppleTags.Copyright))
 					AaxFile.AppleTags.Copyright = AaxFile.AppleTags.Copyright.Replace("(P)", "℗").Replace("&#169;", "©");
+
+				//Add audiobook shelf tags
+				//https://github.com/advplyr/audiobookshelf/issues/1794#issuecomment-1565050213
+				const string tagDomain = "com.pilabor.tone";
+
+				AaxFile.AppleTags.Title = DownloadOptions.Title;
+
+				if (DownloadOptions.Subtitle is string subtitle)
+					AaxFile.AppleTags.AppleListBox.EditOrAddFreeformTag(tagDomain, "SUBTITLE", subtitle);
+
+				if (DownloadOptions.Publisher is string publisher)
+					AaxFile.AppleTags.AppleListBox.EditOrAddFreeformTag(tagDomain, "PUBLISHER", publisher);
+
+				if (DownloadOptions.Language is string language)
+					AaxFile.AppleTags.AppleListBox.EditOrAddFreeformTag(tagDomain, "LANGUAGE", language);
+
+				if (DownloadOptions.AudibleProductId is string asin)
+				{
+					AaxFile.AppleTags.Asin = asin;
+					AaxFile.AppleTags.AppleListBox.EditOrAddTag("asin", asin);
+					AaxFile.AppleTags.AppleListBox.EditOrAddFreeformTag(tagDomain, "AUDIBLE_ASIN", asin);
+				}
+
+				if (DownloadOptions.SeriesName is string series)
+					AaxFile.AppleTags.AppleListBox.EditOrAddFreeformTag(tagDomain, "SERIES", series);
+
+				if (DownloadOptions.SeriesNumber is float part)
+					AaxFile.AppleTags.AppleListBox.EditOrAddFreeformTag(tagDomain, "PART", part.ToString());
 			}
 
 			//Finishing configuring lame encoder.

--- a/Source/AaxDecrypter/IDownloadOptions.cs
+++ b/Source/AaxDecrypter/IDownloadOptions.cs
@@ -21,7 +21,14 @@ namespace AaxDecrypter
         long DownloadSpeedBps { get; }
         ChapterInfo ChapterInfo { get; }
         bool FixupFile { get; }
-        NAudio.Lame.LameConfig LameConfig { get; }
+		string AudibleProductId { get; }
+		string Title { get; }
+		string Subtitle { get; }
+		string Publisher { get; }
+		string Language { get; }
+		string SeriesName { get; }
+		float? SeriesNumber { get; }
+		NAudio.Lame.LameConfig LameConfig { get; }
         bool Downsample { get; }
         bool MatchSourceBitrate { get; }
         bool MoveMoovToBeginning { get; }

--- a/Source/AaxDecrypter/MpegUtil.cs
+++ b/Source/AaxDecrypter/MpegUtil.cs
@@ -1,4 +1,5 @@
 ﻿using AAXClean;
+using AAXClean.Codecs;
 using NAudio.Lame;
 using System;
 
@@ -6,6 +7,7 @@ namespace AaxDecrypter
 {
 	public static class MpegUtil
 	{
+		private const string TagDomain = "com.pilabor.tone";
 		public static void ConfigureLameOptions(Mp4File mp4File, LameConfig lameConfig, bool downsample, bool matchSourceBitrate)
 		{
 			double bitrateMultiple = 1;
@@ -36,6 +38,21 @@ namespace AaxDecrypter
 				else if (lameConfig.VBR == VBRMode.ABR)
 					lameConfig.ABRRateKbps = kbps;
 			}
+
+			//Setup metadata tags
+			lameConfig.ID3 = mp4File.AppleTags.ToIDTags();
+
+			if (mp4File.AppleTags.AppleListBox.GetFreeformTagString(TagDomain, "SUBTITLE") is string subtitle)
+				lameConfig.ID3.Subtitle = subtitle;
+
+			if (mp4File.AppleTags.AppleListBox.GetFreeformTagString(TagDomain, "LANGUAGE") is string lang)
+				lameConfig.ID3.UserDefinedText.Add("LANGUAGE", lang);
+
+			if (mp4File.AppleTags.AppleListBox.GetFreeformTagString(TagDomain, "SERIES") is string series)
+				lameConfig.ID3.UserDefinedText.Add("SERIES", series);
+
+			if (mp4File.AppleTags.AppleListBox.GetFreeformTagString(TagDomain, "PART") is string part)
+				lameConfig.ID3.UserDefinedText.Add("PART", part);
 		}
 	}
 }

--- a/Source/AaxDecrypter/UnencryptedAudiobookDownloader.cs
+++ b/Source/AaxDecrypter/UnencryptedAudiobookDownloader.cs
@@ -26,11 +26,7 @@ namespace AaxDecrypter
 
 		protected override async Task<bool> Step_DownloadAndDecryptAudiobookAsync()
 		{
-			TaskCompletionSource completionSource = new();
-
-			InputFileStream.DownloadCompleted += (_, _) => completionSource.SetResult();
-
-			await completionSource.Task;
+			await InputFileStream.DownloadTask;
 
 			if (IsCanceled)
 				return false;

--- a/Source/AppScaffolding/LibationScaffolding.cs
+++ b/Source/AppScaffolding/LibationScaffolding.cs
@@ -43,21 +43,6 @@ namespace AppScaffolding
 		public static ReleaseIdentifier ReleaseIdentifier { get; private set; }
 		public static Variety Variety { get; private set; }
 
-		public static void SetReleaseIdentifier(Variety varietyType)
-		{
-			Variety = Enum.IsDefined(varietyType) ? varietyType : Variety.None;
-
-			var releaseID = (ReleaseIdentifier)((int)varietyType | (int)Configuration.OS | (int)RuntimeInformation.ProcessArchitecture);
-
-			if (Enum.IsDefined(releaseID))
-				ReleaseIdentifier = releaseID;
-			else
-			{
-				ReleaseIdentifier = ReleaseIdentifier.None;
-				Serilog.Log.Logger.Warning("Unknown release identifier @{DebugInfo}", new { Variety = varietyType, Configuration.OS, RuntimeInformation.ProcessArchitecture });
-			}
-		}
-
 		// AppScaffolding
 		private static Assembly _executingAssembly;
 		private static Assembly ExecutingAssembly
@@ -110,6 +95,22 @@ namespace AppScaffolding
 			ensureSerilogConfig(config);
 			configureLogging(config);
 			logStartupState(config);
+
+			#region Determine Libation Variery and Release ID
+
+			Variety = File.Exists("System.Windows.Forms.dll") ? Variety.Classic : Variety.Chardonnay;
+
+			var releaseID = (ReleaseIdentifier)((int)Variety | (int)Configuration.OS | (int)RuntimeInformation.ProcessArchitecture);
+
+			if (Enum.IsDefined(releaseID))
+				ReleaseIdentifier = releaseID;
+			else
+			{
+				ReleaseIdentifier = ReleaseIdentifier.None;
+				Serilog.Log.Logger.Warning("Unknown release identifier @{DebugInfo}", new { Variety, Configuration.OS, RuntimeInformation.ProcessArchitecture });
+			}
+
+			#endregion
 
 			// all else should occur after logging
 

--- a/Source/DataLayer/EfClasses/AudioFormat.cs
+++ b/Source/DataLayer/EfClasses/AudioFormat.cs
@@ -13,7 +13,11 @@ namespace DataLayer
         LC_64_22050_stereo = (64L << 18) | (22050 << 2) | 2,
         LC_64_44100_stereo = (64L << 18) | (44100 << 2) | 2,
         LC_128_44100_stereo = (128L << 18) | (44100 << 2) | 2,
-    }
+		AAX_22_32 = LC_32_22050_stereo,
+		AAX_22_64 = LC_64_22050_stereo,
+		AAX_44_64 = LC_64_44100_stereo,
+		AAX_44_128 = LC_128_44100_stereo
+	}
 
     public class AudioFormat : IComparable<AudioFormat>, IComparable
     {

--- a/Source/FileLiberator/DownloadDecryptBook.cs
+++ b/Source/FileLiberator/DownloadDecryptBook.cs
@@ -121,8 +121,9 @@ namespace FileLiberator
 
             downloadValidation(libraryBook);
 
+            var quality = (AudibleApi.DownloadQuality)config.FileDownloadQuality;
             var api = await libraryBook.GetApiAsync();
-            var contentLic = await api.GetDownloadLicenseAsync(libraryBook.Book.AudibleProductId);
+            var contentLic = await api.GetDownloadLicenseAsync(libraryBook.Book.AudibleProductId, quality);
             using var dlOptions = BuildDownloadOptions(libraryBook, config, contentLic);
 
             var outFileName = AudibleFileStorage.Audio.GetInProgressFilename(libraryBook, dlOptions.OutputFormat.ToString().ToLower());
@@ -169,7 +170,10 @@ namespace FileLiberator
                 ? contentLic.ContentMetadata.ChapterInfo.BrandIntroDurationMs
                 : 0;
 
-            var dlOptions = new DownloadOptions(config, libraryBook, contentLic?.ContentMetadata?.ContentUrl?.OfflineUrl)
+            //Set the requested AudioFormat for use in file naming templates
+			libraryBook.Book.AudioFormat = AudioFormat.FromString(contentLic.ContentMetadata.ContentReference.ContentFormat);
+
+			var dlOptions = new DownloadOptions(config, libraryBook, contentLic?.ContentMetadata?.ContentUrl?.OfflineUrl)
             {
                 AudibleKey = contentLic?.Voucher?.Key,
                 AudibleIV = contentLic?.Voucher?.Iv,

--- a/Source/FileLiberator/DownloadOptions.cs
+++ b/Source/FileLiberator/DownloadOptions.cs
@@ -21,6 +21,13 @@ namespace FileLiberator
 		public TimeSpan RuntimeLength { get; init; }
 		public OutputFormat OutputFormat { get; init; }
 		public ChapterInfo ChapterInfo { get; init; }
+		public string Title => LibraryBook.Book.Title;
+		public string Subtitle => LibraryBook.Book.Subtitle;
+		public string Publisher => LibraryBook.Book.Publisher;
+		public string Language => LibraryBook.Book.Language;
+		public string AudibleProductId => LibraryBookDto.AudibleProductId;
+		public string SeriesName => LibraryBookDto.SeriesName;
+		public float? SeriesNumber => LibraryBookDto.SeriesNumber;
 		public NAudio.Lame.LameConfig LameConfig { get; init; }
 		public string UserAgent => AudibleApi.Resources.Download_User_Agent;
 		public bool TrimOutputToChapterLength => config.AllowLibationFixup && config.StripAudibleBrandAudio;

--- a/Source/FileManager/LongPath.cs
+++ b/Source/FileManager/LongPath.cs
@@ -163,6 +163,11 @@ namespace FileManager
 
 		public override string ToString() => Path;
 
+		public override int GetHashCode() => Path.GetHashCode();
+		public override bool Equals(object obj) => obj is LongPath other && Path == other.Path;
+		public static bool operator ==(LongPath path1, LongPath path2) => path1.Equals(path2);
+		public static bool operator !=(LongPath path1, LongPath path2) => !path1.Equals(path2);
+
 
 		[DllImport("kernel32.dll", CharSet = CharSet.Unicode)]
 		private static extern int GetShortPathName([MarshalAs(UnmanagedType.LPWStr)] string path, [MarshalAs(UnmanagedType.LPWStr)] StringBuilder shortPath, int shortPathLength);

--- a/Source/HangoverAvalonia/HangoverAvalonia.csproj
+++ b/Source/HangoverAvalonia/HangoverAvalonia.csproj
@@ -67,13 +67,13 @@
 	</ItemGroup>
 	<ItemGroup>
 
-		<PackageReference Include="Avalonia" Version="11.0.0-rc1.1" />
-		<PackageReference Include="Avalonia.Desktop" Version="11.0.0-rc1.1" />
+		<PackageReference Include="Avalonia" Version="11.0.0-rc2.2" />
+		<PackageReference Include="Avalonia.Desktop" Version="11.0.0-rc2.2" />
 		<!--Condition below is needed to remove Avalonia.Diagnostics package from build output in Release configuration.-->
-		<PackageReference Condition="'$(Configuration)' == 'Debug'" Include="Avalonia.Diagnostics" Version="11.0.0-rc1.1" />
-		<PackageReference Include="Avalonia.ReactiveUI" Version="11.0.0-rc1.1" />
-		<PackageReference Include="Avalonia.Controls.ItemsRepeater" Version="11.0.0-rc1.1" />
-		<PackageReference Include="Avalonia.Themes.Fluent" Version="11.0.0-rc1.1" />
+		<PackageReference Condition="'$(Configuration)' == 'Debug'" Include="Avalonia.Diagnostics" Version="11.0.0-rc2.2" />
+		<PackageReference Include="Avalonia.ReactiveUI" Version="11.0.0-rc2.2" />
+		<PackageReference Include="Avalonia.Controls.ItemsRepeater" Version="11.0.0-rc2.2" />
+		<PackageReference Include="Avalonia.Themes.Fluent" Version="11.0.0-rc2.2" />
 	</ItemGroup>
 	<ItemGroup>
 		<ProjectReference Include="..\HangoverBase\HangoverBase.csproj" />

--- a/Source/LibationAvalonia/Controls/Settings/Audio.axaml
+++ b/Source/LibationAvalonia/Controls/Settings/Audio.axaml
@@ -2,7 +2,7 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-             mc:Ignorable="d" d:DesignWidth="750" d:DesignHeight="600"
+             mc:Ignorable="d" d:DesignWidth="750" d:DesignHeight="650"
 			 xmlns:controls="clr-namespace:LibationAvalonia.Controls"
 			 xmlns:vm="clr-namespace:LibationAvalonia.ViewModels.Settings"
 			 x:DataType="vm:AudioSettingsVM"
@@ -31,6 +31,18 @@
 		<StackPanel
 			Grid.Row="0"
 			Grid.Column="0">
+
+			<Grid ColumnDefinitions="*,Auto">
+				<TextBlock
+					VerticalAlignment="Center"
+					Text="{CompiledBinding FileDownloadQualityText}" />
+
+				<controls:WheelComboBox
+					Margin="5,0,0,0"
+					Grid.Column="1"
+					ItemsSource="{CompiledBinding DownloadQualities}"
+					SelectedItem="{CompiledBinding FileDownloadQuality}"/>
+			</Grid>
 
 			<CheckBox IsChecked="{CompiledBinding CreateCueSheet, Mode=TwoWay}">
 				<TextBlock Text="{CompiledBinding CreateCueSheetText}" />

--- a/Source/LibationAvalonia/LibationAvalonia.csproj
+++ b/Source/LibationAvalonia/LibationAvalonia.csproj
@@ -70,13 +70,13 @@
 	</ItemGroup>
 
 	<ItemGroup>		
-		<PackageReference Include="Avalonia.Diagnostics" Version="11.0.0-rc1.1" Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'" />
-		<PackageReference Include="Avalonia" Version="11.0.0-rc1.1" />
-		<PackageReference Include="Avalonia.Controls.DataGrid" Version="11.0.0-rc1.1" />
-		<PackageReference Include="Avalonia.Controls.ItemsRepeater" Version="11.0.0-rc1.1" />
-		<PackageReference Include="Avalonia.Desktop" Version="11.0.0-rc1.1" />
-		<PackageReference Include="Avalonia.ReactiveUI" Version="11.0.0-rc1.1" />
-		<PackageReference Include="Avalonia.Themes.Fluent" Version="11.0.0-rc1.1" />
+		<PackageReference Include="Avalonia.Diagnostics" Version="11.0.0-rc2.2" Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'" />
+		<PackageReference Include="Avalonia" Version="11.0.0-rc2.2" />
+		<PackageReference Include="Avalonia.Controls.DataGrid" Version="11.0.0-rc2.2" />
+		<PackageReference Include="Avalonia.Controls.ItemsRepeater" Version="11.0.0-rc2.2" />
+		<PackageReference Include="Avalonia.Desktop" Version="11.0.0-rc2.2" />
+		<PackageReference Include="Avalonia.ReactiveUI" Version="11.0.0-rc2.2" />
+		<PackageReference Include="Avalonia.Themes.Fluent" Version="11.0.0-rc2.2" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/Source/LibationAvalonia/Program.cs
+++ b/Source/LibationAvalonia/Program.cs
@@ -48,12 +48,6 @@ namespace LibationAvalonia
 			var classicLifetimeTask = Task.Run(() => new ClassicDesktopStyleApplicationLifetime());
 			var appBuilderTask = Task.Run(BuildAvaloniaApp);
 
-			LibationScaffolding.SetReleaseIdentifier(Variety.Chardonnay);
-
-			if (LibationScaffolding.ReleaseIdentifier is ReleaseIdentifier.None)
-				return;
-
-
 			if (config.LibationSettingsAreValid)
 			{
 				if (!RunDbMigrations(config))
@@ -81,7 +75,7 @@ namespace LibationAvalonia
 				LibationScaffolding.RunPostConfigMigrations(config);
 				LibationScaffolding.RunPostMigrationScaffolding(config);
 
-				return true;
+				return LibationScaffolding.ReleaseIdentifier is not ReleaseIdentifier.None;
 			}
 			catch (Exception exDebug)
 			{

--- a/Source/LibationAvalonia/ViewModels/Settings/AudioSettingsVM.cs
+++ b/Source/LibationAvalonia/ViewModels/Settings/AudioSettingsVM.cs
@@ -48,6 +48,7 @@ namespace LibationAvalonia.ViewModels.Settings
 			DownloadCoverArt = config.DownloadCoverArt;
 			RetainAaxFile = config.RetainAaxFile;
 			DownloadClipsBookmarks = config.DownloadClipsBookmarks;
+			FileDownloadQuality = config.FileDownloadQuality;
 			ClipBookmarkFormat = config.ClipsBookmarksFileFormat;
 			SplitFilesByChapter = config.SplitFilesByChapter;
 			MergeOpeningAndEndCredits = config.MergeOpeningAndEndCredits;
@@ -74,6 +75,7 @@ namespace LibationAvalonia.ViewModels.Settings
 			config.DownloadCoverArt = DownloadCoverArt;
 			config.RetainAaxFile = RetainAaxFile;
 			config.DownloadClipsBookmarks = DownloadClipsBookmarks;
+			config.FileDownloadQuality = FileDownloadQuality;
 			config.ClipsBookmarksFileFormat = ClipBookmarkFormat;
 			config.SplitFilesByChapter = SplitFilesByChapter;
 			config.MergeOpeningAndEndCredits = MergeOpeningAndEndCredits;
@@ -93,7 +95,9 @@ namespace LibationAvalonia.ViewModels.Settings
 			config.MaxSampleRate = SelectedSampleRate?.Value ?? config.MaxSampleRate;
 		}
 
+		public AvaloniaList<Configuration.DownloadQuality> DownloadQualities { get; } = new(Enum<Configuration.DownloadQuality>.GetValues());
 		public AvaloniaList<Configuration.ClipBookmarkFormat> ClipBookmarkFormats { get; } = new(Enum<Configuration.ClipBookmarkFormat>.GetValues());
+		public string FileDownloadQualityText { get; } = Configuration.GetDescription(nameof(Configuration.FileDownloadQuality));
 		public string CreateCueSheetText { get; } = Configuration.GetDescription(nameof(Configuration.CreateCueSheet));
 		public string AllowLibationFixupText { get; } = Configuration.GetDescription(nameof(Configuration.AllowLibationFixup));
 		public string DownloadCoverArtText { get; } = Configuration.GetDescription(nameof(Configuration.DownloadCoverArt));
@@ -109,6 +113,7 @@ namespace LibationAvalonia.ViewModels.Settings
 		public bool DownloadCoverArt { get; set; }
 		public bool RetainAaxFile { get; set; }
 		public bool DownloadClipsBookmarks { get => _downloadClipsBookmarks; set => this.RaiseAndSetIfChanged(ref _downloadClipsBookmarks, value); }
+		public Configuration.DownloadQuality FileDownloadQuality { get; set; }
 		public Configuration.ClipBookmarkFormat ClipBookmarkFormat { get; set; }
 		public bool MergeOpeningAndEndCredits { get; set; }
 		public bool StripAudibleBrandAudio { get; set; }

--- a/Source/LibationCli/ConsoleProgressBar.cs
+++ b/Source/LibationCli/ConsoleProgressBar.cs
@@ -30,7 +30,6 @@ internal class ConsoleProgressBar
 		}
 	}
 
-
 	private double m_Progress;
 	private TimeSpan m_RemainingTime;
 	private int m_LastWriteLength = 0;
@@ -71,7 +70,7 @@ internal class ConsoleProgressBar
 
 	public void Clear()
 		=> Output.Write(
-			new string('\b', m_LastWriteLength)
-			+ new string(' ', m_LastWriteLength)
-			+ new string('\b', m_LastWriteLength));
+			new string('\b', m_LastWriteLength) +
+			new string(' ', m_LastWriteLength) +
+			new string('\b', m_LastWriteLength));
 }

--- a/Source/LibationCli/ConsoleProgressBar.cs
+++ b/Source/LibationCli/ConsoleProgressBar.cs
@@ -1,0 +1,77 @@
+﻿using System;
+using System.IO;
+
+namespace LibationCli;
+
+internal class ConsoleProgressBar
+{
+	public TextWriter Output { get; }
+	public int MaxWidth { get; }
+	public char ProgressChar { get; }
+	public char NoProgressChar { get; }
+
+	public double? Progress
+	{
+		get => m_Progress;
+		set
+		{
+			m_Progress = value ?? 0;
+			WriteProgress();
+		}
+	}
+
+	public TimeSpan RemainingTime
+	{
+		get => m_RemainingTime;
+		set
+		{
+			m_RemainingTime = value;
+			WriteProgress();
+		}
+	}
+
+
+	private double m_Progress;
+	private TimeSpan m_RemainingTime;
+	private int m_LastWriteLength = 0;
+	private const int MAX_ETA_LEN = 10;
+	private readonly int m_NumProgressPieces;
+
+	public ConsoleProgressBar(
+		TextWriter output,
+		int maxWidth = 80,
+		char progressCharr = '#',
+		char noProgressChar = '.')
+	{
+		Output = output;
+		MaxWidth = maxWidth;
+		ProgressChar = progressCharr;
+		NoProgressChar = noProgressChar;
+		m_NumProgressPieces = MaxWidth - MAX_ETA_LEN - 4;
+	}
+
+	private void WriteProgress()
+	{
+		var numCompleted = (int)Math.Round(double.Min(100, m_Progress) * m_NumProgressPieces / 100);
+		var numRemaining = m_NumProgressPieces - numCompleted;
+		var progressBar = $"[{new string(ProgressChar, numCompleted)}{new string(NoProgressChar, numRemaining)}]  ";
+
+		progressBar += RemainingTime.TotalMinutes > 1000
+			? "ETA ∞"
+			: $"ETA {(int)RemainingTime.TotalMinutes}:{RemainingTime.Seconds:D2}";
+
+		Output.Write(new string('\b', m_LastWriteLength) + progressBar);
+		if (progressBar.Length < m_LastWriteLength)
+		{
+			var extra = m_LastWriteLength - progressBar.Length;
+			Output.Write(new string(' ', extra) + new string('\b', extra));
+		}
+		m_LastWriteLength = progressBar.Length;
+	}
+
+	public void Clear()
+		=> Output.Write(
+			new string('\b', m_LastWriteLength)
+			+ new string(' ', m_LastWriteLength)
+			+ new string('\b', m_LastWriteLength));
+}

--- a/Source/LibationCli/HelpVerb.cs
+++ b/Source/LibationCli/HelpVerb.cs
@@ -16,18 +16,14 @@ internal class HelpVerb
 	/// <summary>
 	/// Create a base <see cref="HelpText"/> for <see cref="LibationCli"/>
 	/// </summary>
-	public static HelpText CreateHelpText()
+	public static HelpText CreateHelpText() => new HelpText
 	{
-		var auto = new HelpText
-		{
-			AutoVersion = false,
-			AutoHelp = false,
-			Heading = $"LibationCli v{LibationScaffolding.BuildVersion.ToString(3)}",
-			AdditionalNewLineAfterOption = true,
-			MaximumDisplayWidth = 80
-		};
-		return auto;
-	}
+		AutoVersion = false,
+		AutoHelp = false,
+		Heading = $"LibationCli v{LibationScaffolding.BuildVersion.ToString(3)}",
+		AdditionalNewLineAfterOption = true,
+		MaximumDisplayWidth = 80
+	};
 
 	/// <summary>
 	/// Get the <see cref="HelpType"/>'s <see cref="HelpText"/>
@@ -43,8 +39,8 @@ internal class HelpVerb
 		}
 		else
 		{
-			helpText.AddDashesToOption = true;
 			helpText.AutoHelp = true;
+			helpText.AddDashesToOption = true;
 			helpText.AddOptions(result);
 		}
 		return helpText;

--- a/Source/LibationCli/HelpVerb.cs
+++ b/Source/LibationCli/HelpVerb.cs
@@ -1,0 +1,52 @@
+﻿using AppScaffolding;
+using CommandLine;
+using CommandLine.Text;
+
+namespace LibationCli;
+
+[Verb("help", HelpText = "Display more information on a specific command.")]
+internal class HelpVerb
+{
+	/// <summary>
+	/// Name of the verb to get help about
+	/// </summary>
+	[Value(0, Default = "")]
+	public string HelpType { get; set; }
+
+	/// <summary>
+	/// Create a base <see cref="HelpText"/> for <see cref="LibationCli"/>
+	/// </summary>
+	public static HelpText CreateHelpText()
+	{
+		var auto = new HelpText
+		{
+			AutoVersion = false,
+			AutoHelp = false,
+			Heading = $"LibationCli v{LibationScaffolding.BuildVersion.ToString(3)}",
+			AdditionalNewLineAfterOption = true,
+			MaximumDisplayWidth = 80
+		};
+		return auto;
+	}
+
+	/// <summary>
+	/// Get the <see cref="HelpType"/>'s <see cref="HelpText"/>
+	/// </summary>
+	public HelpText GetHelpText()
+	{
+		var helpText = CreateHelpText();
+		var result = new Parser().ParseArguments(new string[] { HelpType }, Program.VerbTypes);
+		if (result.TypeInfo.Current == typeof(NullInstance))
+		{
+			//HelpType is not a defined verb so get LibationCli usage
+			helpText.AddVerbs(Program.VerbTypes);
+		}
+		else
+		{
+			helpText.AddDashesToOption = true;
+			helpText.AutoHelp = true;
+			helpText.AddOptions(result);
+		}
+		return helpText;
+	}
+}

--- a/Source/LibationCli/LibationCli.csproj
+++ b/Source/LibationCli/LibationCli.csproj
@@ -3,7 +3,8 @@
 
 	<PropertyGroup>
 		<OutputType>Exe</OutputType>
-		<TargetFramework>net7.0</TargetFramework>
+		<TargetFramework>net7.0-windows</TargetFramework>
+		<RuntimeIdentifier>win-x64</RuntimeIdentifier>
 		<PublishReadyToRun>true</PublishReadyToRun>
 		<AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
 		<AppendRuntimeIdentifierToOutputPath>false</AppendRuntimeIdentifierToOutputPath>

--- a/Source/LibationCli/Options/ConvertOptions.cs
+++ b/Source/LibationCli/Options/ConvertOptions.cs
@@ -1,8 +1,5 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
+﻿using CommandLine;
 using System.Threading.Tasks;
-using CommandLine;
 
 namespace LibationCli
 {

--- a/Source/LibationCli/Options/ExportOptions.cs
+++ b/Source/LibationCli/Options/ExportOptions.cs
@@ -27,13 +27,13 @@ namespace LibationCli
 		}
 		*/
 		#endregion
-		[Option(shortName: 'x', longName: "xlsx", HelpText = "Microsoft Excel Spreadsheet", SetName = "Export Format")]
+		[Option(shortName: 'x', longName: "xlsx", HelpText = "Microsoft Excel Spreadsheet", SetName = "xlsx")]
 		public bool xlsx { get; set; }
 
-		[Option(shortName: 'c', longName: "csv", HelpText = "Comma-separated values", SetName = "Export Format")]
+		[Option(shortName: 'c', longName: "csv", HelpText = "Comma-separated values", SetName = "csv")]
 		public bool csv { get; set; }
 
-		[Option(shortName: 'j', longName: "json", HelpText = "JavaScript Object Notation", SetName = "Export Format")]
+		[Option(shortName: 'j', longName: "json", HelpText = "JavaScript Object Notation", SetName = "json")]
 		public bool json { get; set; }
 
 		protected override Task ProcessAsync()

--- a/Source/LibationCli/Options/ExportOptions.cs
+++ b/Source/LibationCli/Options/ExportOptions.cs
@@ -1,10 +1,8 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
-using ApplicationServices;
-using AudibleUtilities;
+﻿using ApplicationServices;
 using CommandLine;
+using System;
+using System.IO;
+using System.Threading.Tasks;
 
 namespace LibationCli
 {
@@ -29,26 +27,38 @@ namespace LibationCli
 		}
 		*/
 		#endregion
-		[Option(shortName: 'x', longName: "xlsx", SetName = "xlsx", Required = true)]
+		[Option(shortName: 'x', longName: "xlsx", HelpText = "Microsoft Excel Spreadsheet", SetName = "Export Format")]
 		public bool xlsx { get; set; }
 
-		[Option(shortName: 'c', longName: "csv", SetName = "csv", Required = true)]
+		[Option(shortName: 'c', longName: "csv", HelpText = "Comma-separated values", SetName = "Export Format")]
 		public bool csv { get; set; }
 
-		[Option(shortName: 'j', longName: "json", SetName = "json", Required = true)]
+		[Option(shortName: 'j', longName: "json", HelpText = "JavaScript Object Notation", SetName = "Export Format")]
 		public bool json { get; set; }
 
 		protected override Task ProcessAsync()
 		{
-			if (xlsx)
-				LibraryExporter.ToXlsx(FilePath);
-			if (csv)
-				LibraryExporter.ToCsv(FilePath);
-			if (json)
-				LibraryExporter.ToJson(FilePath);
+			Action<string> exporter
+				= csv ? LibraryExporter.ToCsv
+				: json ? LibraryExporter.ToJson
+				: xlsx ? LibraryExporter.ToXlsx
+				: Path.GetExtension(FilePath)?.ToLower() switch
+				{
+					".xlsx" => LibraryExporter.ToXlsx,
+					".csv" => LibraryExporter.ToCsv,
+					".json" => LibraryExporter.ToJson,
+					_ => null
+				};
 
-			Console.WriteLine($"Library exported to: {FilePath}");
-
+			if (exporter is null)
+			{
+				PrintVerbUsage($"Undefined export format for file type \"{Path.GetExtension(FilePath)}\"");
+			}
+			else
+			{
+				exporter(FilePath);
+				Console.WriteLine($"Library exported to: {FilePath}");
+			}
 			return Task.CompletedTask;
 		}
 	}

--- a/Source/LibationCli/Options/LiberateOptions.cs
+++ b/Source/LibationCli/Options/LiberateOptions.cs
@@ -1,10 +1,7 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
-using CommandLine;
+﻿using CommandLine;
 using DataLayer;
 using FileLiberator;
+using System.Threading.Tasks;
 
 namespace LibationCli
 {

--- a/Source/LibationCli/Options/SearchOptions.cs
+++ b/Source/LibationCli/Options/SearchOptions.cs
@@ -3,48 +3,53 @@ using CommandLine;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Text;
 using System.Threading.Tasks;
 
-namespace LibationCli.Options
+namespace LibationCli.Options;
+
+[Verb("search", HelpText = "Search for books in your library")]
+internal class SearchOptions : OptionsBase
 {
-	[Verb("search", HelpText = "Search for books in your library")]
-	internal class SearchOptions : OptionsBase
+	[Value(0, MetaName = "query", Required = true, HelpText = "Lucene search string")]
+	public IEnumerable<string> Query { get; set; }
+
+	protected override Task ProcessAsync()
 	{
-		[Value(0, MetaName = "query", Required = true, HelpText = "Lucene search string")]
-		public IEnumerable<string> Query { get; set; }
+		var query = string.Join(" ", Query).Trim('\"');
+		var results = SearchEngineCommands.Search(query).Docs.ToList();
 
-		protected override Task ProcessAsync()
+		Console.WriteLine($"Found {results.Count} matching results.");
+
+		const int numResults = 10;
+
+		string nextPrompt = "Press any key for the next " + numResults + " results or Esc for all results";
+		bool waitForNextBatch = true;
+
+		for (int i = 0; i < results.Count; i += numResults)
 		{
-			var query = string.Join(" ", Query).Trim('\"');
-			var results = SearchEngineCommands.Search(query).Docs.ToList();
+			var sb = new StringBuilder();
+			for (int j = i; j < int.Min(results.Count, i + numResults); j++)
+				sb.AppendLine(getDocDisplay(results[j].Doc));
 
-			Console.WriteLine($"Found {results.Count} matching results.");
+			Console.Write(sb.ToString());
 
-			const string nextPrompt = "Press any key for the next 10 results or Esc for all results";
-			bool waitForNextBatch = true;
-
-			for (int i = 0; i < results.Count; i += 10)
+			if (waitForNextBatch)
 			{
-				foreach (var doc in results.Skip(i).Take(10))
-					Console.WriteLine(getDocDisplay(doc.Doc));
-
-				if (waitForNextBatch)
-				{
-					Console.Write(nextPrompt);
-					waitForNextBatch = Console.ReadKey(intercept: true).Key != ConsoleKey.Escape;
-					ReplaceConsoleText(Console.Out, nextPrompt.Length, "");
-					Console.SetCursorPosition(0, Console.CursorTop);
-				}
+				Console.Write(nextPrompt);
+				waitForNextBatch = Console.ReadKey(intercept: true).Key != ConsoleKey.Escape;
+				ReplaceConsoleText(Console.Out, nextPrompt.Length, "");
+				Console.CursorLeft = 0;
 			}
-
-			return Task.CompletedTask;
 		}
 
-		private static string getDocDisplay(Lucene.Net.Documents.Document doc)
-		{
-			var title = doc.GetField("title");
-			var id = doc.GetField("_ID_");
-			return $"[{id.StringValue}] - {title.StringValue}";
-		}
+		return Task.CompletedTask;
+	}
+
+	private static string getDocDisplay(Lucene.Net.Documents.Document doc)
+	{
+		var title = doc.GetField("title");
+		var id = doc.GetField("_ID_");
+		return $"[{id.StringValue}] - {title.StringValue}";
 	}
 }

--- a/Source/LibationCli/Options/SearchOptions.cs
+++ b/Source/LibationCli/Options/SearchOptions.cs
@@ -10,7 +10,7 @@ namespace LibationCli.Options
 	[Verb("search", HelpText = "Search for books in your library")]
 	internal class SearchOptions : OptionsBase
 	{
-		[Value(0, MetaName = "query", Required = true, HelpText = "Lucene query test to search")]
+		[Value(0, MetaName = "query", Required = true, HelpText = "Lucene search string")]
 		public IEnumerable<string> Query { get; set; }
 
 		protected override Task ProcessAsync()
@@ -31,7 +31,7 @@ namespace LibationCli.Options
 				if (waitForNextBatch)
 				{
 					Console.Write(nextPrompt);
-					waitForNextBatch = Console.ReadKey().Key != ConsoleKey.Escape;
+					waitForNextBatch = Console.ReadKey(intercept: true).Key != ConsoleKey.Escape;
 					ReplaceConsoleText(Console.Out, nextPrompt.Length, "");
 					Console.SetCursorPosition(0, Console.CursorTop);
 				}

--- a/Source/LibationCli/Options/SearchOptions.cs
+++ b/Source/LibationCli/Options/SearchOptions.cs
@@ -11,6 +11,9 @@ namespace LibationCli.Options;
 [Verb("search", HelpText = "Search for books in your library")]
 internal class SearchOptions : OptionsBase
 {
+	[Option('n', Default = 10, HelpText = "Number of search results per page")]
+	public int NumResultsPerPage { get; set; }
+
 	[Value(0, MetaName = "query", Required = true, HelpText = "Lucene search string")]
 	public IEnumerable<string> Query { get; set; }
 
@@ -21,15 +24,13 @@ internal class SearchOptions : OptionsBase
 
 		Console.WriteLine($"Found {results.Count} matching results.");
 
-		const int numResults = 10;
-
-		string nextPrompt = "Press any key for the next " + numResults + " results or Esc for all results";
+		string nextPrompt = "Press any key for the next " + NumResultsPerPage + " results or Esc for all results";
 		bool waitForNextBatch = true;
 
-		for (int i = 0; i < results.Count; i += numResults)
+		for (int i = 0; i < results.Count; i += NumResultsPerPage)
 		{
 			var sb = new StringBuilder();
-			for (int j = i; j < int.Min(results.Count, i + numResults); j++)
+			for (int j = i; j < int.Min(results.Count, i + NumResultsPerPage); j++)
 				sb.AppendLine(getDocDisplay(results[j].Doc));
 
 			Console.Write(sb.ToString());

--- a/Source/LibationCli/Options/SearchOptions.cs
+++ b/Source/LibationCli/Options/SearchOptions.cs
@@ -1,0 +1,50 @@
+﻿using ApplicationServices;
+using CommandLine;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace LibationCli.Options
+{
+	[Verb("search", HelpText = "Search for books in your library")]
+	internal class SearchOptions : OptionsBase
+	{
+		[Value(0, MetaName = "query", Required = true, HelpText = "Lucene query test to search")]
+		public IEnumerable<string> Query { get; set; }
+
+		protected override Task ProcessAsync()
+		{
+			var query = string.Join(" ", Query).Trim('\"');
+			var results = SearchEngineCommands.Search(query).Docs.ToList();
+
+			Console.WriteLine($"Found {results.Count} matching results.");
+
+			const string nextPrompt = "Press any key for the next 10 results or Esc for all results";
+			bool waitForNextBatch = true;
+
+			for (int i = 0; i < results.Count; i += 10)
+			{
+				foreach (var doc in results.Skip(i).Take(10))
+					Console.WriteLine(getDocDisplay(doc.Doc));
+
+				if (waitForNextBatch)
+				{
+					Console.Write(nextPrompt);
+					waitForNextBatch = Console.ReadKey().Key != ConsoleKey.Escape;
+					ReplaceConsoleText(Console.Out, nextPrompt.Length, "");
+					Console.SetCursorPosition(0, Console.CursorTop);
+				}
+			}
+
+			return Task.CompletedTask;
+		}
+
+		private static string getDocDisplay(Lucene.Net.Documents.Document doc)
+		{
+			var title = doc.GetField("title");
+			var id = doc.GetField("_ID_");
+			return $"[{id.StringValue}] - {title.StringValue}";
+		}
+	}
+}

--- a/Source/LibationCli/Options/SetDownloadStatusOptions.cs
+++ b/Source/LibationCli/Options/SetDownloadStatusOptions.cs
@@ -1,37 +1,69 @@
-﻿using System;
+﻿using ApplicationServices;
+using CommandLine;
+using DataLayer;
+using Dinah.Core;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
-using ApplicationServices;
-using AudibleUtilities;
-using CommandLine;
 
 namespace LibationCli
 {
-    [Verb("set-status", HelpText = """
-        Set download statuses throughout library based on whether each book's audio file can be found. 
-        Must include at least one flag: --downloaded , --not-downloaded. 
-        Downloaded: If the audio file can be found, set download status to 'Downloaded'. 
-        Not Downloaded: If the audio file cannot be found, set download status to 'Not Downloaded'
+	[Verb("set-status", HelpText = """
+        Set download statuses throughout library based on whether each book's audio file can be found.
         """)]
-    public class SetDownloadStatusOptions : OptionsBase
-    {
-        [Option(shortName: 'd', longName: "downloaded", Required = true)]
-        public bool SetDownloaded { get; set; }
+	public class SetDownloadStatusOptions : OptionsBase
+	{
+		[Option(shortName: 'd', longName: "downloaded", Group = "Download Status", HelpText = "set download status to 'Downloaded'")]
+		public bool SetDownloaded { get; set; }
 
-        [Option(shortName: 'n', longName: "not-downloaded", Required = true)]
-        public bool SetNotDownloaded { get; set; }
+		[Option(shortName: 'n', longName: "not-downloaded", Group = "Download Status", HelpText = "set download status to 'Downloaded'")]
+		public bool SetNotDownloaded { get; set; }
 
-        protected override async Task ProcessAsync()
-        {
-            var libraryBooks = DbContexts.GetLibrary_Flat_NoTracking();
+		[Option("force", HelpText = "Set the download status regardless of whether the book's audio file can be found. Only one download status option may be used with this option.")]
+		public bool Force { get; set; }
 
-            var bulkSetStatus = new BulkSetDownloadStatus(libraryBooks, SetDownloaded, SetNotDownloaded);
-            await Task.Run(() => bulkSetStatus.Discover());
-            bulkSetStatus.Execute();
+		[Value(0, MetaName = "[asins]", HelpText = "Optional product IDs of books on which to set download status.")]
+		public IEnumerable<string> Asins { get; set; }
 
-            foreach (var msg in bulkSetStatus.Messages)
-                Console.WriteLine(msg);
-        }
-    }
+		protected override async Task ProcessAsync()
+		{
+			if (Force && SetDownloaded && SetNotDownloaded)
+			{
+				PrintVerbUsage("ERROR:\nWhen run with --force option, only one download status option may be used.");
+				return;
+			}
+
+			var libraryBooks = DbContexts.GetLibrary_Flat_NoTracking();
+
+			if (Asins.Any())
+			{
+				var asins = Asins.Select(a => a.ToLower()).ToArray();
+				libraryBooks = libraryBooks.Where(lb => lb.Book.AudibleProductId.ToLower().In(asins)).ToList();
+
+				if (libraryBooks.Count == 0)
+				{
+					Console.Error.WriteLine("Could not find any books matching asins");
+					return;
+				}
+			}
+
+			if (Force)
+			{
+				var status = SetDownloaded ? LiberatedStatus.Liberated : LiberatedStatus.NotLiberated;
+
+				var num = libraryBooks.UpdateBookStatus(status);
+				Console.WriteLine($"Set LiberatedStatus to '{status}' on {"book".PluralizeWithCount(num)}");
+			}
+			else
+			{
+				var bulkSetStatus = new BulkSetDownloadStatus(libraryBooks, SetDownloaded, SetNotDownloaded);
+				await Task.Run(() => bulkSetStatus.Discover());
+				bulkSetStatus.Execute();
+
+				foreach (var msg in bulkSetStatus.Messages)
+					Console.WriteLine(msg);
+			}
+		}
+	}
 }

--- a/Source/LibationCli/Options/SetDownloadStatusOptions.cs
+++ b/Source/LibationCli/Options/SetDownloadStatusOptions.cs
@@ -14,6 +14,7 @@ namespace LibationCli
         """)]
 	public class SetDownloadStatusOptions : OptionsBase
 	{
+		//https://github.com/commandlineparser/commandline/wiki/Option-Groups
 		[Option(shortName: 'd', longName: "downloaded", Group = "Download Status", HelpText = "set download status to 'Downloaded'")]
 		public bool SetDownloaded { get; set; }
 

--- a/Source/LibationCli/Options/SetDownloadStatusOptions.cs
+++ b/Source/LibationCli/Options/SetDownloadStatusOptions.cs
@@ -17,7 +17,7 @@ namespace LibationCli
 		[Option(shortName: 'd', longName: "downloaded", Group = "Download Status", HelpText = "set download status to 'Downloaded'")]
 		public bool SetDownloaded { get; set; }
 
-		[Option(shortName: 'n', longName: "not-downloaded", Group = "Download Status", HelpText = "set download status to 'Downloaded'")]
+		[Option(shortName: 'n', longName: "not-downloaded", Group = "Download Status", HelpText = "set download status to 'Not Downloaded'")]
 		public bool SetNotDownloaded { get; set; }
 
 		[Option("force", HelpText = "Set the download status regardless of whether the book's audio file can be found. Only one download status option may be used with this option.")]
@@ -38,7 +38,7 @@ namespace LibationCli
 
 			if (Asins.Any())
 			{
-				var asins = Asins.Select(a => a.ToLower()).ToArray();
+				var asins = Asins.Select(a => a.TrimStart('[').TrimEnd(']').ToLower()).ToArray();
 				libraryBooks = libraryBooks.Where(lb => lb.Book.AudibleProductId.ToLower().In(asins)).ToList();
 
 				if (libraryBooks.Count == 0)

--- a/Source/LibationCli/Options/VersionOptions.cs
+++ b/Source/LibationCli/Options/VersionOptions.cs
@@ -1,0 +1,59 @@
+﻿using AppScaffolding;
+using CommandLine;
+using System;
+using System.Threading.Tasks;
+
+namespace LibationCli.Options;
+
+[Verb("version", HelpText = "Display version information.")]
+internal class VersionOptions : OptionsBase
+{
+	[Option('c', "check", Required = false, HelpText = "Check if an upgrade is available")]
+	public bool CheckForUpgrade { get; set; }
+
+	protected override Task ProcessAsync()
+	{
+		const string checkingForUpgrade = "Checking for upgrade...";
+		Console.WriteLine($"Libation {LibationScaffolding.Variety} v{LibationScaffolding.BuildVersion.ToString(3)}");
+
+		if (CheckForUpgrade)
+		{
+			Console.Write(checkingForUpgrade);
+
+			var origColor = Console.ForegroundColor;
+			try
+			{
+				var upgradeProperties = LibationScaffolding.GetLatestRelease();
+
+				if (upgradeProperties is null)
+				{
+					Console.ForegroundColor = ConsoleColor.Green;
+					ReplaceConsoleText(Console.Out, checkingForUpgrade.Length, "No available upgrade");
+					Console.WriteLine();
+				}
+				else
+				{
+					Console.ForegroundColor = ConsoleColor.Red;
+					ReplaceConsoleText(Console.Out, checkingForUpgrade.Length, $"Upgrade Available: v{upgradeProperties.LatestRelease.ToString(3)}");
+					Console.WriteLine();
+					Console.WriteLine();
+					Console.WriteLine(upgradeProperties.ZipUrl);
+					Console.WriteLine();
+					Console.WriteLine("Release Notes");
+					Console.WriteLine("=============");
+					Console.WriteLine(upgradeProperties.Notes);
+				}
+			}
+			catch
+			{
+				Console.Error.WriteLine("ERROR CHECKING FOR UPGRADE");
+			}
+			finally
+			{
+				Console.ForegroundColor = origColor;
+			}
+		}
+
+		return Task.CompletedTask;
+	}
+}

--- a/Source/LibationCli/Options/_OptionsBase.cs
+++ b/Source/LibationCli/Options/_OptionsBase.cs
@@ -1,8 +1,8 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
+﻿using CommandLine;
+using System;
+using System.IO;
+using System.Reflection;
 using System.Threading.Tasks;
-using CommandLine;
 
 namespace LibationCli
 {
@@ -17,13 +17,32 @@ namespace LibationCli
 			catch (Exception ex)
 			{
 				Environment.ExitCode = (int)ExitCode.RunTimeError;
-
-				Console.Error.WriteLine("ERROR");
-				Console.Error.WriteLine("=====");
-				Console.Error.WriteLine(ex.Message);
-				Console.Error.WriteLine();
-				Console.Error.WriteLine(ex.StackTrace);
+				PrintVerbUsage(new string[]
+				{
+					"ERROR",
+					"=====",
+					ex.Message,
+					"",
+					ex.StackTrace
+				});
 			}
+		}
+
+		protected void PrintVerbUsage(params string[] linesBeforeUsage)
+		{
+			var verb = GetType().GetCustomAttribute<VerbAttribute>().Name;
+			var helpText = new HelpVerb { HelpType = verb }.GetHelpText();
+			helpText.AddPreOptionsLines(linesBeforeUsage);
+			helpText.AddPreOptionsLine("");
+			helpText.AddPreOptionsLine($"{verb} Usage:");
+			Console.Error.WriteLine(helpText);
+		}
+
+		protected static void ReplaceConsoleText(TextWriter writer, int previousLength, string newText)
+		{
+			writer.Write(new string('\b', previousLength));
+			writer.Write(newText);
+			writer.Write(new string(' ', int.Max(0, previousLength - newText.Length)));
 		}
 
 		protected abstract Task ProcessAsync();

--- a/Source/LibationCli/Options/_ProcessableOptionsBase.cs
+++ b/Source/LibationCli/Options/_ProcessableOptionsBase.cs
@@ -1,23 +1,34 @@
-﻿using System;
+﻿using ApplicationServices;
+using CommandLine;
+using DataLayer;
+using Dinah.Core;
+using FileLiberator;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
-using ApplicationServices;
-using CommandLine;
-using DataLayer;
-using FileLiberator;
 
 namespace LibationCli
 {
 	public abstract class ProcessableOptionsBase : OptionsBase
 	{
+
+		[Value(0, MetaName = "[asins]", HelpText = "Optional product IDs of books to process.")]
+		public IEnumerable<string> Asins { get; set; }
+
 		protected static TProcessable CreateProcessable<TProcessable>(EventHandler<LibraryBook> completedAction = null)
 			where TProcessable : Processable, new()
 		{
+			var progressBar = new ConsoleProgressBar(Console.Out);
 			var strProc = new TProcessable();
 
 			strProc.Begin += (o, e) => Console.WriteLine($"{typeof(TProcessable).Name} Begin: {e}");
-			strProc.Completed += (o, e) => Console.WriteLine($"{typeof(TProcessable).Name} Completed: {e}");
+
+			strProc.Completed += (o, e) =>
+			{
+				progressBar.Clear();
+				Console.WriteLine($"{typeof(TProcessable).Name} Completed: {e}");
+			};
 
 			strProc.Completed += (s, e) =>
 			{
@@ -32,12 +43,23 @@ namespace LibationCli
 				}
 			};
 
+			strProc.StreamingTimeRemaining += (_, e) => progressBar.RemainingTime = e;
+			strProc.StreamingProgressChanged += (_, e) => progressBar.Progress = e.ProgressPercentage;
+
 			return strProc;
 		}
 
-		protected static async Task RunAsync(Processable Processable)
+		protected async Task RunAsync(Processable Processable)
 		{
-			foreach (var libraryBook in Processable.GetValidLibraryBooks(DbContexts.GetLibrary_Flat_NoTracking()))
+			var libraryBooks = DbContexts.GetLibrary_Flat_NoTracking().AsEnumerable();
+
+			if (Asins.Any())
+			{
+				var asinsLower = Asins.Select(a => a.ToLower()).ToArray();
+				libraryBooks = libraryBooks.Where(lb => lb.Book.AudibleProductId.ToLower().In(asinsLower));
+			}
+
+			foreach (var libraryBook in Processable.GetValidLibraryBooks(libraryBooks))
 				await ProcessOneAsync(Processable, libraryBook, false);
 
 			var done = "Done. All books have been processed";

--- a/Source/LibationCli/Options/_ProcessableOptionsBase.cs
+++ b/Source/LibationCli/Options/_ProcessableOptionsBase.cs
@@ -51,16 +51,20 @@ namespace LibationCli
 
 		protected async Task RunAsync(Processable Processable)
 		{
-			var libraryBooks = DbContexts.GetLibrary_Flat_NoTracking().AsEnumerable();
+			var libraryBooks = DbContexts.GetLibrary_Flat_NoTracking();
 
 			if (Asins.Any())
 			{
-				var asinsLower = Asins.Select(a => a.ToLower()).ToArray();
-				libraryBooks = libraryBooks.Where(lb => lb.Book.AudibleProductId.ToLower().In(asinsLower));
-			}
+				var asinsLower = Asins.Select(a => a.TrimStart('[').TrimEnd(']').ToLower()).ToArray();
 
-			foreach (var libraryBook in Processable.GetValidLibraryBooks(libraryBooks))
-				await ProcessOneAsync(Processable, libraryBook, false);
+				foreach (var lb in libraryBooks.Where(lb => lb.Book.AudibleProductId.ToLower().In(asinsLower)))
+					await ProcessOneAsync(Processable, lb, true);
+			}
+			else
+			{
+				foreach (var lb in Processable.GetValidLibraryBooks(libraryBooks))
+					await ProcessOneAsync(Processable, lb, false);
+			}
 
 			var done = "Done. All books have been processed";
 			Console.WriteLine(done);

--- a/Source/LibationCli/Program.cs
+++ b/Source/LibationCli/Program.cs
@@ -21,7 +21,7 @@ namespace LibationCli
 		{
 
 #if DEBUG
-			string input = null;
+			string input = "";
 
 			//input = "  set-status -n --force B017V4IM1G";
 			//input = "  liberate B017V4IM1G";

--- a/Source/LibationCli/Setup.cs
+++ b/Source/LibationCli/Setup.cs
@@ -10,11 +10,6 @@ namespace LibationCli
 	{
 		public static void Initialize()
 		{
-			//Determine variety by the dlls present in the current directory.
-			//Necessary to be able to check for upgrades.
-			var variety = System.IO.File.Exists("System.Windows.Forms.dll") ? Variety.Classic : Variety.Chardonnay;
-			LibationScaffolding.SetReleaseIdentifier(variety);
-
 			//***********************************************//
 			//                                               //
 			//   do not use Configuration before this line   //

--- a/Source/LibationCli/Setup.cs
+++ b/Source/LibationCli/Setup.cs
@@ -1,14 +1,8 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using AppScaffolding;
+using CommandLine;
+using System;
 using System.Linq;
 using System.Reflection;
-using System.Threading.Tasks;
-using AppScaffolding;
-using CommandLine;
-using CommandLine.Text;
-using Dinah.Core;
-using Dinah.Core.Collections;
-using Dinah.Core.Collections.Generic;
 
 namespace LibationCli
 {
@@ -16,6 +10,11 @@ namespace LibationCli
 	{
 		public static void Initialize()
 		{
+			//Determine variety by the dlls present in the current directory.
+			//Necessary to be able to check for upgrades.
+			var variety = System.IO.File.Exists("System.Windows.Forms.dll") ? Variety.Classic : Variety.Chardonnay;
+			LibationScaffolding.SetReleaseIdentifier(variety);
+
 			//***********************************************//
 			//                                               //
 			//   do not use Configuration before this line   //
@@ -26,28 +25,6 @@ namespace LibationCli
 
 			LibationScaffolding.RunPostConfigMigrations(config);
 			LibationScaffolding.RunPostMigrationScaffolding(config);
-
-#if !DEBUG
-			checkForUpdate();
-#endif
-		}
-
-		private static void checkForUpdate()
-		{
-			var upgradeProperties = LibationScaffolding.GetLatestRelease();
-			if (upgradeProperties is null)
-				return;
-
-			var origColor = Console.ForegroundColor;
-			try
-			{
-				Console.ForegroundColor = ConsoleColor.Red;
-				Console.WriteLine($"UPDATE AVAILABLE @ {upgradeProperties.ZipUrl}");
-			}
-			finally
-			{
-				Console.ForegroundColor = origColor;
-			}
 		}
 
 		public static Type[] LoadVerbs() => Assembly.GetExecutingAssembly()

--- a/Source/LibationFileManager/AudibleFileStorage.cs
+++ b/Source/LibationFileManager/AudibleFileStorage.cs
@@ -127,10 +127,10 @@ namespace LibationFileManager
 
             var regex = GetBookSearchRegex(productId);
 
-            //Find all extant files matching the priductID
-            //using both the file system and the file path cache
+			//Find all extant files matching the productId
+			//using both the file system and the file path cache
 			return
-                FilePathCache
+				FilePathCache
                 .GetFiles(productId)
                 .Where(c => c.fileType == FileType.Audio && File.Exists(c.path))
                 .Select(c => c.path)

--- a/Source/LibationFileManager/AudibleFileStorage.cs
+++ b/Source/LibationFileManager/AudibleFileStorage.cs
@@ -126,7 +126,16 @@ namespace LibationFileManager
                     BookDirectoryFiles = new BackgroundFileSystem(BooksDirectory, "*.*", SearchOption.AllDirectories);
 
             var regex = GetBookSearchRegex(productId);
-            return BookDirectoryFiles.FindFiles(regex);
+
+            //Find all extant files matching the priductID
+            //using both the file system and the file path cache
+			return
+                FilePathCache
+                .GetFiles(productId)
+                .Where(c => c.fileType == FileType.Audio && File.Exists(c.path))
+                .Select(c => c.path)
+                .Union(BookDirectoryFiles.FindFiles(regex))
+                .ToList();
         }
 
         public void Refresh() => BookDirectoryFiles.RefreshFiles();

--- a/Source/LibationFileManager/Configuration.PersistentSettings.cs
+++ b/Source/LibationFileManager/Configuration.PersistentSettings.cs
@@ -205,6 +205,16 @@ namespace LibationFileManager
 			Added
 		}
 
+		[JsonConverter(typeof(StringEnumConverter))]
+		public enum DownloadQuality
+		{
+			High,
+			Normal
+		}
+
+		[Description("Audio quality to request from Audible:")]
+		public DownloadQuality FileDownloadQuality { get => GetNonString(defaultValue: DownloadQuality.High); set => SetNonString(value); }
+
 		[Description("Set file \"created\" timestamp to:")]
 		public DateTimeSource CreationTime { get => GetNonString(defaultValue: DateTimeSource.File); set => SetNonString(value); }
 

--- a/Source/LibationWinForms/Dialogs/SettingsDialog.AudioSettings.cs
+++ b/Source/LibationWinForms/Dialogs/SettingsDialog.AudioSettings.cs
@@ -9,6 +9,7 @@ namespace LibationWinForms.Dialogs
 	{
 		private void Load_AudioSettings(Configuration config)
 		{
+			this.fileDownloadQualityLbl.Text = desc(nameof(config.FileDownloadQuality));
 			this.allowLibationFixupCbox.Text = desc(nameof(config.AllowLibationFixup));
 			this.createCueSheetCbox.Text = desc(nameof(config.CreateCueSheet));
 			this.downloadCoverArtCbox.Text = desc(nameof(config.DownloadCoverArt));
@@ -18,6 +19,13 @@ namespace LibationWinForms.Dialogs
 			this.stripAudibleBrandingCbox.Text = desc(nameof(config.StripAudibleBrandAudio));
 			this.stripUnabridgedCbox.Text = desc(nameof(config.StripUnabridged));
 			this.moveMoovAtomCbox.Text = desc(nameof(config.MoveMoovToBeginning));
+
+			fileDownloadQualityCb.Items.AddRange(
+				new object[]
+				{
+					Configuration.DownloadQuality.Normal,
+					Configuration.DownloadQuality.High
+				});
 
 			clipsBookmarksFormatCb.Items.AddRange(
 				new object[]
@@ -44,6 +52,7 @@ namespace LibationWinForms.Dialogs
 			createCueSheetCbox.Checked = config.CreateCueSheet;
 			downloadCoverArtCbox.Checked = config.DownloadCoverArt;
 			downloadClipsBookmarksCbox.Checked = config.DownloadClipsBookmarks;
+			fileDownloadQualityCb.SelectedItem = config.FileDownloadQuality;
 			clipsBookmarksFormatCb.SelectedItem = config.ClipsBookmarksFileFormat;
 			retainAaxFileCbox.Checked = config.RetainAaxFile;
 			splitFilesByChapterCbox.Checked = config.SplitFilesByChapter;
@@ -87,6 +96,7 @@ namespace LibationWinForms.Dialogs
 			config.CreateCueSheet = createCueSheetCbox.Checked;
 			config.DownloadCoverArt = downloadCoverArtCbox.Checked;
 			config.DownloadClipsBookmarks = downloadClipsBookmarksCbox.Checked;
+			config.FileDownloadQuality = (Configuration.DownloadQuality)fileDownloadQualityCb.SelectedItem;
 			config.ClipsBookmarksFileFormat = (Configuration.ClipBookmarkFormat)clipsBookmarksFormatCb.SelectedItem;
 			config.RetainAaxFile = retainAaxFileCbox.Checked;
 			config.SplitFilesByChapter = splitFilesByChapterCbox.Checked;
@@ -98,7 +108,6 @@ namespace LibationWinForms.Dialogs
 			config.LameTargetBitrate = lameTargetBitrateRb.Checked;
 			config.MaxSampleRate = ((EnumDiaplay<AAXClean.SampleRate>)maxSampleRateCb.SelectedItem).Value;
 			config.LameEncoderQuality = (NAudio.Lame.EncoderQuality)encoderQualityCb.SelectedItem;
-			encoderQualityCb.SelectedItem = config.LameEncoderQuality;
 			config.LameDownsampleMono = lameDownsampleMonoCbox.Checked;
 			config.LameBitrate = lameBitrateTb.Value;
 			config.LameConstantBitrate = lameConstantBitrateCbox.Checked;

--- a/Source/LibationWinForms/Dialogs/SettingsDialog.Designer.cs
+++ b/Source/LibationWinForms/Dialogs/SettingsDialog.Designer.cs
@@ -78,6 +78,8 @@
 			folderTemplateTb = new System.Windows.Forms.TextBox();
 			folderTemplateLbl = new System.Windows.Forms.Label();
 			tab4AudioFileOptions = new System.Windows.Forms.TabPage();
+			fileDownloadQualityCb = new System.Windows.Forms.ComboBox();
+			fileDownloadQualityLbl = new System.Windows.Forms.Label();
 			clipsBookmarksFormatCb = new System.Windows.Forms.ComboBox();
 			downloadClipsBookmarksCbox = new System.Windows.Forms.CheckBox();
 			audiobookFixupsGb = new System.Windows.Forms.GroupBox();
@@ -146,30 +148,30 @@
 			// booksLocationDescLbl
 			// 
 			booksLocationDescLbl.AutoSize = true;
-			booksLocationDescLbl.Location = new System.Drawing.Point(7, 19);
-			booksLocationDescLbl.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+			booksLocationDescLbl.Location = new System.Drawing.Point(13, 41);
+			booksLocationDescLbl.Margin = new System.Windows.Forms.Padding(7, 0, 7, 0);
 			booksLocationDescLbl.Name = "booksLocationDescLbl";
-			booksLocationDescLbl.Size = new System.Drawing.Size(69, 15);
+			booksLocationDescLbl.Size = new System.Drawing.Size(137, 32);
 			booksLocationDescLbl.TabIndex = 1;
 			booksLocationDescLbl.Text = "[book desc]";
 			// 
 			// inProgressDescLbl
 			// 
 			inProgressDescLbl.AutoSize = true;
-			inProgressDescLbl.Location = new System.Drawing.Point(7, 19);
-			inProgressDescLbl.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+			inProgressDescLbl.Location = new System.Drawing.Point(13, 41);
+			inProgressDescLbl.Margin = new System.Windows.Forms.Padding(7, 0, 7, 0);
 			inProgressDescLbl.Name = "inProgressDescLbl";
-			inProgressDescLbl.Size = new System.Drawing.Size(100, 45);
+			inProgressDescLbl.Size = new System.Drawing.Size(201, 96);
 			inProgressDescLbl.TabIndex = 18;
 			inProgressDescLbl.Text = "[in progress desc]\r\n[line 2]\r\n[line 3]";
 			// 
 			// saveBtn
 			// 
 			saveBtn.Anchor = System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right;
-			saveBtn.Location = new System.Drawing.Point(667, 491);
-			saveBtn.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+			saveBtn.Location = new System.Drawing.Point(1239, 1047);
+			saveBtn.Margin = new System.Windows.Forms.Padding(7, 6, 7, 6);
 			saveBtn.Name = "saveBtn";
-			saveBtn.Size = new System.Drawing.Size(88, 27);
+			saveBtn.Size = new System.Drawing.Size(163, 58);
 			saveBtn.TabIndex = 98;
 			saveBtn.Text = "Save";
 			saveBtn.UseVisualStyleBackColor = true;
@@ -179,10 +181,10 @@
 			// 
 			cancelBtn.Anchor = System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right;
 			cancelBtn.DialogResult = System.Windows.Forms.DialogResult.Cancel;
-			cancelBtn.Location = new System.Drawing.Point(785, 491);
-			cancelBtn.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+			cancelBtn.Location = new System.Drawing.Point(1458, 1047);
+			cancelBtn.Margin = new System.Windows.Forms.Padding(7, 6, 7, 6);
 			cancelBtn.Name = "cancelBtn";
-			cancelBtn.Size = new System.Drawing.Size(88, 27);
+			cancelBtn.Size = new System.Drawing.Size(163, 58);
 			cancelBtn.TabIndex = 99;
 			cancelBtn.Text = "Cancel";
 			cancelBtn.UseVisualStyleBackColor = true;
@@ -191,9 +193,10 @@
 			// importEpisodesCb
 			// 
 			importEpisodesCb.AutoSize = true;
-			importEpisodesCb.Location = new System.Drawing.Point(6, 56);
+			importEpisodesCb.Location = new System.Drawing.Point(11, 119);
+			importEpisodesCb.Margin = new System.Windows.Forms.Padding(6);
 			importEpisodesCb.Name = "importEpisodesCb";
-			importEpisodesCb.Size = new System.Drawing.Size(146, 19);
+			importEpisodesCb.Size = new System.Drawing.Size(287, 36);
 			importEpisodesCb.TabIndex = 3;
 			importEpisodesCb.Text = "[import episodes desc]";
 			importEpisodesCb.UseVisualStyleBackColor = true;
@@ -201,9 +204,10 @@
 			// downloadEpisodesCb
 			// 
 			downloadEpisodesCb.AutoSize = true;
-			downloadEpisodesCb.Location = new System.Drawing.Point(6, 81);
+			downloadEpisodesCb.Location = new System.Drawing.Point(11, 173);
+			downloadEpisodesCb.Margin = new System.Windows.Forms.Padding(6);
 			downloadEpisodesCb.Name = "downloadEpisodesCb";
-			downloadEpisodesCb.Size = new System.Drawing.Size(163, 19);
+			downloadEpisodesCb.Size = new System.Drawing.Size(321, 36);
 			downloadEpisodesCb.TabIndex = 4;
 			downloadEpisodesCb.Text = "[download episodes desc]";
 			downloadEpisodesCb.UseVisualStyleBackColor = true;
@@ -215,9 +219,11 @@
 			badBookGb.Controls.Add(badBookRetryRb);
 			badBookGb.Controls.Add(badBookAbortRb);
 			badBookGb.Controls.Add(badBookAskRb);
-			badBookGb.Location = new System.Drawing.Point(7, 6);
+			badBookGb.Location = new System.Drawing.Point(13, 13);
+			badBookGb.Margin = new System.Windows.Forms.Padding(6);
 			badBookGb.Name = "badBookGb";
-			badBookGb.Size = new System.Drawing.Size(834, 76);
+			badBookGb.Padding = new System.Windows.Forms.Padding(6);
+			badBookGb.Size = new System.Drawing.Size(1549, 162);
 			badBookGb.TabIndex = 13;
 			badBookGb.TabStop = false;
 			badBookGb.Text = "[bad book desc]";
@@ -225,9 +231,10 @@
 			// badBookIgnoreRb
 			// 
 			badBookIgnoreRb.AutoSize = true;
-			badBookIgnoreRb.Location = new System.Drawing.Point(384, 47);
+			badBookIgnoreRb.Location = new System.Drawing.Point(713, 100);
+			badBookIgnoreRb.Margin = new System.Windows.Forms.Padding(6);
 			badBookIgnoreRb.Name = "badBookIgnoreRb";
-			badBookIgnoreRb.Size = new System.Drawing.Size(94, 19);
+			badBookIgnoreRb.Size = new System.Drawing.Size(183, 36);
 			badBookIgnoreRb.TabIndex = 17;
 			badBookIgnoreRb.TabStop = true;
 			badBookIgnoreRb.Text = "[ignore desc]";
@@ -236,9 +243,10 @@
 			// badBookRetryRb
 			// 
 			badBookRetryRb.AutoSize = true;
-			badBookRetryRb.Location = new System.Drawing.Point(5, 47);
+			badBookRetryRb.Location = new System.Drawing.Point(9, 100);
+			badBookRetryRb.Margin = new System.Windows.Forms.Padding(6);
 			badBookRetryRb.Name = "badBookRetryRb";
-			badBookRetryRb.Size = new System.Drawing.Size(84, 19);
+			badBookRetryRb.Size = new System.Drawing.Size(163, 36);
 			badBookRetryRb.TabIndex = 16;
 			badBookRetryRb.TabStop = true;
 			badBookRetryRb.Text = "[retry desc]";
@@ -247,9 +255,10 @@
 			// badBookAbortRb
 			// 
 			badBookAbortRb.AutoSize = true;
-			badBookAbortRb.Location = new System.Drawing.Point(384, 22);
+			badBookAbortRb.Location = new System.Drawing.Point(713, 47);
+			badBookAbortRb.Margin = new System.Windows.Forms.Padding(6);
 			badBookAbortRb.Name = "badBookAbortRb";
-			badBookAbortRb.Size = new System.Drawing.Size(88, 19);
+			badBookAbortRb.Size = new System.Drawing.Size(170, 36);
 			badBookAbortRb.TabIndex = 15;
 			badBookAbortRb.TabStop = true;
 			badBookAbortRb.Text = "[abort desc]";
@@ -258,9 +267,10 @@
 			// badBookAskRb
 			// 
 			badBookAskRb.AutoSize = true;
-			badBookAskRb.Location = new System.Drawing.Point(6, 22);
+			badBookAskRb.Location = new System.Drawing.Point(11, 47);
+			badBookAskRb.Margin = new System.Windows.Forms.Padding(6);
 			badBookAskRb.Name = "badBookAskRb";
-			badBookAskRb.Size = new System.Drawing.Size(77, 19);
+			badBookAskRb.Size = new System.Drawing.Size(148, 36);
 			badBookAskRb.TabIndex = 14;
 			badBookAskRb.TabStop = true;
 			badBookAskRb.Text = "[ask desc]";
@@ -269,9 +279,10 @@
 			// stripAudibleBrandingCbox
 			// 
 			stripAudibleBrandingCbox.AutoSize = true;
-			stripAudibleBrandingCbox.Location = new System.Drawing.Point(13, 72);
+			stripAudibleBrandingCbox.Location = new System.Drawing.Point(24, 154);
+			stripAudibleBrandingCbox.Margin = new System.Windows.Forms.Padding(6);
 			stripAudibleBrandingCbox.Name = "stripAudibleBrandingCbox";
-			stripAudibleBrandingCbox.Size = new System.Drawing.Size(143, 34);
+			stripAudibleBrandingCbox.Size = new System.Drawing.Size(279, 68);
 			stripAudibleBrandingCbox.TabIndex = 13;
 			stripAudibleBrandingCbox.Text = "[StripAudibleBranding\r\ndesc]";
 			stripAudibleBrandingCbox.UseVisualStyleBackColor = true;
@@ -279,9 +290,10 @@
 			// splitFilesByChapterCbox
 			// 
 			splitFilesByChapterCbox.AutoSize = true;
-			splitFilesByChapterCbox.Location = new System.Drawing.Point(13, 22);
+			splitFilesByChapterCbox.Location = new System.Drawing.Point(24, 47);
+			splitFilesByChapterCbox.Margin = new System.Windows.Forms.Padding(6);
 			splitFilesByChapterCbox.Name = "splitFilesByChapterCbox";
-			splitFilesByChapterCbox.Size = new System.Drawing.Size(162, 19);
+			splitFilesByChapterCbox.Size = new System.Drawing.Size(319, 36);
 			splitFilesByChapterCbox.TabIndex = 13;
 			splitFilesByChapterCbox.Text = "[SplitFilesByChapter desc]";
 			splitFilesByChapterCbox.UseVisualStyleBackColor = true;
@@ -292,9 +304,10 @@
 			allowLibationFixupCbox.AutoSize = true;
 			allowLibationFixupCbox.Checked = true;
 			allowLibationFixupCbox.CheckState = System.Windows.Forms.CheckState.Checked;
-			allowLibationFixupCbox.Location = new System.Drawing.Point(19, 143);
+			allowLibationFixupCbox.Location = new System.Drawing.Point(35, 336);
+			allowLibationFixupCbox.Margin = new System.Windows.Forms.Padding(6);
 			allowLibationFixupCbox.Name = "allowLibationFixupCbox";
-			allowLibationFixupCbox.Size = new System.Drawing.Size(163, 19);
+			allowLibationFixupCbox.Size = new System.Drawing.Size(315, 36);
 			allowLibationFixupCbox.TabIndex = 10;
 			allowLibationFixupCbox.Text = "[AllowLibationFixup desc]";
 			allowLibationFixupCbox.UseVisualStyleBackColor = true;
@@ -303,9 +316,10 @@
 			// convertLossyRb
 			// 
 			convertLossyRb.AutoSize = true;
-			convertLossyRb.Location = new System.Drawing.Point(13, 158);
+			convertLossyRb.Location = new System.Drawing.Point(24, 337);
+			convertLossyRb.Margin = new System.Windows.Forms.Padding(6);
 			convertLossyRb.Name = "convertLossyRb";
-			convertLossyRb.Size = new System.Drawing.Size(329, 19);
+			convertLossyRb.Size = new System.Drawing.Size(659, 36);
 			convertLossyRb.TabIndex = 12;
 			convertLossyRb.Text = "Download my books as .MP3 files (transcode if necessary)";
 			convertLossyRb.UseVisualStyleBackColor = true;
@@ -315,9 +329,10 @@
 			// 
 			convertLosslessRb.AutoSize = true;
 			convertLosslessRb.Checked = true;
-			convertLosslessRb.Location = new System.Drawing.Point(13, 111);
+			convertLosslessRb.Location = new System.Drawing.Point(24, 237);
+			convertLosslessRb.Margin = new System.Windows.Forms.Padding(6);
 			convertLosslessRb.Name = "convertLosslessRb";
-			convertLosslessRb.Size = new System.Drawing.Size(335, 19);
+			convertLosslessRb.Size = new System.Drawing.Size(670, 36);
 			convertLosslessRb.TabIndex = 11;
 			convertLosslessRb.TabStop = true;
 			convertLosslessRb.Text = "Download my books in the original audio format (Lossless)";
@@ -327,17 +342,18 @@
 			// inProgressSelectControl
 			// 
 			inProgressSelectControl.Anchor = System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right;
-			inProgressSelectControl.Location = new System.Drawing.Point(7, 68);
-			inProgressSelectControl.Margin = new System.Windows.Forms.Padding(3, 4, 3, 4);
+			inProgressSelectControl.Location = new System.Drawing.Point(13, 145);
+			inProgressSelectControl.Margin = new System.Windows.Forms.Padding(6, 9, 6, 9);
 			inProgressSelectControl.Name = "inProgressSelectControl";
-			inProgressSelectControl.Size = new System.Drawing.Size(828, 52);
+			inProgressSelectControl.Size = new System.Drawing.Size(1538, 111);
 			inProgressSelectControl.TabIndex = 19;
 			// 
 			// logsBtn
 			// 
-			logsBtn.Location = new System.Drawing.Point(256, 261);
+			logsBtn.Location = new System.Drawing.Point(475, 557);
+			logsBtn.Margin = new System.Windows.Forms.Padding(6);
 			logsBtn.Name = "logsBtn";
-			logsBtn.Size = new System.Drawing.Size(132, 23);
+			logsBtn.Size = new System.Drawing.Size(245, 49);
 			logsBtn.TabIndex = 5;
 			logsBtn.Text = "Open log folder";
 			logsBtn.UseVisualStyleBackColor = true;
@@ -346,18 +362,19 @@
 			// booksSelectControl
 			// 
 			booksSelectControl.Anchor = System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right;
-			booksSelectControl.Location = new System.Drawing.Point(7, 37);
-			booksSelectControl.Margin = new System.Windows.Forms.Padding(3, 4, 3, 4);
+			booksSelectControl.Location = new System.Drawing.Point(13, 79);
+			booksSelectControl.Margin = new System.Windows.Forms.Padding(6, 9, 6, 9);
 			booksSelectControl.Name = "booksSelectControl";
-			booksSelectControl.Size = new System.Drawing.Size(829, 87);
+			booksSelectControl.Size = new System.Drawing.Size(1540, 186);
 			booksSelectControl.TabIndex = 2;
 			// 
 			// loggingLevelLbl
 			// 
 			loggingLevelLbl.AutoSize = true;
-			loggingLevelLbl.Location = new System.Drawing.Point(6, 264);
+			loggingLevelLbl.Location = new System.Drawing.Point(11, 563);
+			loggingLevelLbl.Margin = new System.Windows.Forms.Padding(6, 0, 6, 0);
 			loggingLevelLbl.Name = "loggingLevelLbl";
-			loggingLevelLbl.Size = new System.Drawing.Size(78, 15);
+			loggingLevelLbl.Size = new System.Drawing.Size(158, 32);
 			loggingLevelLbl.TabIndex = 3;
 			loggingLevelLbl.Text = "Logging level";
 			// 
@@ -365,9 +382,10 @@
 			// 
 			loggingLevelCb.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
 			loggingLevelCb.FormattingEnabled = true;
-			loggingLevelCb.Location = new System.Drawing.Point(90, 261);
+			loggingLevelCb.Location = new System.Drawing.Point(167, 557);
+			loggingLevelCb.Margin = new System.Windows.Forms.Padding(6);
 			loggingLevelCb.Name = "loggingLevelCb";
-			loggingLevelCb.Size = new System.Drawing.Size(129, 23);
+			loggingLevelCb.Size = new System.Drawing.Size(236, 40);
 			loggingLevelCb.TabIndex = 4;
 			// 
 			// tabControl
@@ -377,10 +395,11 @@
 			tabControl.Controls.Add(tab2ImportLibrary);
 			tabControl.Controls.Add(tab3DownloadDecrypt);
 			tabControl.Controls.Add(tab4AudioFileOptions);
-			tabControl.Location = new System.Drawing.Point(12, 12);
+			tabControl.Location = new System.Drawing.Point(22, 26);
+			tabControl.Margin = new System.Windows.Forms.Padding(6);
 			tabControl.Name = "tabControl";
 			tabControl.SelectedIndex = 0;
-			tabControl.Size = new System.Drawing.Size(862, 473);
+			tabControl.Size = new System.Drawing.Size(1601, 1009);
 			tabControl.TabIndex = 100;
 			// 
 			// tab1ImportantSettings
@@ -390,10 +409,11 @@
 			tab1ImportantSettings.Controls.Add(logsBtn);
 			tab1ImportantSettings.Controls.Add(loggingLevelCb);
 			tab1ImportantSettings.Controls.Add(loggingLevelLbl);
-			tab1ImportantSettings.Location = new System.Drawing.Point(4, 24);
+			tab1ImportantSettings.Location = new System.Drawing.Point(8, 46);
+			tab1ImportantSettings.Margin = new System.Windows.Forms.Padding(6);
 			tab1ImportantSettings.Name = "tab1ImportantSettings";
-			tab1ImportantSettings.Padding = new System.Windows.Forms.Padding(3);
-			tab1ImportantSettings.Size = new System.Drawing.Size(854, 445);
+			tab1ImportantSettings.Padding = new System.Windows.Forms.Padding(6);
+			tab1ImportantSettings.Size = new System.Drawing.Size(1585, 955);
 			tab1ImportantSettings.TabIndex = 0;
 			tab1ImportantSettings.Text = "Important settings";
 			tab1ImportantSettings.UseVisualStyleBackColor = true;
@@ -403,9 +423,10 @@
 			betaOptInCbox.Anchor = System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left;
 			betaOptInCbox.AutoSize = true;
 			betaOptInCbox.Enabled = false;
-			betaOptInCbox.Location = new System.Drawing.Point(13, 399);
+			betaOptInCbox.Location = new System.Drawing.Point(24, 856);
+			betaOptInCbox.Margin = new System.Windows.Forms.Padding(6);
 			betaOptInCbox.Name = "betaOptInCbox";
-			betaOptInCbox.Size = new System.Drawing.Size(107, 19);
+			betaOptInCbox.Size = new System.Drawing.Size(210, 36);
 			betaOptInCbox.TabIndex = 6;
 			betaOptInCbox.Text = "[Opt in to Beta]";
 			betaOptInCbox.UseVisualStyleBackColor = true;
@@ -421,9 +442,11 @@
 			booksGb.Controls.Add(saveEpisodesToSeriesFolderCbox);
 			booksGb.Controls.Add(booksSelectControl);
 			booksGb.Controls.Add(booksLocationDescLbl);
-			booksGb.Location = new System.Drawing.Point(6, 6);
+			booksGb.Location = new System.Drawing.Point(11, 13);
+			booksGb.Margin = new System.Windows.Forms.Padding(6);
 			booksGb.Name = "booksGb";
-			booksGb.Size = new System.Drawing.Size(842, 249);
+			booksGb.Padding = new System.Windows.Forms.Padding(6);
+			booksGb.Size = new System.Drawing.Size(1564, 531);
 			booksGb.TabIndex = 0;
 			booksGb.TabStop = false;
 			booksGb.Text = "Books location";
@@ -432,46 +455,49 @@
 			// 
 			lastWriteTimeCb.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
 			lastWriteTimeCb.FormattingEnabled = true;
-			lastWriteTimeCb.Location = new System.Drawing.Point(188, 214);
+			lastWriteTimeCb.Location = new System.Drawing.Point(391, 457);
+			lastWriteTimeCb.Margin = new System.Windows.Forms.Padding(6);
 			lastWriteTimeCb.Name = "lastWriteTimeCb";
-			lastWriteTimeCb.Size = new System.Drawing.Size(272, 23);
+			lastWriteTimeCb.Size = new System.Drawing.Size(502, 40);
 			lastWriteTimeCb.TabIndex = 5;
 			// 
 			// creationTimeCb
 			// 
 			creationTimeCb.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
 			creationTimeCb.FormattingEnabled = true;
-			creationTimeCb.Location = new System.Drawing.Point(188, 185);
+			creationTimeCb.Location = new System.Drawing.Point(391, 395);
+			creationTimeCb.Margin = new System.Windows.Forms.Padding(6);
 			creationTimeCb.Name = "creationTimeCb";
-			creationTimeCb.Size = new System.Drawing.Size(272, 23);
+			creationTimeCb.Size = new System.Drawing.Size(502, 40);
 			creationTimeCb.TabIndex = 5;
 			// 
 			// lastWriteTimeLbl
 			// 
 			lastWriteTimeLbl.AutoSize = true;
-			lastWriteTimeLbl.Location = new System.Drawing.Point(7, 217);
-			lastWriteTimeLbl.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+			lastWriteTimeLbl.Location = new System.Drawing.Point(13, 463);
+			lastWriteTimeLbl.Margin = new System.Windows.Forms.Padding(7, 0, 7, 0);
 			lastWriteTimeLbl.Name = "lastWriteTimeLbl";
-			lastWriteTimeLbl.Size = new System.Drawing.Size(116, 15);
+			lastWriteTimeLbl.Size = new System.Drawing.Size(233, 32);
 			lastWriteTimeLbl.TabIndex = 4;
 			lastWriteTimeLbl.Text = "[last write time desc]";
 			// 
 			// creationTimeLbl
 			// 
 			creationTimeLbl.AutoSize = true;
-			creationTimeLbl.Location = new System.Drawing.Point(7, 188);
-			creationTimeLbl.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+			creationTimeLbl.Location = new System.Drawing.Point(13, 401);
+			creationTimeLbl.Margin = new System.Windows.Forms.Padding(7, 0, 7, 0);
 			creationTimeLbl.Name = "creationTimeLbl";
-			creationTimeLbl.Size = new System.Drawing.Size(112, 15);
+			creationTimeLbl.Size = new System.Drawing.Size(224, 32);
 			creationTimeLbl.TabIndex = 4;
 			creationTimeLbl.Text = "[creation time desc]";
 			// 
 			// overwriteExistingCbox
 			// 
 			overwriteExistingCbox.AutoSize = true;
-			overwriteExistingCbox.Location = new System.Drawing.Point(7, 156);
+			overwriteExistingCbox.Location = new System.Drawing.Point(13, 333);
+			overwriteExistingCbox.Margin = new System.Windows.Forms.Padding(6);
 			overwriteExistingCbox.Name = "overwriteExistingCbox";
-			overwriteExistingCbox.Size = new System.Drawing.Size(129, 19);
+			overwriteExistingCbox.Size = new System.Drawing.Size(251, 36);
 			overwriteExistingCbox.TabIndex = 3;
 			overwriteExistingCbox.Text = "[Overwrite Existing]";
 			overwriteExistingCbox.UseVisualStyleBackColor = true;
@@ -479,9 +505,10 @@
 			// saveEpisodesToSeriesFolderCbox
 			// 
 			saveEpisodesToSeriesFolderCbox.AutoSize = true;
-			saveEpisodesToSeriesFolderCbox.Location = new System.Drawing.Point(7, 131);
+			saveEpisodesToSeriesFolderCbox.Location = new System.Drawing.Point(13, 279);
+			saveEpisodesToSeriesFolderCbox.Margin = new System.Windows.Forms.Padding(6);
 			saveEpisodesToSeriesFolderCbox.Name = "saveEpisodesToSeriesFolderCbox";
-			saveEpisodesToSeriesFolderCbox.Size = new System.Drawing.Size(191, 19);
+			saveEpisodesToSeriesFolderCbox.Size = new System.Drawing.Size(386, 36);
 			saveEpisodesToSeriesFolderCbox.TabIndex = 3;
 			saveEpisodesToSeriesFolderCbox.Text = "[Save Episodes To Series Folder]";
 			saveEpisodesToSeriesFolderCbox.UseVisualStyleBackColor = true;
@@ -493,10 +520,11 @@
 			tab2ImportLibrary.Controls.Add(showImportedStatsCb);
 			tab2ImportLibrary.Controls.Add(importEpisodesCb);
 			tab2ImportLibrary.Controls.Add(downloadEpisodesCb);
-			tab2ImportLibrary.Location = new System.Drawing.Point(4, 24);
+			tab2ImportLibrary.Location = new System.Drawing.Point(8, 46);
+			tab2ImportLibrary.Margin = new System.Windows.Forms.Padding(6);
 			tab2ImportLibrary.Name = "tab2ImportLibrary";
-			tab2ImportLibrary.Padding = new System.Windows.Forms.Padding(3);
-			tab2ImportLibrary.Size = new System.Drawing.Size(854, 445);
+			tab2ImportLibrary.Padding = new System.Windows.Forms.Padding(6);
+			tab2ImportLibrary.Size = new System.Drawing.Size(1585, 955);
 			tab2ImportLibrary.TabIndex = 1;
 			tab2ImportLibrary.Text = "Import library";
 			tab2ImportLibrary.UseVisualStyleBackColor = true;
@@ -504,9 +532,10 @@
 			// autoDownloadEpisodesCb
 			// 
 			autoDownloadEpisodesCb.AutoSize = true;
-			autoDownloadEpisodesCb.Location = new System.Drawing.Point(6, 106);
+			autoDownloadEpisodesCb.Location = new System.Drawing.Point(11, 226);
+			autoDownloadEpisodesCb.Margin = new System.Windows.Forms.Padding(6);
 			autoDownloadEpisodesCb.Name = "autoDownloadEpisodesCb";
-			autoDownloadEpisodesCb.Size = new System.Drawing.Size(190, 19);
+			autoDownloadEpisodesCb.Size = new System.Drawing.Size(376, 36);
 			autoDownloadEpisodesCb.TabIndex = 5;
 			autoDownloadEpisodesCb.Text = "[auto download episodes desc]";
 			autoDownloadEpisodesCb.UseVisualStyleBackColor = true;
@@ -514,9 +543,10 @@
 			// autoScanCb
 			// 
 			autoScanCb.AutoSize = true;
-			autoScanCb.Location = new System.Drawing.Point(6, 6);
+			autoScanCb.Location = new System.Drawing.Point(11, 13);
+			autoScanCb.Margin = new System.Windows.Forms.Padding(6);
 			autoScanCb.Name = "autoScanCb";
-			autoScanCb.Size = new System.Drawing.Size(112, 19);
+			autoScanCb.Size = new System.Drawing.Size(217, 36);
 			autoScanCb.TabIndex = 1;
 			autoScanCb.Text = "[auto scan desc]";
 			autoScanCb.UseVisualStyleBackColor = true;
@@ -524,9 +554,10 @@
 			// showImportedStatsCb
 			// 
 			showImportedStatsCb.AutoSize = true;
-			showImportedStatsCb.Location = new System.Drawing.Point(6, 31);
+			showImportedStatsCb.Location = new System.Drawing.Point(11, 66);
+			showImportedStatsCb.Margin = new System.Windows.Forms.Padding(6);
 			showImportedStatsCb.Name = "showImportedStatsCb";
-			showImportedStatsCb.Size = new System.Drawing.Size(168, 19);
+			showImportedStatsCb.Size = new System.Drawing.Size(330, 36);
 			showImportedStatsCb.TabIndex = 2;
 			showImportedStatsCb.Text = "[show imported stats desc]";
 			showImportedStatsCb.UseVisualStyleBackColor = true;
@@ -537,10 +568,11 @@
 			tab3DownloadDecrypt.Controls.Add(inProgressFilesGb);
 			tab3DownloadDecrypt.Controls.Add(customFileNamingGb);
 			tab3DownloadDecrypt.Controls.Add(badBookGb);
-			tab3DownloadDecrypt.Location = new System.Drawing.Point(4, 24);
+			tab3DownloadDecrypt.Location = new System.Drawing.Point(8, 46);
+			tab3DownloadDecrypt.Margin = new System.Windows.Forms.Padding(6);
 			tab3DownloadDecrypt.Name = "tab3DownloadDecrypt";
-			tab3DownloadDecrypt.Padding = new System.Windows.Forms.Padding(3);
-			tab3DownloadDecrypt.Size = new System.Drawing.Size(854, 445);
+			tab3DownloadDecrypt.Padding = new System.Windows.Forms.Padding(6);
+			tab3DownloadDecrypt.Size = new System.Drawing.Size(1585, 955);
 			tab3DownloadDecrypt.TabIndex = 2;
 			tab3DownloadDecrypt.Text = "Download/Decrypt";
 			tab3DownloadDecrypt.UseVisualStyleBackColor = true;
@@ -548,9 +580,10 @@
 			// useCoverAsFolderIconCb
 			// 
 			useCoverAsFolderIconCb.AutoSize = true;
-			useCoverAsFolderIconCb.Location = new System.Drawing.Point(7, 415);
+			useCoverAsFolderIconCb.Location = new System.Drawing.Point(13, 885);
+			useCoverAsFolderIconCb.Margin = new System.Windows.Forms.Padding(6);
 			useCoverAsFolderIconCb.Name = "useCoverAsFolderIconCb";
-			useCoverAsFolderIconCb.Size = new System.Drawing.Size(180, 19);
+			useCoverAsFolderIconCb.Size = new System.Drawing.Size(353, 36);
 			useCoverAsFolderIconCb.TabIndex = 22;
 			useCoverAsFolderIconCb.Text = "[UseCoverAsFolderIcon desc]";
 			useCoverAsFolderIconCb.UseVisualStyleBackColor = true;
@@ -560,9 +593,11 @@
 			inProgressFilesGb.Anchor = System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right;
 			inProgressFilesGb.Controls.Add(inProgressDescLbl);
 			inProgressFilesGb.Controls.Add(inProgressSelectControl);
-			inProgressFilesGb.Location = new System.Drawing.Point(6, 281);
+			inProgressFilesGb.Location = new System.Drawing.Point(11, 599);
+			inProgressFilesGb.Margin = new System.Windows.Forms.Padding(6);
 			inProgressFilesGb.Name = "inProgressFilesGb";
-			inProgressFilesGb.Size = new System.Drawing.Size(841, 128);
+			inProgressFilesGb.Padding = new System.Windows.Forms.Padding(6);
+			inProgressFilesGb.Size = new System.Drawing.Size(1562, 273);
 			inProgressFilesGb.TabIndex = 21;
 			inProgressFilesGb.TabStop = false;
 			inProgressFilesGb.Text = "In progress files";
@@ -580,9 +615,11 @@
 			customFileNamingGb.Controls.Add(folderTemplateBtn);
 			customFileNamingGb.Controls.Add(folderTemplateTb);
 			customFileNamingGb.Controls.Add(folderTemplateLbl);
-			customFileNamingGb.Location = new System.Drawing.Point(7, 88);
+			customFileNamingGb.Location = new System.Drawing.Point(13, 188);
+			customFileNamingGb.Margin = new System.Windows.Forms.Padding(6);
 			customFileNamingGb.Name = "customFileNamingGb";
-			customFileNamingGb.Size = new System.Drawing.Size(841, 187);
+			customFileNamingGb.Padding = new System.Windows.Forms.Padding(6);
+			customFileNamingGb.Size = new System.Drawing.Size(1562, 399);
 			customFileNamingGb.TabIndex = 20;
 			customFileNamingGb.TabStop = false;
 			customFileNamingGb.Text = "Custom file naming";
@@ -590,9 +627,10 @@
 			// editCharreplacementBtn
 			// 
 			editCharreplacementBtn.Anchor = System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left;
-			editCharreplacementBtn.Location = new System.Drawing.Point(5, 158);
+			editCharreplacementBtn.Location = new System.Drawing.Point(9, 337);
+			editCharreplacementBtn.Margin = new System.Windows.Forms.Padding(6);
 			editCharreplacementBtn.Name = "editCharreplacementBtn";
-			editCharreplacementBtn.Size = new System.Drawing.Size(281, 23);
+			editCharreplacementBtn.Size = new System.Drawing.Size(522, 49);
 			editCharreplacementBtn.TabIndex = 8;
 			editCharreplacementBtn.Text = "[edit char replacement desc]";
 			editCharreplacementBtn.UseVisualStyleBackColor = true;
@@ -601,9 +639,10 @@
 			// chapterFileTemplateBtn
 			// 
 			chapterFileTemplateBtn.Anchor = System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right;
-			chapterFileTemplateBtn.Location = new System.Drawing.Point(761, 124);
+			chapterFileTemplateBtn.Location = new System.Drawing.Point(1413, 265);
+			chapterFileTemplateBtn.Margin = new System.Windows.Forms.Padding(6);
 			chapterFileTemplateBtn.Name = "chapterFileTemplateBtn";
-			chapterFileTemplateBtn.Size = new System.Drawing.Size(75, 23);
+			chapterFileTemplateBtn.Size = new System.Drawing.Size(139, 49);
 			chapterFileTemplateBtn.TabIndex = 8;
 			chapterFileTemplateBtn.Text = "Edit...";
 			chapterFileTemplateBtn.UseVisualStyleBackColor = true;
@@ -612,27 +651,30 @@
 			// chapterFileTemplateTb
 			// 
 			chapterFileTemplateTb.Anchor = System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right;
-			chapterFileTemplateTb.Location = new System.Drawing.Point(6, 125);
+			chapterFileTemplateTb.Location = new System.Drawing.Point(11, 267);
+			chapterFileTemplateTb.Margin = new System.Windows.Forms.Padding(6);
 			chapterFileTemplateTb.Name = "chapterFileTemplateTb";
 			chapterFileTemplateTb.ReadOnly = true;
-			chapterFileTemplateTb.Size = new System.Drawing.Size(749, 23);
+			chapterFileTemplateTb.Size = new System.Drawing.Size(1388, 39);
 			chapterFileTemplateTb.TabIndex = 7;
 			// 
 			// chapterFileTemplateLbl
 			// 
 			chapterFileTemplateLbl.AutoSize = true;
-			chapterFileTemplateLbl.Location = new System.Drawing.Point(6, 107);
+			chapterFileTemplateLbl.Location = new System.Drawing.Point(11, 228);
+			chapterFileTemplateLbl.Margin = new System.Windows.Forms.Padding(6, 0, 6, 0);
 			chapterFileTemplateLbl.Name = "chapterFileTemplateLbl";
-			chapterFileTemplateLbl.Size = new System.Drawing.Size(132, 15);
+			chapterFileTemplateLbl.Size = new System.Drawing.Size(265, 32);
 			chapterFileTemplateLbl.TabIndex = 6;
 			chapterFileTemplateLbl.Text = "[chapter template desc]";
 			// 
 			// fileTemplateBtn
 			// 
 			fileTemplateBtn.Anchor = System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right;
-			fileTemplateBtn.Location = new System.Drawing.Point(761, 80);
+			fileTemplateBtn.Location = new System.Drawing.Point(1413, 171);
+			fileTemplateBtn.Margin = new System.Windows.Forms.Padding(6);
 			fileTemplateBtn.Name = "fileTemplateBtn";
-			fileTemplateBtn.Size = new System.Drawing.Size(75, 23);
+			fileTemplateBtn.Size = new System.Drawing.Size(139, 49);
 			fileTemplateBtn.TabIndex = 5;
 			fileTemplateBtn.Text = "Edit...";
 			fileTemplateBtn.UseVisualStyleBackColor = true;
@@ -641,27 +683,30 @@
 			// fileTemplateTb
 			// 
 			fileTemplateTb.Anchor = System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right;
-			fileTemplateTb.Location = new System.Drawing.Point(6, 81);
+			fileTemplateTb.Location = new System.Drawing.Point(11, 173);
+			fileTemplateTb.Margin = new System.Windows.Forms.Padding(6);
 			fileTemplateTb.Name = "fileTemplateTb";
 			fileTemplateTb.ReadOnly = true;
-			fileTemplateTb.Size = new System.Drawing.Size(749, 23);
+			fileTemplateTb.Size = new System.Drawing.Size(1388, 39);
 			fileTemplateTb.TabIndex = 4;
 			// 
 			// fileTemplateLbl
 			// 
 			fileTemplateLbl.AutoSize = true;
-			fileTemplateLbl.Location = new System.Drawing.Point(6, 63);
+			fileTemplateLbl.Location = new System.Drawing.Point(11, 134);
+			fileTemplateLbl.Margin = new System.Windows.Forms.Padding(6, 0, 6, 0);
 			fileTemplateLbl.Name = "fileTemplateLbl";
-			fileTemplateLbl.Size = new System.Drawing.Size(108, 15);
+			fileTemplateLbl.Size = new System.Drawing.Size(218, 32);
 			fileTemplateLbl.TabIndex = 3;
 			fileTemplateLbl.Text = "[file template desc]";
 			// 
 			// folderTemplateBtn
 			// 
 			folderTemplateBtn.Anchor = System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right;
-			folderTemplateBtn.Location = new System.Drawing.Point(760, 36);
+			folderTemplateBtn.Location = new System.Drawing.Point(1411, 77);
+			folderTemplateBtn.Margin = new System.Windows.Forms.Padding(6);
 			folderTemplateBtn.Name = "folderTemplateBtn";
-			folderTemplateBtn.Size = new System.Drawing.Size(75, 23);
+			folderTemplateBtn.Size = new System.Drawing.Size(139, 49);
 			folderTemplateBtn.TabIndex = 2;
 			folderTemplateBtn.Text = "Edit...";
 			folderTemplateBtn.UseVisualStyleBackColor = true;
@@ -670,23 +715,27 @@
 			// folderTemplateTb
 			// 
 			folderTemplateTb.Anchor = System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right;
-			folderTemplateTb.Location = new System.Drawing.Point(5, 37);
+			folderTemplateTb.Location = new System.Drawing.Point(9, 79);
+			folderTemplateTb.Margin = new System.Windows.Forms.Padding(6);
 			folderTemplateTb.Name = "folderTemplateTb";
 			folderTemplateTb.ReadOnly = true;
-			folderTemplateTb.Size = new System.Drawing.Size(749, 23);
+			folderTemplateTb.Size = new System.Drawing.Size(1388, 39);
 			folderTemplateTb.TabIndex = 1;
 			// 
 			// folderTemplateLbl
 			// 
 			folderTemplateLbl.AutoSize = true;
-			folderTemplateLbl.Location = new System.Drawing.Point(5, 19);
+			folderTemplateLbl.Location = new System.Drawing.Point(9, 41);
+			folderTemplateLbl.Margin = new System.Windows.Forms.Padding(6, 0, 6, 0);
 			folderTemplateLbl.Name = "folderTemplateLbl";
-			folderTemplateLbl.Size = new System.Drawing.Size(123, 15);
+			folderTemplateLbl.Size = new System.Drawing.Size(248, 32);
 			folderTemplateLbl.TabIndex = 0;
 			folderTemplateLbl.Text = "[folder template desc]";
 			// 
 			// tab4AudioFileOptions
 			// 
+			tab4AudioFileOptions.Controls.Add(fileDownloadQualityCb);
+			tab4AudioFileOptions.Controls.Add(fileDownloadQualityLbl);
 			tab4AudioFileOptions.Controls.Add(clipsBookmarksFormatCb);
 			tab4AudioFileOptions.Controls.Add(downloadClipsBookmarksCbox);
 			tab4AudioFileOptions.Controls.Add(audiobookFixupsGb);
@@ -697,29 +746,52 @@
 			tab4AudioFileOptions.Controls.Add(downloadCoverArtCbox);
 			tab4AudioFileOptions.Controls.Add(createCueSheetCbox);
 			tab4AudioFileOptions.Controls.Add(allowLibationFixupCbox);
-			tab4AudioFileOptions.Location = new System.Drawing.Point(4, 24);
+			tab4AudioFileOptions.Location = new System.Drawing.Point(8, 46);
+			tab4AudioFileOptions.Margin = new System.Windows.Forms.Padding(6);
 			tab4AudioFileOptions.Name = "tab4AudioFileOptions";
-			tab4AudioFileOptions.Padding = new System.Windows.Forms.Padding(3);
-			tab4AudioFileOptions.Size = new System.Drawing.Size(854, 445);
+			tab4AudioFileOptions.Padding = new System.Windows.Forms.Padding(6);
+			tab4AudioFileOptions.Size = new System.Drawing.Size(1585, 955);
 			tab4AudioFileOptions.TabIndex = 3;
 			tab4AudioFileOptions.Text = "Audio File Options";
 			tab4AudioFileOptions.UseVisualStyleBackColor = true;
+			// 
+			// fileDownloadQualityCb
+			// 
+			fileDownloadQualityCb.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+			fileDownloadQualityCb.FormattingEnabled = true;
+			fileDownloadQualityCb.Location = new System.Drawing.Point(490, 16);
+			fileDownloadQualityCb.Margin = new System.Windows.Forms.Padding(6, 6, 10, 6);
+			fileDownloadQualityCb.Name = "fileDownloadQualityCb";
+			fileDownloadQualityCb.Size = new System.Drawing.Size(160, 40);
+			fileDownloadQualityCb.TabIndex = 23;
+			// 
+			// fileDownloadQualityLbl
+			// 
+			fileDownloadQualityLbl.AutoSize = true;
+			fileDownloadQualityLbl.Location = new System.Drawing.Point(35, 19);
+			fileDownloadQualityLbl.Margin = new System.Windows.Forms.Padding(0, 0, 3, 0);
+			fileDownloadQualityLbl.Name = "fileDownloadQualityLbl";
+			fileDownloadQualityLbl.Size = new System.Drawing.Size(304, 32);
+			fileDownloadQualityLbl.TabIndex = 22;
+			fileDownloadQualityLbl.Text = "[FileDownloadQuality desc]";
 			// 
 			// clipsBookmarksFormatCb
 			// 
 			clipsBookmarksFormatCb.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
 			clipsBookmarksFormatCb.FormattingEnabled = true;
-			clipsBookmarksFormatCb.Location = new System.Drawing.Point(269, 64);
+			clipsBookmarksFormatCb.Location = new System.Drawing.Point(529, 172);
+			clipsBookmarksFormatCb.Margin = new System.Windows.Forms.Padding(6);
 			clipsBookmarksFormatCb.Name = "clipsBookmarksFormatCb";
-			clipsBookmarksFormatCb.Size = new System.Drawing.Size(67, 23);
+			clipsBookmarksFormatCb.Size = new System.Drawing.Size(121, 40);
 			clipsBookmarksFormatCb.TabIndex = 21;
 			// 
 			// downloadClipsBookmarksCbox
 			// 
 			downloadClipsBookmarksCbox.AutoSize = true;
-			downloadClipsBookmarksCbox.Location = new System.Drawing.Point(19, 68);
+			downloadClipsBookmarksCbox.Location = new System.Drawing.Point(35, 176);
+			downloadClipsBookmarksCbox.Margin = new System.Windows.Forms.Padding(6);
 			downloadClipsBookmarksCbox.Name = "downloadClipsBookmarksCbox";
-			downloadClipsBookmarksCbox.Size = new System.Drawing.Size(248, 19);
+			downloadClipsBookmarksCbox.Size = new System.Drawing.Size(492, 36);
 			downloadClipsBookmarksCbox.TabIndex = 20;
 			downloadClipsBookmarksCbox.Text = "Download Clips, Notes, and Bookmarks as";
 			downloadClipsBookmarksCbox.UseVisualStyleBackColor = true;
@@ -733,9 +805,11 @@
 			audiobookFixupsGb.Controls.Add(convertLosslessRb);
 			audiobookFixupsGb.Controls.Add(convertLossyRb);
 			audiobookFixupsGb.Controls.Add(stripAudibleBrandingCbox);
-			audiobookFixupsGb.Location = new System.Drawing.Point(6, 169);
+			audiobookFixupsGb.Location = new System.Drawing.Point(11, 408);
+			audiobookFixupsGb.Margin = new System.Windows.Forms.Padding(6);
 			audiobookFixupsGb.Name = "audiobookFixupsGb";
-			audiobookFixupsGb.Size = new System.Drawing.Size(403, 185);
+			audiobookFixupsGb.Padding = new System.Windows.Forms.Padding(6);
+			audiobookFixupsGb.Size = new System.Drawing.Size(748, 395);
 			audiobookFixupsGb.TabIndex = 19;
 			audiobookFixupsGb.TabStop = false;
 			audiobookFixupsGb.Text = "Audiobook Fix-ups";
@@ -743,9 +817,10 @@
 			// moveMoovAtomCbox
 			// 
 			moveMoovAtomCbox.AutoSize = true;
-			moveMoovAtomCbox.Location = new System.Drawing.Point(23, 133);
+			moveMoovAtomCbox.Location = new System.Drawing.Point(43, 284);
+			moveMoovAtomCbox.Margin = new System.Windows.Forms.Padding(6);
 			moveMoovAtomCbox.Name = "moveMoovAtomCbox";
-			moveMoovAtomCbox.Size = new System.Drawing.Size(188, 19);
+			moveMoovAtomCbox.Size = new System.Drawing.Size(372, 36);
 			moveMoovAtomCbox.TabIndex = 14;
 			moveMoovAtomCbox.Text = "[MoveMoovToBeginning desc]";
 			moveMoovAtomCbox.UseVisualStyleBackColor = true;
@@ -753,9 +828,10 @@
 			// stripUnabridgedCbox
 			// 
 			stripUnabridgedCbox.AutoSize = true;
-			stripUnabridgedCbox.Location = new System.Drawing.Point(13, 47);
+			stripUnabridgedCbox.Location = new System.Drawing.Point(24, 100);
+			stripUnabridgedCbox.Margin = new System.Windows.Forms.Padding(6);
 			stripUnabridgedCbox.Name = "stripUnabridgedCbox";
-			stripUnabridgedCbox.Size = new System.Drawing.Size(147, 19);
+			stripUnabridgedCbox.Size = new System.Drawing.Size(288, 36);
 			stripUnabridgedCbox.TabIndex = 13;
 			stripUnabridgedCbox.Text = "[StripUnabridged desc]";
 			stripUnabridgedCbox.UseVisualStyleBackColor = true;
@@ -764,9 +840,11 @@
 			// 
 			chapterTitleTemplateGb.Controls.Add(chapterTitleTemplateBtn);
 			chapterTitleTemplateGb.Controls.Add(chapterTitleTemplateTb);
-			chapterTitleTemplateGb.Location = new System.Drawing.Point(6, 360);
+			chapterTitleTemplateGb.Location = new System.Drawing.Point(6, 828);
+			chapterTitleTemplateGb.Margin = new System.Windows.Forms.Padding(6);
 			chapterTitleTemplateGb.Name = "chapterTitleTemplateGb";
-			chapterTitleTemplateGb.Size = new System.Drawing.Size(842, 54);
+			chapterTitleTemplateGb.Padding = new System.Windows.Forms.Padding(6);
+			chapterTitleTemplateGb.Size = new System.Drawing.Size(1573, 115);
 			chapterTitleTemplateGb.TabIndex = 18;
 			chapterTitleTemplateGb.TabStop = false;
 			chapterTitleTemplateGb.Text = "[chapter title template desc]";
@@ -774,9 +852,10 @@
 			// chapterTitleTemplateBtn
 			// 
 			chapterTitleTemplateBtn.Anchor = System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right;
-			chapterTitleTemplateBtn.Location = new System.Drawing.Point(764, 22);
+			chapterTitleTemplateBtn.Location = new System.Drawing.Point(1428, 47);
+			chapterTitleTemplateBtn.Margin = new System.Windows.Forms.Padding(6);
 			chapterTitleTemplateBtn.Name = "chapterTitleTemplateBtn";
-			chapterTitleTemplateBtn.Size = new System.Drawing.Size(75, 23);
+			chapterTitleTemplateBtn.Size = new System.Drawing.Size(139, 49);
 			chapterTitleTemplateBtn.TabIndex = 17;
 			chapterTitleTemplateBtn.Text = "Edit...";
 			chapterTitleTemplateBtn.UseVisualStyleBackColor = true;
@@ -785,10 +864,11 @@
 			// chapterTitleTemplateTb
 			// 
 			chapterTitleTemplateTb.Anchor = System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right;
-			chapterTitleTemplateTb.Location = new System.Drawing.Point(6, 22);
+			chapterTitleTemplateTb.Location = new System.Drawing.Point(11, 47);
+			chapterTitleTemplateTb.Margin = new System.Windows.Forms.Padding(6);
 			chapterTitleTemplateTb.Name = "chapterTitleTemplateTb";
 			chapterTitleTemplateTb.ReadOnly = true;
-			chapterTitleTemplateTb.Size = new System.Drawing.Size(752, 23);
+			chapterTitleTemplateTb.Size = new System.Drawing.Size(1402, 39);
 			chapterTitleTemplateTb.TabIndex = 16;
 			// 
 			// lameOptionsGb
@@ -802,9 +882,11 @@
 			lameOptionsGb.Controls.Add(label1);
 			lameOptionsGb.Controls.Add(lameQualityGb);
 			lameOptionsGb.Controls.Add(groupBox2);
-			lameOptionsGb.Location = new System.Drawing.Point(415, 6);
+			lameOptionsGb.Location = new System.Drawing.Point(771, 13);
+			lameOptionsGb.Margin = new System.Windows.Forms.Padding(6);
 			lameOptionsGb.Name = "lameOptionsGb";
-			lameOptionsGb.Size = new System.Drawing.Size(433, 348);
+			lameOptionsGb.Padding = new System.Windows.Forms.Padding(6);
+			lameOptionsGb.Size = new System.Drawing.Size(804, 742);
 			lameOptionsGb.TabIndex = 14;
 			lameOptionsGb.TabStop = false;
 			lameOptionsGb.Text = "Mp3 Encoding Options";
@@ -812,18 +894,20 @@
 			// label20
 			// 
 			label20.AutoSize = true;
-			label20.Location = new System.Drawing.Point(12, 78);
+			label20.Location = new System.Drawing.Point(22, 166);
+			label20.Margin = new System.Windows.Forms.Padding(6, 0, 6, 0);
 			label20.Name = "label20";
-			label20.Size = new System.Drawing.Size(101, 15);
+			label20.Size = new System.Drawing.Size(204, 32);
 			label20.TabIndex = 3;
 			label20.Text = "Max Sample Rate:";
 			// 
 			// label21
 			// 
 			label21.AutoSize = true;
-			label21.Location = new System.Drawing.Point(239, 78);
+			label21.Location = new System.Drawing.Point(444, 166);
+			label21.Margin = new System.Windows.Forms.Padding(6, 0, 6, 0);
 			label21.Name = "label21";
-			label21.Size = new System.Drawing.Size(94, 15);
+			label21.Size = new System.Drawing.Size(188, 32);
 			label21.TabIndex = 3;
 			label21.Text = "Encoder Quality:";
 			// 
@@ -831,25 +915,28 @@
 			// 
 			encoderQualityCb.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
 			encoderQualityCb.FormattingEnabled = true;
-			encoderQualityCb.Location = new System.Drawing.Point(337, 75);
+			encoderQualityCb.Location = new System.Drawing.Point(626, 160);
+			encoderQualityCb.Margin = new System.Windows.Forms.Padding(6);
 			encoderQualityCb.Name = "encoderQualityCb";
-			encoderQualityCb.Size = new System.Drawing.Size(90, 23);
+			encoderQualityCb.Size = new System.Drawing.Size(164, 40);
 			encoderQualityCb.TabIndex = 2;
 			// 
 			// maxSampleRateCb
 			// 
 			maxSampleRateCb.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
 			maxSampleRateCb.FormattingEnabled = true;
-			maxSampleRateCb.Location = new System.Drawing.Point(119, 75);
+			maxSampleRateCb.Location = new System.Drawing.Point(221, 160);
+			maxSampleRateCb.Margin = new System.Windows.Forms.Padding(6);
 			maxSampleRateCb.Name = "maxSampleRateCb";
-			maxSampleRateCb.Size = new System.Drawing.Size(101, 23);
+			maxSampleRateCb.Size = new System.Drawing.Size(184, 40);
 			maxSampleRateCb.TabIndex = 2;
 			// 
 			// lameDownsampleMonoCbox
 			// 
-			lameDownsampleMonoCbox.Location = new System.Drawing.Point(237, 30);
+			lameDownsampleMonoCbox.Location = new System.Drawing.Point(440, 64);
+			lameDownsampleMonoCbox.Margin = new System.Windows.Forms.Padding(6);
 			lameDownsampleMonoCbox.Name = "lameDownsampleMonoCbox";
-			lameDownsampleMonoCbox.Size = new System.Drawing.Size(184, 34);
+			lameDownsampleMonoCbox.Size = new System.Drawing.Size(342, 73);
 			lameDownsampleMonoCbox.TabIndex = 1;
 			lameDownsampleMonoCbox.Text = "Downsample stereo to mono?\r\n(Recommended)\r\n";
 			lameDownsampleMonoCbox.UseVisualStyleBackColor = true;
@@ -865,9 +952,11 @@
 			lameBitrateGb.Controls.Add(label11);
 			lameBitrateGb.Controls.Add(label3);
 			lameBitrateGb.Controls.Add(lameBitrateTb);
-			lameBitrateGb.Location = new System.Drawing.Point(6, 104);
+			lameBitrateGb.Location = new System.Drawing.Point(11, 222);
+			lameBitrateGb.Margin = new System.Windows.Forms.Padding(6);
 			lameBitrateGb.Name = "lameBitrateGb";
-			lameBitrateGb.Size = new System.Drawing.Size(421, 102);
+			lameBitrateGb.Padding = new System.Windows.Forms.Padding(6);
+			lameBitrateGb.Size = new System.Drawing.Size(782, 218);
 			lameBitrateGb.TabIndex = 0;
 			lameBitrateGb.TabStop = false;
 			lameBitrateGb.Text = "Bitrate";
@@ -875,9 +964,10 @@
 			// LameMatchSourceBRCbox
 			// 
 			LameMatchSourceBRCbox.AutoSize = true;
-			LameMatchSourceBRCbox.Location = new System.Drawing.Point(275, 76);
+			LameMatchSourceBRCbox.Location = new System.Drawing.Point(511, 162);
+			LameMatchSourceBRCbox.Margin = new System.Windows.Forms.Padding(6);
 			LameMatchSourceBRCbox.Name = "LameMatchSourceBRCbox";
-			LameMatchSourceBRCbox.Size = new System.Drawing.Size(140, 19);
+			LameMatchSourceBRCbox.Size = new System.Drawing.Size(277, 36);
 			LameMatchSourceBRCbox.TabIndex = 3;
 			LameMatchSourceBRCbox.Text = "Match source bitrate?";
 			LameMatchSourceBRCbox.UseVisualStyleBackColor = true;
@@ -886,9 +976,10 @@
 			// lameConstantBitrateCbox
 			// 
 			lameConstantBitrateCbox.AutoSize = true;
-			lameConstantBitrateCbox.Location = new System.Drawing.Point(6, 77);
+			lameConstantBitrateCbox.Location = new System.Drawing.Point(11, 164);
+			lameConstantBitrateCbox.Margin = new System.Windows.Forms.Padding(6);
 			lameConstantBitrateCbox.Name = "lameConstantBitrateCbox";
-			lameConstantBitrateCbox.Size = new System.Drawing.Size(216, 19);
+			lameConstantBitrateCbox.Size = new System.Drawing.Size(431, 36);
 			lameConstantBitrateCbox.TabIndex = 2;
 			lameConstantBitrateCbox.Text = "Restrict encoder to constant bitrate?";
 			lameConstantBitrateCbox.UseVisualStyleBackColor = true;
@@ -897,9 +988,10 @@
 			// 
 			label7.AutoSize = true;
 			label7.BackColor = System.Drawing.SystemColors.ControlLightLight;
-			label7.Location = new System.Drawing.Point(390, 52);
+			label7.Location = new System.Drawing.Point(724, 111);
+			label7.Margin = new System.Windows.Forms.Padding(6, 0, 6, 0);
 			label7.Name = "label7";
-			label7.Size = new System.Drawing.Size(25, 15);
+			label7.Size = new System.Drawing.Size(53, 32);
 			label7.TabIndex = 1;
 			label7.Text = "320";
 			// 
@@ -907,9 +999,10 @@
 			// 
 			label6.AutoSize = true;
 			label6.BackColor = System.Drawing.SystemColors.ControlLightLight;
-			label6.Location = new System.Drawing.Point(309, 52);
+			label6.Location = new System.Drawing.Point(574, 111);
+			label6.Margin = new System.Windows.Forms.Padding(6, 0, 6, 0);
 			label6.Name = "label6";
-			label6.Size = new System.Drawing.Size(25, 15);
+			label6.Size = new System.Drawing.Size(53, 32);
 			label6.TabIndex = 1;
 			label6.Text = "256";
 			// 
@@ -917,9 +1010,10 @@
 			// 
 			label5.AutoSize = true;
 			label5.BackColor = System.Drawing.SystemColors.ControlLightLight;
-			label5.Location = new System.Drawing.Point(228, 52);
+			label5.Location = new System.Drawing.Point(423, 111);
+			label5.Margin = new System.Windows.Forms.Padding(6, 0, 6, 0);
 			label5.Name = "label5";
-			label5.Size = new System.Drawing.Size(25, 15);
+			label5.Size = new System.Drawing.Size(53, 32);
 			label5.TabIndex = 1;
 			label5.Text = "192";
 			// 
@@ -927,9 +1021,10 @@
 			// 
 			label4.AutoSize = true;
 			label4.BackColor = System.Drawing.SystemColors.ControlLightLight;
-			label4.Location = new System.Drawing.Point(147, 52);
+			label4.Location = new System.Drawing.Point(273, 111);
+			label4.Margin = new System.Windows.Forms.Padding(6, 0, 6, 0);
 			label4.Name = "label4";
-			label4.Size = new System.Drawing.Size(25, 15);
+			label4.Size = new System.Drawing.Size(53, 32);
 			label4.TabIndex = 1;
 			label4.Text = "128";
 			// 
@@ -937,9 +1032,10 @@
 			// 
 			label11.AutoSize = true;
 			label11.BackColor = System.Drawing.SystemColors.ControlLightLight;
-			label11.Location = new System.Drawing.Point(10, 52);
+			label11.Location = new System.Drawing.Point(19, 111);
+			label11.Margin = new System.Windows.Forms.Padding(6, 0, 6, 0);
 			label11.Name = "label11";
-			label11.Size = new System.Drawing.Size(19, 15);
+			label11.Size = new System.Drawing.Size(40, 32);
 			label11.TabIndex = 1;
 			label11.Text = "16";
 			// 
@@ -947,9 +1043,10 @@
 			// 
 			label3.AutoSize = true;
 			label3.BackColor = System.Drawing.SystemColors.ControlLightLight;
-			label3.Location = new System.Drawing.Point(71, 52);
+			label3.Location = new System.Drawing.Point(132, 111);
+			label3.Margin = new System.Windows.Forms.Padding(6, 0, 6, 0);
 			label3.Name = "label3";
-			label3.Size = new System.Drawing.Size(19, 15);
+			label3.Size = new System.Drawing.Size(40, 32);
 			label3.TabIndex = 1;
 			label3.Text = "64";
 			// 
@@ -957,11 +1054,12 @@
 			// 
 			lameBitrateTb.BackColor = System.Drawing.SystemColors.ControlLightLight;
 			lameBitrateTb.LargeChange = 32;
-			lameBitrateTb.Location = new System.Drawing.Point(6, 22);
+			lameBitrateTb.Location = new System.Drawing.Point(11, 47);
+			lameBitrateTb.Margin = new System.Windows.Forms.Padding(6);
 			lameBitrateTb.Maximum = 320;
 			lameBitrateTb.Minimum = 16;
 			lameBitrateTb.Name = "lameBitrateTb";
-			lameBitrateTb.Size = new System.Drawing.Size(409, 45);
+			lameBitrateTb.Size = new System.Drawing.Size(760, 90);
 			lameBitrateTb.SmallChange = 8;
 			lameBitrateTb.TabIndex = 0;
 			lameBitrateTb.TickFrequency = 16;
@@ -972,9 +1070,10 @@
 			label1.AutoSize = true;
 			label1.Enabled = false;
 			label1.Font = new System.Drawing.Font("Segoe UI", 9F, System.Drawing.FontStyle.Italic, System.Drawing.GraphicsUnit.Point);
-			label1.Location = new System.Drawing.Point(6, 325);
+			label1.Location = new System.Drawing.Point(11, 693);
+			label1.Margin = new System.Windows.Forms.Padding(6, 0, 6, 0);
 			label1.Name = "label1";
-			label1.Size = new System.Drawing.Size(172, 15);
+			label1.Size = new System.Drawing.Size(333, 32);
 			label1.TabIndex = 1;
 			label1.Text = "Using L.A.M.E. encoding engine";
 			// 
@@ -993,9 +1092,11 @@
 			lameQualityGb.Controls.Add(label14);
 			lameQualityGb.Controls.Add(label2);
 			lameQualityGb.Controls.Add(lameVBRQualityTb);
-			lameQualityGb.Location = new System.Drawing.Point(6, 212);
+			lameQualityGb.Location = new System.Drawing.Point(11, 452);
+			lameQualityGb.Margin = new System.Windows.Forms.Padding(6);
 			lameQualityGb.Name = "lameQualityGb";
-			lameQualityGb.Size = new System.Drawing.Size(421, 103);
+			lameQualityGb.Padding = new System.Windows.Forms.Padding(6);
+			lameQualityGb.Size = new System.Drawing.Size(782, 220);
 			lameQualityGb.TabIndex = 0;
 			lameQualityGb.TabStop = false;
 			lameQualityGb.Text = "Quality";
@@ -1003,108 +1104,120 @@
 			// label19
 			// 
 			label19.AutoSize = true;
-			label19.Location = new System.Drawing.Point(349, 52);
+			label19.Location = new System.Drawing.Point(648, 111);
+			label19.Margin = new System.Windows.Forms.Padding(6, 0, 6, 0);
 			label19.Name = "label19";
-			label19.Size = new System.Drawing.Size(20, 15);
+			label19.Size = new System.Drawing.Size(42, 32);
 			label19.TabIndex = 1;
 			label19.Text = "V8";
 			// 
 			// label18
 			// 
 			label18.AutoSize = true;
-			label18.Location = new System.Drawing.Point(307, 52);
+			label18.Location = new System.Drawing.Point(570, 111);
+			label18.Margin = new System.Windows.Forms.Padding(6, 0, 6, 0);
 			label18.Name = "label18";
-			label18.Size = new System.Drawing.Size(20, 15);
+			label18.Size = new System.Drawing.Size(42, 32);
 			label18.TabIndex = 1;
 			label18.Text = "V7";
 			// 
 			// label17
 			// 
 			label17.AutoSize = true;
-			label17.Location = new System.Drawing.Point(265, 52);
+			label17.Location = new System.Drawing.Point(492, 111);
+			label17.Margin = new System.Windows.Forms.Padding(6, 0, 6, 0);
 			label17.Name = "label17";
-			label17.Size = new System.Drawing.Size(20, 15);
+			label17.Size = new System.Drawing.Size(42, 32);
 			label17.TabIndex = 1;
 			label17.Text = "V6";
 			// 
 			// label16
 			// 
 			label16.AutoSize = true;
-			label16.Location = new System.Drawing.Point(223, 52);
+			label16.Location = new System.Drawing.Point(414, 111);
+			label16.Margin = new System.Windows.Forms.Padding(6, 0, 6, 0);
 			label16.Name = "label16";
-			label16.Size = new System.Drawing.Size(20, 15);
+			label16.Size = new System.Drawing.Size(42, 32);
 			label16.TabIndex = 1;
 			label16.Text = "V5";
 			// 
 			// label12
 			// 
 			label12.AutoSize = true;
-			label12.Location = new System.Drawing.Point(182, 52);
+			label12.Location = new System.Drawing.Point(338, 111);
+			label12.Margin = new System.Windows.Forms.Padding(6, 0, 6, 0);
 			label12.Name = "label12";
-			label12.Size = new System.Drawing.Size(20, 15);
+			label12.Size = new System.Drawing.Size(42, 32);
 			label12.TabIndex = 1;
 			label12.Text = "V4";
 			// 
 			// label15
 			// 
 			label15.AutoSize = true;
-			label15.Location = new System.Drawing.Point(140, 52);
+			label15.Location = new System.Drawing.Point(260, 111);
+			label15.Margin = new System.Windows.Forms.Padding(6, 0, 6, 0);
 			label15.Name = "label15";
-			label15.Size = new System.Drawing.Size(20, 15);
+			label15.Size = new System.Drawing.Size(42, 32);
 			label15.TabIndex = 1;
 			label15.Text = "V3";
 			// 
 			// label9
 			// 
 			label9.AutoSize = true;
-			label9.Location = new System.Drawing.Point(97, 52);
+			label9.Location = new System.Drawing.Point(180, 111);
+			label9.Margin = new System.Windows.Forms.Padding(6, 0, 6, 0);
 			label9.Name = "label9";
-			label9.Size = new System.Drawing.Size(20, 15);
+			label9.Size = new System.Drawing.Size(42, 32);
 			label9.TabIndex = 1;
 			label9.Text = "V2";
 			// 
 			// label8
 			// 
 			label8.AutoSize = true;
-			label8.Location = new System.Drawing.Point(391, 52);
+			label8.Location = new System.Drawing.Point(726, 111);
+			label8.Margin = new System.Windows.Forms.Padding(6, 0, 6, 0);
 			label8.Name = "label8";
-			label8.Size = new System.Drawing.Size(20, 15);
+			label8.Size = new System.Drawing.Size(42, 32);
 			label8.TabIndex = 1;
 			label8.Text = "V9";
 			// 
 			// label13
 			// 
 			label13.AutoSize = true;
-			label13.Location = new System.Drawing.Point(376, 80);
+			label13.Location = new System.Drawing.Point(698, 171);
+			label13.Margin = new System.Windows.Forms.Padding(6, 0, 6, 0);
 			label13.Name = "label13";
-			label13.Size = new System.Drawing.Size(39, 15);
+			label13.Size = new System.Drawing.Size(77, 32);
 			label13.TabIndex = 1;
 			label13.Text = "Lower";
 			// 
 			// label10
 			// 
 			label10.AutoSize = true;
-			label10.Location = new System.Drawing.Point(6, 80);
+			label10.Location = new System.Drawing.Point(11, 171);
+			label10.Margin = new System.Windows.Forms.Padding(6, 0, 6, 0);
 			label10.Name = "label10";
-			label10.Size = new System.Drawing.Size(43, 15);
+			label10.Size = new System.Drawing.Size(86, 32);
 			label10.TabIndex = 1;
 			label10.Text = "Higher";
 			// 
 			// label14
 			// 
 			label14.AutoSize = true;
-			label14.Location = new System.Drawing.Point(56, 52);
+			label14.Location = new System.Drawing.Point(104, 111);
+			label14.Margin = new System.Windows.Forms.Padding(6, 0, 6, 0);
 			label14.Name = "label14";
-			label14.Size = new System.Drawing.Size(20, 15);
+			label14.Size = new System.Drawing.Size(42, 32);
 			label14.TabIndex = 1;
 			label14.Text = "V1";
 			// 
 			// label2
 			// 
 			label2.AutoSize = true;
-			label2.Location = new System.Drawing.Point(14, 52);
+			label2.Location = new System.Drawing.Point(26, 111);
+			label2.Margin = new System.Windows.Forms.Padding(6, 0, 6, 0);
 			label2.Name = "label2";
-			label2.Size = new System.Drawing.Size(20, 15);
+			label2.Size = new System.Drawing.Size(42, 32);
 			label2.TabIndex = 1;
 			label2.Text = "V0";
 			// 
@@ -1112,10 +1225,11 @@
 			// 
 			lameVBRQualityTb.BackColor = System.Drawing.SystemColors.ControlLightLight;
 			lameVBRQualityTb.LargeChange = 1;
-			lameVBRQualityTb.Location = new System.Drawing.Point(10, 22);
+			lameVBRQualityTb.Location = new System.Drawing.Point(19, 47);
+			lameVBRQualityTb.Margin = new System.Windows.Forms.Padding(6);
 			lameVBRQualityTb.Maximum = 9;
 			lameVBRQualityTb.Name = "lameVBRQualityTb";
-			lameVBRQualityTb.Size = new System.Drawing.Size(405, 45);
+			lameVBRQualityTb.Size = new System.Drawing.Size(752, 90);
 			lameVBRQualityTb.TabIndex = 0;
 			lameVBRQualityTb.Value = 9;
 			// 
@@ -1123,9 +1237,11 @@
 			// 
 			groupBox2.Controls.Add(lameTargetQualityRb);
 			groupBox2.Controls.Add(lameTargetBitrateRb);
-			groupBox2.Location = new System.Drawing.Point(6, 22);
+			groupBox2.Location = new System.Drawing.Point(11, 47);
+			groupBox2.Margin = new System.Windows.Forms.Padding(6);
 			groupBox2.Name = "groupBox2";
-			groupBox2.Size = new System.Drawing.Size(214, 47);
+			groupBox2.Padding = new System.Windows.Forms.Padding(6);
+			groupBox2.Size = new System.Drawing.Size(397, 100);
 			groupBox2.TabIndex = 0;
 			groupBox2.TabStop = false;
 			groupBox2.Text = "Target";
@@ -1133,9 +1249,10 @@
 			// lameTargetQualityRb
 			// 
 			lameTargetQualityRb.AutoSize = true;
-			lameTargetQualityRb.Location = new System.Drawing.Point(139, 22);
+			lameTargetQualityRb.Location = new System.Drawing.Point(258, 47);
+			lameTargetQualityRb.Margin = new System.Windows.Forms.Padding(6);
 			lameTargetQualityRb.Name = "lameTargetQualityRb";
-			lameTargetQualityRb.Size = new System.Drawing.Size(63, 19);
+			lameTargetQualityRb.Size = new System.Drawing.Size(121, 36);
 			lameTargetQualityRb.TabIndex = 0;
 			lameTargetQualityRb.TabStop = true;
 			lameTargetQualityRb.Text = "Quality";
@@ -1145,9 +1262,10 @@
 			// lameTargetBitrateRb
 			// 
 			lameTargetBitrateRb.AutoSize = true;
-			lameTargetBitrateRb.Location = new System.Drawing.Point(6, 22);
+			lameTargetBitrateRb.Location = new System.Drawing.Point(11, 47);
+			lameTargetBitrateRb.Margin = new System.Windows.Forms.Padding(6);
 			lameTargetBitrateRb.Name = "lameTargetBitrateRb";
-			lameTargetBitrateRb.Size = new System.Drawing.Size(59, 19);
+			lameTargetBitrateRb.Size = new System.Drawing.Size(114, 36);
 			lameTargetBitrateRb.TabIndex = 0;
 			lameTargetBitrateRb.TabStop = true;
 			lameTargetBitrateRb.Text = "Bitrate";
@@ -1157,9 +1275,10 @@
 			// mergeOpeningEndCreditsCbox
 			// 
 			mergeOpeningEndCreditsCbox.AutoSize = true;
-			mergeOpeningEndCreditsCbox.Location = new System.Drawing.Point(19, 118);
+			mergeOpeningEndCreditsCbox.Location = new System.Drawing.Point(35, 283);
+			mergeOpeningEndCreditsCbox.Margin = new System.Windows.Forms.Padding(6);
 			mergeOpeningEndCreditsCbox.Name = "mergeOpeningEndCreditsCbox";
-			mergeOpeningEndCreditsCbox.Size = new System.Drawing.Size(198, 19);
+			mergeOpeningEndCreditsCbox.Size = new System.Drawing.Size(392, 36);
 			mergeOpeningEndCreditsCbox.TabIndex = 13;
 			mergeOpeningEndCreditsCbox.Text = "[MergeOpeningEndCredits desc]";
 			mergeOpeningEndCreditsCbox.UseVisualStyleBackColor = true;
@@ -1167,9 +1286,10 @@
 			// retainAaxFileCbox
 			// 
 			retainAaxFileCbox.AutoSize = true;
-			retainAaxFileCbox.Location = new System.Drawing.Point(19, 93);
+			retainAaxFileCbox.Location = new System.Drawing.Point(35, 229);
+			retainAaxFileCbox.Margin = new System.Windows.Forms.Padding(6);
 			retainAaxFileCbox.Name = "retainAaxFileCbox";
-			retainAaxFileCbox.Size = new System.Drawing.Size(132, 19);
+			retainAaxFileCbox.Size = new System.Drawing.Size(256, 36);
 			retainAaxFileCbox.TabIndex = 10;
 			retainAaxFileCbox.Text = "[RetainAaxFile desc]";
 			retainAaxFileCbox.UseVisualStyleBackColor = true;
@@ -1180,9 +1300,10 @@
 			downloadCoverArtCbox.AutoSize = true;
 			downloadCoverArtCbox.Checked = true;
 			downloadCoverArtCbox.CheckState = System.Windows.Forms.CheckState.Checked;
-			downloadCoverArtCbox.Location = new System.Drawing.Point(19, 43);
+			downloadCoverArtCbox.Location = new System.Drawing.Point(35, 123);
+			downloadCoverArtCbox.Margin = new System.Windows.Forms.Padding(6);
 			downloadCoverArtCbox.Name = "downloadCoverArtCbox";
-			downloadCoverArtCbox.Size = new System.Drawing.Size(162, 19);
+			downloadCoverArtCbox.Size = new System.Drawing.Size(316, 36);
 			downloadCoverArtCbox.TabIndex = 10;
 			downloadCoverArtCbox.Text = "[DownloadCoverArt desc]";
 			downloadCoverArtCbox.UseVisualStyleBackColor = true;
@@ -1193,9 +1314,10 @@
 			createCueSheetCbox.AutoSize = true;
 			createCueSheetCbox.Checked = true;
 			createCueSheetCbox.CheckState = System.Windows.Forms.CheckState.Checked;
-			createCueSheetCbox.Location = new System.Drawing.Point(19, 18);
+			createCueSheetCbox.Location = new System.Drawing.Point(35, 69);
+			createCueSheetCbox.Margin = new System.Windows.Forms.Padding(6);
 			createCueSheetCbox.Name = "createCueSheetCbox";
-			createCueSheetCbox.Size = new System.Drawing.Size(145, 19);
+			createCueSheetCbox.Size = new System.Drawing.Size(287, 36);
 			createCueSheetCbox.TabIndex = 10;
 			createCueSheetCbox.Text = "[CreateCueSheet desc]";
 			createCueSheetCbox.UseVisualStyleBackColor = true;
@@ -1204,15 +1326,15 @@
 			// SettingsDialog
 			// 
 			AcceptButton = saveBtn;
-			AutoScaleDimensions = new System.Drawing.SizeF(7F, 15F);
+			AutoScaleDimensions = new System.Drawing.SizeF(13F, 32F);
 			AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
 			CancelButton = cancelBtn;
-			ClientSize = new System.Drawing.Size(886, 534);
+			ClientSize = new System.Drawing.Size(1645, 1139);
 			Controls.Add(tabControl);
 			Controls.Add(cancelBtn);
 			Controls.Add(saveBtn);
 			FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedDialog;
-			Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+			Margin = new System.Windows.Forms.Padding(7, 6, 7, 6);
 			MaximizeBox = false;
 			MinimizeBox = false;
 			Name = "SettingsDialog";
@@ -1350,5 +1472,7 @@
 		private System.Windows.Forms.ComboBox lastWriteTimeCb;
 		private System.Windows.Forms.ComboBox creationTimeCb;
 		private System.Windows.Forms.Label lastWriteTimeLbl;
+		private System.Windows.Forms.ComboBox fileDownloadQualityCb;
+		private System.Windows.Forms.Label fileDownloadQualityLbl;
 	}
 }

--- a/Source/LibationWinForms/Dialogs/SettingsDialog.ImportLibrary.cs
+++ b/Source/LibationWinForms/Dialogs/SettingsDialog.ImportLibrary.cs
@@ -14,15 +14,6 @@ namespace LibationWinForms.Dialogs
 			this.importEpisodesCb.Text = desc(nameof(config.ImportEpisodes));
 			this.downloadEpisodesCb.Text = desc(nameof(config.DownloadEpisodes));
 			this.autoDownloadEpisodesCb.Text = desc(nameof(config.AutoDownloadEpisodes));
-			creationTimeLbl.Text = desc(nameof(config.CreationTime));
-			lastWriteTimeLbl.Text = desc(nameof(config.LastWriteTime));
-
-			var dateTimeSources = Enum.GetValues<Configuration.DateTimeSource>().Select(v => new EnumDiaplay<Configuration.DateTimeSource>(v)).ToArray();
-			creationTimeCb.Items.AddRange(dateTimeSources);
-			lastWriteTimeCb.Items.AddRange(dateTimeSources);
-
-			creationTimeCb.SelectedItem = dateTimeSources.SingleOrDefault(v => v.Value == config.CreationTime) ?? dateTimeSources[0];
-			lastWriteTimeCb.SelectedItem = dateTimeSources.SingleOrDefault(v => v.Value == config.LastWriteTime) ?? dateTimeSources[0];
 
 			autoScanCb.Checked = config.AutoScan;
 			showImportedStatsCb.Checked = config.ShowImportedStats;
@@ -32,9 +23,6 @@ namespace LibationWinForms.Dialogs
 		}
 		private void Save_ImportLibrary(Configuration config)
 		{
-			config.CreationTime = ((EnumDiaplay<Configuration.DateTimeSource>)creationTimeCb.SelectedItem).Value;
-			config.LastWriteTime = ((EnumDiaplay<Configuration.DateTimeSource>)lastWriteTimeCb.SelectedItem).Value;
-
 			config.AutoScan = autoScanCb.Checked;
 			config.ShowImportedStats = showImportedStatsCb.Checked;
 			config.ImportEpisodes = importEpisodesCb.Checked;

--- a/Source/LibationWinForms/Dialogs/SettingsDialog.Important.cs
+++ b/Source/LibationWinForms/Dialogs/SettingsDialog.Important.cs
@@ -1,6 +1,7 @@
 ﻿using Dinah.Core;
 using FileManager;
 using LibationFileManager;
+using LibationUiBase;
 using System;
 using System.IO;
 using System.Linq;
@@ -25,6 +26,16 @@ namespace LibationWinForms.Dialogs
 			betaOptInCbox.Text = desc(nameof(config.BetaOptIn));
 			saveEpisodesToSeriesFolderCbox.Text = desc(nameof(config.SavePodcastsToParentFolder));
 			overwriteExistingCbox.Text = desc(nameof(config.OverwriteExisting));
+			creationTimeLbl.Text = desc(nameof(config.CreationTime));
+			lastWriteTimeLbl.Text = desc(nameof(config.LastWriteTime));
+
+			var dateTimeSources = Enum.GetValues<Configuration.DateTimeSource>().Select(v => new EnumDiaplay<Configuration.DateTimeSource>(v)).ToArray();
+			creationTimeCb.Items.AddRange(dateTimeSources);
+			lastWriteTimeCb.Items.AddRange(dateTimeSources);
+
+			creationTimeCb.SelectedItem = dateTimeSources.SingleOrDefault(v => v.Value == config.CreationTime) ?? dateTimeSources[0];
+			lastWriteTimeCb.SelectedItem = dateTimeSources.SingleOrDefault(v => v.Value == config.LastWriteTime) ?? dateTimeSources[0];
+
 
 			booksSelectControl.SetSearchTitle("books location");
 			booksSelectControl.SetDirectoryItems(
@@ -82,6 +93,11 @@ namespace LibationWinForms.Dialogs
 			config.OverwriteExisting = overwriteExistingCbox.Checked;
 
 			config.BetaOptIn = betaOptInCbox.Checked;
+
+
+			config.CreationTime = ((EnumDiaplay<Configuration.DateTimeSource>)creationTimeCb.SelectedItem).Value;
+			config.LastWriteTime = ((EnumDiaplay<Configuration.DateTimeSource>)lastWriteTimeCb.SelectedItem).Value;
+
 		}
 
 

--- a/Source/LibationWinForms/Program.cs
+++ b/Source/LibationWinForms/Program.cs
@@ -30,8 +30,6 @@ namespace LibationWinForms
 
 				ApplicationConfiguration.Initialize();
 
-				AppScaffolding.LibationScaffolding.SetReleaseIdentifier(AppScaffolding.Variety.Classic);
-
 				//***********************************************//
 				//                                               //
 				//   do not use Configuration before this line   //


### PR DESCRIPTION
## [Overhaul LibationCli](https://github.com/rmcrackan/Libation/pull/651/commits/29803c6ba0e659a0016de64654c1a68b9cfdc90a)
- Add version verb with option to check for upgrade
- Add Search verb to search the library
- Add export file type inference
- Add more set-status options
- Add console progress bar and ETA
- Add processable option to liberate specific book IDs
- Scan accounts by nickname or account ID
- Improve startup performance for help and on parsing error
- More useful error messages

Unfortunately [there's a bug in CommandLineParser](https://github.com/commandlineparser/commandline/issues/821) that necessitated rolling my own help text implementation, but it's not too convoluted.

## [Add setting to choose downloaded audio quality](https://github.com/rmcrackan/Libation/pull/651/commits/423b5312f7d3d75e515bca7c8fb890a9e86634c9) #648 
