### PR TITLE
Fix query parsing tags with underscores (#655)

### DIFF
--- a/Source/_Tests/LibationSearchEngine.Tests/SearchEngineTests.cs
+++ b/Source/_Tests/LibationSearchEngine.Tests/SearchEngineTests.cs
@@ -30,18 +30,21 @@ namespace SearchEngineTests
 		[DataRow("   ", "*:*")]
 
 		// tag surrounded by spaces
-		[DataRow("[foo]", "tags:foo")]
-		[DataRow("  [foo]", "  tags:foo")]
-		[DataRow("  [   foo   ]", "  tags:foo")]
-		[DataRow("[foo]  ", "tags:foo  ")]
-		[DataRow("  [foo]  ", "  tags:foo  ")]
-		[DataRow("-[foo]", "-tags:foo")]
-		[DataRow("  -[foo]", "  -tags:foo")]
-		[DataRow("-[foo]  ", "-tags:foo  ")]
-		[DataRow("  -[foo]  ", "  -tags:foo  ")]
+		[DataRow("[foo]", "tags:foo ")]
+		[DataRow("  [foo]", "  tags:foo ")]
+		[DataRow("  [   foo   ]", "  tags:foo ")]
+		[DataRow("[foo]  ", "tags:foo   ")]
+		[DataRow("  [foo]  ", "  tags:foo   ")]
+		[DataRow("-[foo]", "-tags:foo ")]
+		[DataRow("  -[foo]", "  -tags:foo ")]
+		[DataRow("-[foo]  ", "-tags:foo   ")]
+		[DataRow("  -[foo]  ", "  -tags:foo   ")]
+		[DataRow("[foo_bar]", "tags:foo_bar ")]
+		[DataRow("-[foo_bar]", "-tags:foo_bar ")]
+		[DataRow("[foo_bar] [foo_bar2]", "tags:foo_bar  tags:foo_bar2 ")]
 
 		// tag case irrelevant
-		[DataRow("[FoO]", "tags:FoO")]
+		[DataRow("[FoO]", "tags:FoO ")]
 
 		// bool keyword surrounded by spaces
 		[DataRow("israted", "israted:True")]
@@ -69,9 +72,9 @@ namespace SearchEngineTests
 		[DataRow("liberated AND isRated:false", "liberated:True AND israted:false")]
 
 		// tag which happens to be a bool keyword >> parse as tag
-		[DataRow("[israted]", "tags:israted")]
-		[DataRow("[tags]    [israted] [tags] [tags]  [isliberated] [israted]   ", "tags:tags    tags:israted tags:tags tags:tags  tags:isliberated tags:israted   ")]
-		[DataRow("[tags][israted]", "tags:tagstags:israted")]
+		[DataRow("[israted]", "tags:israted ")]
+		[DataRow("[tags]    [israted] [tags] [tags]  [isliberated] [israted]   ", "tags:tags     tags:israted  tags:tags  tags:tags   tags:isliberated  tags:israted    ")]
+		[DataRow("[tags][israted]", "tags:tags tags:israted ")]
 
 		// numbers with "to". TO all caps, numbers [8.2] format
 		[DataRow("1 to 10", "00000001.00 TO 00000010.00")]


### PR DESCRIPTION
Brought back the tag block regex.