### PR TITLE
Batch of Fixxed Issues

### DIFF
--- a/Images/libation_glass.svg
+++ b/Images/libation_glass.svg
@@ -1,28 +1,45 @@
-<svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 512 512" enable-background="new 0 0 512 512">
-<path id="glass" d=
-"M139,2
-	A 192,200 0 0 0 103,84
-	A 222,334 41 0 0 241,320
-	V478
-	H160
-	A 16,16 0 0 0 160,510
-	H352
-	A16 16 0 0 0 352,478
-	H271
-	V320
-	A 222,334 -41 0 0 409,84
-	A 192,200 0 0 0 373,2
-M355,32
-	A 192,200 0 0 1 381,127
-	A 187.5,334 -35 0 1 256,286
-	A 187.5,334 35 0 1 131,127
-	A 192,200 0 0 1 157,32
-	H355
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 524 524" enable-background="new 0 0 524 524">
+
+    <defs>
+      <filter id="white-glow" x="-400%" y="-400%" width="800%" height="800%">
+          <feFlood result="flood" flood-color="#ffffff" flood-opacity="1"></feFlood>
+          <feComposite in="flood" result="mask" in2="SourceGraphic" operator="in"></feComposite>
+          <feMorphology in="mask" result="dilated" operator="dilate" radius="3"></feMorphology>
+          <feGaussianBlur in="dilated" result="blurred" stdDeviation="6"></feGaussianBlur>
+          <feMerge>
+              <feMergeNode in="blurred"></feMergeNode>
+              <feMergeNode in="SourceGraphic"></feMergeNode>
+          </feMerge>
+      </filter>
+    </defs>
+
+<rect x="-400%" y="-400%" width="800%" height="800%" fill="Black" />
+<path id="glass" fill-rule="evenodd" style="fill: #000; filter:url(#white-glow)" d=
+"M145,8
+	a 192,200 0 0 0 -36,82
+	a 222,334 41 0 0 138,236
+	v158
+	h-81
+	a 16,16 0 0 0 0,32
+	h192
+	a 16 16 0 0 0 0,-32
+	h-81
+	v-158
+	a 222,334 -41 0 0 138,-236
+	a 192,200 0 0 0 -36,-82
+	h-234
+m18,30
+	a 192,200 0 0 0 -26,95
+	a 187.5,334 35 0 0 125,159
+	a 187.5,334 -35 0 0 125,-159
+	a 192,200 0 0 0 -26,-95
+	h-198
 z" />
 
-<path id="wine-level" d=
-"M146,128
-	A 168,300 35 0 0 256,270
-	A 168,300 -35 0 0 366,128
+<path id="wine-level" style="fill: #000; filter:url(#white-glow)" d=
+"M156,136
+	a 168,300 35 0 0 106,138
+	a 168,300 -35 0 0 106,-138
 z"/>
+
 </svg>

--- a/Images/libation_glass.svg
+++ b/Images/libation_glass.svg
@@ -1,45 +1,39 @@
 <svg version="1.1" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 524 524" enable-background="new 0 0 524 524">
-
-    <defs>
-      <filter id="white-glow" x="-400%" y="-400%" width="800%" height="800%">
-          <feFlood result="flood" flood-color="#ffffff" flood-opacity="1"></feFlood>
-          <feComposite in="flood" result="mask" in2="SourceGraphic" operator="in"></feComposite>
-          <feMorphology in="mask" result="dilated" operator="dilate" radius="3"></feMorphology>
-          <feGaussianBlur in="dilated" result="blurred" stdDeviation="6"></feGaussianBlur>
-          <feMerge>
-              <feMergeNode in="blurred"></feMergeNode>
-              <feMergeNode in="SourceGraphic"></feMergeNode>
-          </feMerge>
-      </filter>
-    </defs>
-
-<rect x="-400%" y="-400%" width="800%" height="800%" fill="Black" />
-<path id="glass" fill-rule="evenodd" style="fill: #000; filter:url(#white-glow)" d=
-"M145,8
-	a 192,200 0 0 0 -36,82
-	a 222,334 41 0 0 138,236
-	v158
-	h-81
-	a 16,16 0 0 0 0,32
-	h192
-	a 16 16 0 0 0 0,-32
-	h-81
-	v-158
-	a 222,334 -41 0 0 138,-236
-	a 192,200 0 0 0 -36,-82
-	h-234
-m18,30
-	a 192,200 0 0 0 -26,95
-	a 187.5,334 35 0 0 125,159
-	a 187.5,334 -35 0 0 125,-159
-	a 192,200 0 0 0 -26,-95
-	h-198
-z" />
-
-<path id="wine-level" style="fill: #000; filter:url(#white-glow)" d=
-"M156,136
-	a 168,300 35 0 0 106,138
-	a 168,300 -35 0 0 106,-138
-z"/>
-
+	<defs>
+		<g id="glass">
+			<path fill-rule="evenodd" d=
+				"M262,8
+					h-117
+					a 192,200 0 0 0 -36,82
+					a 222,334 41 0 0 138,236
+					v158
+					h-81
+					a 16,16 0 0 0 0,32
+					h192
+					a 16 16 0 0 0 0,-32
+					h-81
+					v-158
+					a 222,334 -41 0 0 138,-236
+					a 192,200 0 0 0 -36,-82
+					h-117
+				m-99,30
+					a 192,200 0 0 0 -26,95
+					a 187.5,334 35 0 0 125,159
+					a 187.5,334 -35 0 0 125,-159
+					a 192,200 0 0 0 -26,-95
+					h-198
+				z"/>
+		</g>
+		<g id="wine-level">
+			<path d=
+				"M158,136
+					a 168,305 35 0 0 104,136
+					a 168,305 -35 0 0 104,-136
+				z"/>
+		</g>
+	</defs>	
+	<use href="#glass" stroke="#ffffffa0" stroke-width="16" fill="Transparent" />
+	<use href="#wine-level" stroke="#ffffffa0" stroke-width="16" fill="Transparent" />
+	<use href="#glass" fill="Black" />
+	<use href="#wine-level" fill="Black" />
 </svg>

--- a/Source/DataLayer/EfClasses/Book.cs
+++ b/Source/DataLayer/EfClasses/Book.cs
@@ -106,6 +106,7 @@ namespace DataLayer
             ReplaceAuthors(authors);
             ReplaceNarrators(narrators);
         }
+
         public void UpdateTitle(string title, string subtitle)
         {
             Title = title?.Trim() ?? "";
@@ -113,8 +114,11 @@ namespace DataLayer
             _titleWithSubtitle = null;
         }
 
-        #region contributors, authors, narrators
-        internal HashSet<BookContributor> ContributorsLink { get; private set; }
+        public void UpdateLengthInMinutes(int lengthInMinutes)
+            => LengthInMinutes = lengthInMinutes;
+
+		#region contributors, authors, narrators
+		internal HashSet<BookContributor> ContributorsLink { get; private set; }
 
         public IEnumerable<Contributor> Authors => ContributorsLink.ByRole(Role.Author).Select(bc => bc.Contributor).ToList();
         public IEnumerable<Contributor> Narrators => ContributorsLink.ByRole(Role.Narrator).Select(bc => bc.Contributor).ToList();

--- a/Source/DtoImporterService/BookImporter.cs
+++ b/Source/DtoImporterService/BookImporter.cs
@@ -149,6 +149,8 @@ namespace DtoImporterService
 		{
 			var item = importItem.DtoItem;
 
+			book.UpdateLengthInMinutes(item.LengthInMinutes);
+
 			// Update the book titles, since formatting can change
 			book.UpdateTitle(item.Title, item.Subtitle);
 

--- a/Source/FileLiberator/AudioFileStorageExt.cs
+++ b/Source/FileLiberator/AudioFileStorageExt.cs
@@ -21,7 +21,8 @@ namespace FileLiberator
 				var series = libraryBook.Book.SeriesLink.SingleOrDefault();
 				if (series is not null)
 				{
-					var seriesParent = ApplicationServices.DbContexts.GetContext().GetLibraryBook_Flat_NoTracking(series.Series.AudibleSeriesId);
+					using var context = ApplicationServices.DbContexts.GetContext();
+					var seriesParent = context.GetLibraryBook_Flat_NoTracking(series.Series.AudibleSeriesId);
 
 					if (seriesParent is not null)
 					{

--- a/Source/HangoverAvalonia/HangoverAvalonia.csproj
+++ b/Source/HangoverAvalonia/HangoverAvalonia.csproj
@@ -67,13 +67,13 @@
 	</ItemGroup>
 	<ItemGroup>
 
-		<PackageReference Include="Avalonia" Version="11.0.2" />
-		<PackageReference Include="Avalonia.Desktop" Version="11.0.2" />
+		<PackageReference Include="Avalonia" Version="11.0.3" />
+		<PackageReference Include="Avalonia.Desktop" Version="11.0.3" />
 		<!--Condition below is needed to remove Avalonia.Diagnostics package from build output in Release configuration.-->
-		<PackageReference Condition="'$(Configuration)' == 'Debug'" Include="Avalonia.Diagnostics" Version="11.0.2" />
-		<PackageReference Include="Avalonia.ReactiveUI" Version="11.0.2" />
-		<PackageReference Include="Avalonia.Controls.ItemsRepeater" Version="11.0.2" />
-		<PackageReference Include="Avalonia.Themes.Fluent" Version="11.0.2" />
+		<PackageReference Condition="'$(Configuration)' == 'Debug'" Include="Avalonia.Diagnostics" Version="11.0.3" />
+		<PackageReference Include="Avalonia.ReactiveUI" Version="11.0.3" />
+		<PackageReference Include="Avalonia.Controls.ItemsRepeater" Version="11.0.3" />
+		<PackageReference Include="Avalonia.Themes.Fluent" Version="11.0.3" />
 	</ItemGroup>
 	<ItemGroup>
 		<ProjectReference Include="..\HangoverBase\HangoverBase.csproj" />

--- a/Source/LibationAvalonia/App.axaml
+++ b/Source/LibationAvalonia/App.axaml
@@ -44,9 +44,9 @@
 
 					<SolidColorBrush x:Key="CancelRed" Color="#802727" />
 					<SolidColorBrush x:Key="IconFill" Color="#DCE0DF" />
-					<SolidColorBrush x:Key="StoplightRed" Color="#5F0707" />
-					<SolidColorBrush x:Key="StoplightYellow" Color="#5F5B1A" />
-					<SolidColorBrush x:Key="StoplightGreen" Color="#174E15" />
+					<SolidColorBrush x:Key="StoplightRed" Color="#7d1f1f" />
+					<SolidColorBrush x:Key="StoplightYellow" Color="#7d7d1f" />
+					<SolidColorBrush x:Key="StoplightGreen" Color="#1f7d1f" />
 
 
 					<SolidColorBrush x:Key="DisabledGrayBrush" Opacity="0.4"  Color="{StaticResource SystemChromeMediumColor}" />

--- a/Source/LibationAvalonia/LibationAvalonia.csproj
+++ b/Source/LibationAvalonia/LibationAvalonia.csproj
@@ -70,13 +70,13 @@
 	</ItemGroup>
 
 	<ItemGroup>		
-		<PackageReference Include="Avalonia.Diagnostics" Version="11.0.2" Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'" />
-		<PackageReference Include="Avalonia" Version="11.0.2" />
-		<PackageReference Include="Avalonia.Controls.DataGrid" Version="11.0.2" />
-		<PackageReference Include="Avalonia.Controls.ItemsRepeater" Version="11.0.2" />
-		<PackageReference Include="Avalonia.Desktop" Version="11.0.2" />
-		<PackageReference Include="Avalonia.ReactiveUI" Version="11.0.2" />
-		<PackageReference Include="Avalonia.Themes.Fluent" Version="11.0.2" />
+		<PackageReference Include="Avalonia.Diagnostics" Version="11.0.3" Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'" />
+		<PackageReference Include="Avalonia" Version="11.0.3" />
+		<PackageReference Include="Avalonia.Controls.DataGrid" Version="11.0.3" />
+		<PackageReference Include="Avalonia.Controls.ItemsRepeater" Version="11.0.3" />
+		<PackageReference Include="Avalonia.Desktop" Version="11.0.3" />
+		<PackageReference Include="Avalonia.ReactiveUI" Version="11.0.3" />
+		<PackageReference Include="Avalonia.Themes.Fluent" Version="11.0.3" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/Source/LibationAvalonia/MessageBox.cs
+++ b/Source/LibationAvalonia/MessageBox.cs
@@ -177,9 +177,12 @@ Libation.
 			tbx.MinWidth = vm.TextBlockMinWidth;
 			tbx.Text = message;
 
-			var thisScreen = owner.Screens.ScreenFromVisual(owner);
+			
+			var thisScreen = owner.Screens?.ScreenFromVisual(owner);
 
-			var maxSize = new Size(0.20 * thisScreen.Bounds.Width, 0.9 * thisScreen.Bounds.Height - 55);
+			var maxSize
+				= thisScreen is null ? owner.ClientSize
+				: new Size(0.20 * thisScreen.Bounds.Width, 0.9 * thisScreen.Bounds.Height - 55);
 
 			var desiredMax = new Size(maxSize.Width, maxSize.Height);
 

--- a/Source/LibationAvalonia/ViewModels/ProductsDisplayViewModel.cs
+++ b/Source/LibationAvalonia/ViewModels/ProductsDisplayViewModel.cs
@@ -1,15 +1,18 @@
 using ApplicationServices;
 using AudibleUtilities;
 using Avalonia.Collections;
+using Avalonia.Controls;
 using Avalonia.Threading;
 using DataLayer;
 using LibationAvalonia.Dialogs.Login;
+using LibationFileManager;
 using LibationUiBase.GridView;
 using ReactiveUI;
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Linq;
+using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
 
 namespace LibationAvalonia.ViewModels
@@ -27,8 +30,8 @@ namespace LibationAvalonia.ViewModels
 		public string FilterString { get; private set; }
 		public DataGridCollectionView GridEntries { get; private set; }
 
-		private bool _removeColumnVisivle;
-		public bool RemoveColumnVisivle { get => _removeColumnVisivle; private set => this.RaiseAndSetIfChanged(ref _removeColumnVisivle, value); }
+		private bool _removeColumnVisible;
+		public bool RemoveColumnVisible { get => _removeColumnVisible; private set => this.RaiseAndSetIfChanged(ref _removeColumnVisible, value); }
 
 		public List<LibraryBook> GetVisibleBookEntries()
 			=> FilteredInGridEntries?
@@ -321,7 +324,7 @@ namespace LibationAvalonia.ViewModels
 		{
 			foreach (var item in SOURCE)
 				item.PropertyChanged -= GridEntry_PropertyChanged;
-			RemoveColumnVisivle = false;
+			RemoveColumnVisible = false;
 		}
 
 		public async Task RemoveCheckedBooksAsync()
@@ -376,7 +379,7 @@ namespace LibationAvalonia.ViewModels
 				item.PropertyChanged += GridEntry_PropertyChanged;
 			}
 
-			RemoveColumnVisivle = true;
+			RemoveColumnVisible = true;
 			RemovableCountChanged?.Invoke(this, 0);
 
 			try
@@ -417,6 +420,45 @@ namespace LibationAvalonia.ViewModels
 			{
 				int removeCount = GetAllBookEntries().Count(lbe => lbe.Remove is true);
 				RemovableCountChanged?.Invoke(this, removeCount);
+			}
+		}
+
+		#endregion
+
+		#region Column Widths
+
+		public DataGridLength TitleWidth { get => getColumnWidth("Title", 200); set => setColumnWidth("Title", value); }
+		public DataGridLength AuthorsWidth { get => getColumnWidth("Authors", 100); set => setColumnWidth("Authors", value); }
+		public DataGridLength NarratorsWidth { get => getColumnWidth("Narrators", 100); set => setColumnWidth("Narrators", value); }
+		public DataGridLength LengthWidth { get => getColumnWidth("Length", 80); set => setColumnWidth("Length", value); }
+		public DataGridLength SeriesWidth { get => getColumnWidth("Series", 100); set => setColumnWidth("Series", value); }
+		public DataGridLength SeriesOrderWidth { get => getColumnWidth("SeriesOrder", 60); set => setColumnWidth("SeriesOrder", value); }
+		public DataGridLength DescriptionWidth { get => getColumnWidth("Description", 100); set => setColumnWidth("Description", value); }
+		public DataGridLength CategoryWidth { get => getColumnWidth("Category", 100); set => setColumnWidth("Category", value); }
+		public DataGridLength ProductRatingWidth { get => getColumnWidth("ProductRating", 95); set => setColumnWidth("ProductRating", value); }
+		public DataGridLength PurchaseDateWidth { get => getColumnWidth("PurchaseDate", 75); set => setColumnWidth("PurchaseDate", value); }
+		public DataGridLength MyRatingWidth { get => getColumnWidth("MyRating", 95); set => setColumnWidth("MyRating", value); }
+		public DataGridLength MiscWidth { get => getColumnWidth("Misc", 140); set => setColumnWidth("Misc", value); }
+		public DataGridLength LastDownloadWidth { get => getColumnWidth("LastDownload", 100); set => setColumnWidth("LastDownload", value); }
+		public DataGridLength BookTagsWidth { get => getColumnWidth("BookTags", 100); set => setColumnWidth("BookTags", value); }
+
+		private static DataGridLength getColumnWidth(string columnName, double defaultWidth)
+			=> Configuration.Instance.GridColumnsWidths.TryGetValue(columnName, out var val)
+			? new DataGridLength(val)
+			: new DataGridLength(defaultWidth);
+
+		private void setColumnWidth(string columnName, DataGridLength width, [CallerMemberName] string propertyName = "")
+		{
+			var dictionary = Configuration.Instance.GridColumnsWidths;
+
+			var newValue = (int)width.DisplayValue;
+			var valueSame = dictionary.TryGetValue(columnName, out var val) && val == newValue;
+			dictionary[columnName] = newValue;
+
+			if (!valueSame)
+			{
+				Configuration.Instance.GridColumnsWidths = dictionary;
+				this.RaisePropertyChanged(propertyName);
 			}
 		}
 

--- a/Source/LibationAvalonia/Views/MainWindow.axaml.cs
+++ b/Source/LibationAvalonia/Views/MainWindow.axaml.cs
@@ -21,7 +21,7 @@ namespace LibationAvalonia.Views
 			InitializeComponent();
 			Configure_Upgrade();
 
-			Loaded += MainWindow_Loaded;
+			Opened += MainWindow_Opened;
 			Closing += MainWindow_Closing;
 			LibraryLoaded += MainWindow_LibraryLoaded;
 
@@ -35,7 +35,7 @@ namespace LibationAvalonia.Views
 			}
 		}
 
-		private async void MainWindow_Loaded(object sender, EventArgs e)
+		private async void MainWindow_Opened(object sender, EventArgs e)
 		{
 			if (Configuration.Instance.FirstLaunch)
 			{

--- a/Source/LibationAvalonia/Views/ProductsDisplay.axaml
+++ b/Source/LibationAvalonia/Views/ProductsDisplay.axaml
@@ -17,6 +17,7 @@
 			AutoGenerateColumns="False"
 			ItemsSource="{Binding GridEntries}"
 			CanUserSortColumns="True" BorderThickness="3"
+			CanUserResizeColumns="True"
 			CanUserReorderColumns="True">
 
 			<DataGrid.Styles>
@@ -45,10 +46,11 @@
 			</DataGrid.Styles>
 			
 			<DataGrid.Columns>
-
+ 
 				<DataGridTemplateColumn
 					CanUserSort="True"
-					IsVisible="{Binding RemoveColumnVisivle}"
+					CanUserResize="False"
+					IsVisible="{Binding RemoveColumnVisible}"
 					PropertyChanged="RemoveColumn_PropertyChanged"
 					Header="Remove"
 					IsReadOnly="False"
@@ -65,7 +67,7 @@
 					</DataGridTemplateColumn.CellTemplate>
 				</DataGridTemplateColumn>
 
-				<controls:DataGridTemplateColumnExt CanUserSort="True" Header="Liberate" SortMemberPath="Liberate" ClipboardContentBinding="{Binding Liberate.ToolTip}">
+				<controls:DataGridTemplateColumnExt CanUserResize="False" CanUserSort="True" Header="Liberate" SortMemberPath="Liberate" ClipboardContentBinding="{Binding Liberate.ToolTip}">
 					<DataGridTemplateColumn.CellTemplate>
 						<DataTemplate x:DataType="uibase:IGridEntry">
 							<views:LiberateStatusButton
@@ -80,15 +82,15 @@
 					</DataGridTemplateColumn.CellTemplate>
 				</controls:DataGridTemplateColumnExt>
 
-				<controls:DataGridTemplateColumnExt CanUserSort="False" Header="Cover" SortMemberPath="Cover" ClipboardContentBinding="{Binding LibraryBook.Book.PictureLarge}">
+				<controls:DataGridTemplateColumnExt CanUserResize="False" CanUserSort="False" Header="Cover" SortMemberPath="Cover" ClipboardContentBinding="{Binding LibraryBook.Book.PictureLarge}">
 					<DataGridTemplateColumn.CellTemplate>
-						<DataTemplate  x:DataType="uibase:IGridEntry">
+						<DataTemplate x:DataType="uibase:IGridEntry">
 							<Image Opacity="{CompiledBinding Liberate.Opacity}" Tapped="Cover_Click" Source="{CompiledBinding Cover}" ToolTip.Tip="Click to see full size" />
 						</DataTemplate>
 					</DataGridTemplateColumn.CellTemplate>
 				</controls:DataGridTemplateColumnExt>
 
-				<controls:DataGridTemplateColumnExt MinWidth="150" Width="2*" Header="Title" CanUserSort="True" SortMemberPath="Title" ClipboardContentBinding="{Binding Title}">
+				<controls:DataGridTemplateColumnExt Header="Title" MinWidth="10" Width="{Binding TitleWidth, Mode=TwoWay}" CanUserSort="True" SortMemberPath="Title" ClipboardContentBinding="{Binding Title}">
 					<DataGridTemplateColumn.CellTemplate>
 						<DataTemplate x:DataType="uibase:IGridEntry">
 							<Panel Opacity="{CompiledBinding Liberate.Opacity}" Background="{CompiledBinding Liberate.BackgroundBrush}">
@@ -98,7 +100,7 @@
 					</DataGridTemplateColumn.CellTemplate>
 				</controls:DataGridTemplateColumnExt>
 
-				<controls:DataGridTemplateColumnExt MinWidth="80" Width="1*" Header="Authors" CanUserSort="True" SortMemberPath="Authors" ClipboardContentBinding="{Binding Authors}">
+				<controls:DataGridTemplateColumnExt Header="Authors" MinWidth="10" Width="{Binding AuthorsWidth, Mode=TwoWay}" CanUserSort="True" SortMemberPath="Authors" ClipboardContentBinding="{Binding Authors}">
 					<DataGridTemplateColumn.CellTemplate>
 						<DataTemplate x:DataType="uibase:IGridEntry">
 							<Panel Opacity="{CompiledBinding Liberate.Opacity}" Background="{CompiledBinding Liberate.BackgroundBrush}">
@@ -108,7 +110,7 @@
 					</DataGridTemplateColumn.CellTemplate>
 				</controls:DataGridTemplateColumnExt>
 
-				<controls:DataGridTemplateColumnExt MinWidth="80" Width="1*"  Header="Narrators" CanUserSort="True" SortMemberPath="Narrators" ClipboardContentBinding="{Binding Narrators}">
+				<controls:DataGridTemplateColumnExt Header="Narrators" MinWidth="10" Width="{Binding NarratorsWidth, Mode=TwoWay}" CanUserSort="True" SortMemberPath="Narrators" ClipboardContentBinding="{Binding Narrators}">
 					<DataGridTemplateColumn.CellTemplate>
 						<DataTemplate x:DataType="uibase:IGridEntry">
 							<Panel Opacity="{CompiledBinding Liberate.Opacity}" Background="{CompiledBinding Liberate.BackgroundBrush}">
@@ -118,7 +120,7 @@
 					</DataGridTemplateColumn.CellTemplate>
 				</controls:DataGridTemplateColumnExt>
 
-				<controls:DataGridTemplateColumnExt Width="90"  Header="Length" CanUserSort="True" SortMemberPath="Length" ClipboardContentBinding="{Binding Length}">
+				<controls:DataGridTemplateColumnExt Header="Length" MinWidth="10" Width="{Binding LengthWidth, Mode=TwoWay}" CanUserSort="True" SortMemberPath="Length" ClipboardContentBinding="{Binding Length}">
 					<DataGridTemplateColumn.CellTemplate>
 						<DataTemplate x:DataType="uibase:IGridEntry">
 							<Panel Opacity="{CompiledBinding Liberate.Opacity}" Background="{CompiledBinding Liberate.BackgroundBrush}">
@@ -128,7 +130,7 @@
 					</DataGridTemplateColumn.CellTemplate>
 				</controls:DataGridTemplateColumnExt>
 
-				<controls:DataGridTemplateColumnExt MinWidth="80" Width="1*" Header="Series" CanUserSort="True" SortMemberPath="Series" ClipboardContentBinding="{Binding Series}">
+				<controls:DataGridTemplateColumnExt Header="Series" MinWidth="10" Width="{Binding SeriesWidth, Mode=TwoWay}" CanUserSort="True" SortMemberPath="Series" ClipboardContentBinding="{Binding Series}">
 					<DataGridTemplateColumn.CellTemplate>
 						<DataTemplate x:DataType="uibase:IGridEntry">
 							<Panel Opacity="{CompiledBinding Liberate.Opacity}" Background="{CompiledBinding Liberate.BackgroundBrush}">
@@ -138,7 +140,7 @@
 					</DataGridTemplateColumn.CellTemplate>
 				</controls:DataGridTemplateColumnExt>
 
-				<controls:DataGridTemplateColumnExt Width="Auto" Header="Series&#xA;Order" CanUserSort="True" SortMemberPath="SeriesOrder" ClipboardContentBinding="{Binding Series}">
+				<controls:DataGridTemplateColumnExt Header="Series&#xA;Order" MinWidth="10" Width="{Binding SeriesOrderWidth, Mode=TwoWay}" CanUserSort="True" SortMemberPath="SeriesOrder" ClipboardContentBinding="{Binding Series}">
 					<DataGridTemplateColumn.CellTemplate>
 						<DataTemplate x:DataType="uibase:IGridEntry">
 							<Panel Opacity="{CompiledBinding Liberate.Opacity}" Background="{CompiledBinding Liberate.BackgroundBrush}">
@@ -148,7 +150,7 @@
 					</DataGridTemplateColumn.CellTemplate>
 				</controls:DataGridTemplateColumnExt>
 
-				<controls:DataGridTemplateColumnExt MinWidth="100" Width="1*" Header="Description" CanUserSort="True" SortMemberPath="Description" ClipboardContentBinding="{Binding Description}">
+				<controls:DataGridTemplateColumnExt Header="Description" MinWidth="10" Width="{Binding DescriptionWidth, Mode=TwoWay}" CanUserSort="True" SortMemberPath="Description" ClipboardContentBinding="{Binding Description}">
 					<DataGridTemplateColumn.CellTemplate>
 						<DataTemplate x:DataType="uibase:IGridEntry">
 							<Panel Opacity="{CompiledBinding Liberate.Opacity}" Background="{CompiledBinding Liberate.BackgroundBrush}" Tapped="Description_Click" ToolTip.Tip="Click to see full description" >
@@ -158,7 +160,7 @@
 					</DataGridTemplateColumn.CellTemplate>
 				</controls:DataGridTemplateColumnExt>
 
-				<controls:DataGridTemplateColumnExt Width="100" Header="Category" CanUserSort="True" SortMemberPath="Category" ClipboardContentBinding="{Binding Category}">
+				<controls:DataGridTemplateColumnExt Header="Category" MinWidth="10" Width="{Binding CategoryWidth, Mode=TwoWay}" CanUserSort="True" SortMemberPath="Category" ClipboardContentBinding="{Binding Category}">
 					<DataGridTemplateColumn.CellTemplate>
 						<DataTemplate x:DataType="uibase:IGridEntry">
 							<Panel Opacity="{CompiledBinding Liberate.Opacity}" Background="{CompiledBinding Liberate.BackgroundBrush}">
@@ -172,14 +174,14 @@
 					x:DataType="uibase:IGridEntry"
 					Header="Product&#xA;Rating"
 					IsReadOnly="true"
-					Width="115"
+					MinWidth="10" Width="{Binding ProductRatingWidth, Mode=TwoWay}"
 					SortMemberPath="ProductRating" CanUserSort="True"
 					OpacityBinding="{CompiledBinding Liberate.Opacity}"
 					BackgroundBinding="{CompiledBinding Liberate.BackgroundBrush}"
 					ClipboardContentBinding="{CompiledBinding ProductRating}"
 					Binding="{CompiledBinding ProductRating}" />
 
-				<controls:DataGridTemplateColumnExt Width="90" Header="Purchase&#xA;Date" CanUserSort="True" SortMemberPath="PurchaseDate" ClipboardContentBinding="{Binding PurchaseDate}">
+				<controls:DataGridTemplateColumnExt Header="Purchase&#xA;Date" MinWidth="10" Width="{Binding PurchaseDateWidth, Mode=TwoWay}" CanUserSort="True" SortMemberPath="PurchaseDate" ClipboardContentBinding="{Binding PurchaseDate}">
 					<DataGridTemplateColumn.CellTemplate>
 						<DataTemplate x:DataType="uibase:IGridEntry">
 							<Panel Opacity="{CompiledBinding Liberate.Opacity}" Background="{CompiledBinding Liberate.BackgroundBrush}">
@@ -191,16 +193,16 @@
 
 				<controls:DataGridMyRatingColumn
 					x:DataType="uibase:IGridEntry"
-					Header="My Rating"					
+					Header="My Rating"
 					IsReadOnly="false"
-					Width="115"
+					MinWidth="10" Width="{Binding MyRatingWidth, Mode=TwoWay}"
 					SortMemberPath="MyRating" CanUserSort="True"
 					OpacityBinding="{CompiledBinding Liberate.Opacity}"
 					BackgroundBinding="{CompiledBinding Liberate.BackgroundBrush}"
 					ClipboardContentBinding="{CompiledBinding MyRating}"					
 					Binding="{CompiledBinding MyRating, Mode=TwoWay}" />
 
-				<controls:DataGridTemplateColumnExt Width="135" Header="Misc" CanUserSort="True" SortMemberPath="Misc" ClipboardContentBinding="{Binding Misc}">
+				<controls:DataGridTemplateColumnExt Header="Misc" MinWidth="10" Width="{Binding MiscWidth, Mode=TwoWay}" CanUserSort="True" SortMemberPath="Misc" ClipboardContentBinding="{Binding Misc}">
 					<DataGridTemplateColumn.CellTemplate>
 						<DataTemplate x:DataType="uibase:IGridEntry">
 							<Panel Opacity="{CompiledBinding Liberate.Opacity}" Background="{CompiledBinding Liberate.BackgroundBrush}">
@@ -210,7 +212,7 @@
 					</DataGridTemplateColumn.CellTemplate>
 				</controls:DataGridTemplateColumnExt>
 				
-				<controls:DataGridTemplateColumnExt Width="102" Header="Last&#xA;Download" CanUserSort="True" SortMemberPath="LastDownload" ClipboardContentBinding="{Binding LastDownload}">
+				<controls:DataGridTemplateColumnExt Header="Last&#xA;Download" MinWidth="10" Width="{Binding LastDownloadWidth, Mode=TwoWay}" CanUserSort="True" SortMemberPath="LastDownload" ClipboardContentBinding="{Binding LastDownload}">
 					<DataGridTemplateColumn.CellTemplate>
 						<DataTemplate x:DataType="uibase:IGridEntry">
 							<Panel Opacity="{CompiledBinding Liberate.Opacity}" Background="{CompiledBinding Liberate.BackgroundBrush}" ToolTip.Tip="{CompiledBinding LastDownload.ToolTipText}" DoubleTapped="Version_DoubleClick">
@@ -220,7 +222,7 @@
 					</DataGridTemplateColumn.CellTemplate>
 				</controls:DataGridTemplateColumnExt>
 
-				<controls:DataGridTemplateColumnExt CanUserSort="True" Width="100" Header="Tags" SortMemberPath="BookTags" ClipboardContentBinding="{Binding BookTags}">
+				<controls:DataGridTemplateColumnExt Header="Tags" MinWidth="10" Width="{Binding BookTagsWidth, Mode=TwoWay}" CanUserSort="True" SortMemberPath="BookTags" ClipboardContentBinding="{Binding BookTags}">
 					<DataGridTemplateColumn.CellTemplate>
 						<DataTemplate x:DataType="uibase:IGridEntry">
 							<Button

--- a/Source/LibationUiBase/GridView/GridContextMenu.cs
+++ b/Source/LibationUiBase/GridView/GridContextMenu.cs
@@ -1,0 +1,114 @@
+﻿using ApplicationServices;
+using DataLayer;
+using FileLiberator;
+using LibationFileManager;
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using System.Windows.Input;
+
+namespace LibationUiBase.GridView;
+
+public class GridContextMenu
+{
+	public string CopyCellText => $"{Accelerator}Copy Cell Contents";
+	public string LiberateEpisodesText => $"{Accelerator}Liberate All Episodes";
+	public string SetDownloadedText => $"Set Download status to '{Accelerator}Downloaded'";
+	public string SetNotDownloadedText => $"Set Download status to '{Accelerator}Not Downloaded'";
+	public string RemoveText => $"{Accelerator}Remove from library";
+	public string LocateFileText => $"{Accelerator}Locate file...";
+	public string LocateFileDialogTitle => $"Locate the audio file for '{GridEntry.Book.TitleWithSubtitle}'";
+	public string LocateFileErrorMessage => "Error saving book's location";
+	public string ConvertToMp3Text => $"{Accelerator}Convert to Mp3";
+	public string ReDownloadText => "Re-download this audiobook";
+	public string EditTemplatesText => "Edit Templates";
+	public string FolderTemplateText => "Folder Template";
+	public string FileTemplateText => "File Template";
+	public string MultipartTemplateText => "Multipart File Template";
+	public string ViewBookmarksText => "View _Bookmarks/Clips";
+	public string ViewSeriesText => GridEntry.Liberate.IsSeries ? "View All Episodes in Series" : "View All Books in Series";
+
+	public bool LiberateEpisodesEnabled => GridEntry is ISeriesEntry sEntry && sEntry.Children.Any(c => c.Liberate.BookStatus is LiberatedStatus.NotLiberated or LiberatedStatus.PartialDownload);
+	public bool SetDownloadedEnabled => GridEntry.Book.UserDefinedItem.BookStatus != LiberatedStatus.Liberated || GridEntry.Liberate.IsSeries;
+	public bool SetNotDownloadedEnabled => GridEntry.Book.UserDefinedItem.BookStatus != LiberatedStatus.NotLiberated || GridEntry.Liberate.IsSeries;
+	public bool ConvertToMp3Enabled => GridEntry.Book.UserDefinedItem.BookStatus is LiberatedStatus.Liberated;
+	public bool ReDownloadEnabled => GridEntry.Book.UserDefinedItem.BookStatus is LiberatedStatus.Liberated;
+
+	public IGridEntry GridEntry { get; }
+	public char Accelerator { get; }
+
+	public GridContextMenu(IGridEntry gridEntry, char accelerator)
+	{
+		GridEntry = gridEntry;
+		Accelerator = accelerator;
+	}
+
+	public void SetDownloaded()
+	{
+		if (GridEntry is ISeriesEntry series)
+		{
+			series.Children.Select(c => c.LibraryBook).UpdateBookStatus(LiberatedStatus.Liberated);
+		}
+		else
+		{
+			GridEntry.LibraryBook.UpdateBookStatus(LiberatedStatus.Liberated);
+		}
+	}
+
+	public void SetNotDownloaded()
+	{
+		if (GridEntry is ISeriesEntry series)
+		{
+			series.Children.Select(c => c.LibraryBook).UpdateBookStatus(LiberatedStatus.NotLiberated);
+		}
+		else
+		{
+			GridEntry.LibraryBook.UpdateBookStatus(LiberatedStatus.NotLiberated);
+		}
+	}
+
+	public async Task RemoveAsync()
+	{
+		if (GridEntry is ISeriesEntry series)
+		{
+			await series.Children.Select(c => c.LibraryBook).RemoveBooksAsync();
+		}
+		else
+		{
+			await Task.Run(GridEntry.LibraryBook.RemoveBook);
+		}
+	}
+
+	public ITemplateEditor CreateTemplateEditor<T>(LibraryBook libraryBook, string existingTemplate)
+			where T : Templates, ITemplate, new()
+	{
+		LibraryBookDto fileDto = libraryBook.ToDto(), folderDto = fileDto;
+
+		if (libraryBook.Book.IsEpisodeChild() &&
+			Configuration.Instance.SavePodcastsToParentFolder &&
+			libraryBook.Book.SeriesLink.SingleOrDefault() is SeriesBook series)
+		{
+			using var context = DbContexts.GetContext();
+			var seriesParent = context.GetLibraryBook_Flat_NoTracking(series.Series.AudibleSeriesId);
+			folderDto = seriesParent?.ToDto() ?? fileDto;
+		}
+
+		return TemplateEditor<T>.CreateFilenameEditor(Configuration.Instance.Books, existingTemplate, folderDto, fileDto);
+	}
+
+
+}
+class Command : ICommand
+{
+	public event EventHandler CanExecuteChanged;
+
+	public bool CanExecute(object parameter)
+	{
+		throw new NotImplementedException();
+	}
+
+	public void Execute(object parameter)
+	{
+		throw new NotImplementedException();
+	}
+}

--- a/Source/LoadByOS/LinuxConfigApp/libation_glass.svg
+++ b/Source/LoadByOS/LinuxConfigApp/libation_glass.svg
@@ -1,45 +1,39 @@
 <svg version="1.1" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 524 524" enable-background="new 0 0 524 524">
-
-    <defs>
-      <filter id="white-glow" x="-400%" y="-400%" width="800%" height="800%">
-          <feFlood result="flood" flood-color="#ffffff" flood-opacity="1"></feFlood>
-          <feComposite in="flood" result="mask" in2="SourceGraphic" operator="in"></feComposite>
-          <feMorphology in="mask" result="dilated" operator="dilate" radius="3"></feMorphology>
-          <feGaussianBlur in="dilated" result="blurred" stdDeviation="6"></feGaussianBlur>
-          <feMerge>
-              <feMergeNode in="blurred"></feMergeNode>
-              <feMergeNode in="SourceGraphic"></feMergeNode>
-          </feMerge>
-      </filter>
-    </defs>
-
-<rect x="-400%" y="-400%" width="800%" height="800%" fill="Black" />
-<path id="glass" fill-rule="evenodd" style="fill: #000; filter:url(#white-glow)" d=
-"M145,8
-	a 192,200 0 0 0 -36,82
-	a 222,334 41 0 0 138,236
-	v158
-	h-81
-	a 16,16 0 0 0 0,32
-	h192
-	a 16 16 0 0 0 0,-32
-	h-81
-	v-158
-	a 222,334 -41 0 0 138,-236
-	a 192,200 0 0 0 -36,-82
-	h-234
-m18,30
-	a 192,200 0 0 0 -26,95
-	a 187.5,334 35 0 0 125,159
-	a 187.5,334 -35 0 0 125,-159
-	a 192,200 0 0 0 -26,-95
-	h-198
-z" />
-
-<path id="wine-level" style="fill: #000; filter:url(#white-glow)" d=
-"M156,136
-	a 168,300 35 0 0 106,138
-	a 168,300 -35 0 0 106,-138
-z"/>
-
+	<defs>
+		<g id="glass">
+			<path fill-rule="evenodd" d=
+				"M262,8
+					h-117
+					a 192,200 0 0 0 -36,82
+					a 222,334 41 0 0 138,236
+					v158
+					h-81
+					a 16,16 0 0 0 0,32
+					h192
+					a 16 16 0 0 0 0,-32
+					h-81
+					v-158
+					a 222,334 -41 0 0 138,-236
+					a 192,200 0 0 0 -36,-82
+					h-117
+				m-99,30
+					a 192,200 0 0 0 -26,95
+					a 187.5,334 35 0 0 125,159
+					a 187.5,334 -35 0 0 125,-159
+					a 192,200 0 0 0 -26,-95
+					h-198
+				z"/>
+		</g>
+		<g id="wine-level">
+			<path d=
+				"M158,136
+					a 168,305 35 0 0 104,136
+					a 168,305 -35 0 0 104,-136
+				z"/>
+		</g>
+	</defs>	
+	<use href="#glass" stroke="#ffffffa0" stroke-width="16" fill="Transparent" />
+	<use href="#wine-level" stroke="#ffffffa0" stroke-width="16" fill="Transparent" />
+	<use href="#glass" fill="Black" />
+	<use href="#wine-level" fill="Black" />
 </svg>

--- a/Source/LoadByOS/LinuxConfigApp/libation_glass.svg
+++ b/Source/LoadByOS/LinuxConfigApp/libation_glass.svg
@@ -1,28 +1,45 @@
-<svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="256.0px" height="256.0px" viewBox="0 0 512 512" enable-background="new 0 0 512 512">
-<path id="glass" d=
-"M139,2
-	A 192,200 0 0 0 103,84
-	A 222,334 41 0 0 241,320
-	V478
-	H160
-	A 16,16 0 0 0 160,510
-	H352
-	A16 16 0 0 0 352,478
-	H271
-	V320
-	A 222,334 -41 0 0 409,84
-	A 192,200 0 0 0 373,2
-M355,32
-	A 192,200 0 0 1 381,127
-	A 187.5,334 -35 0 1 256,286
-	A 187.5,334 35 0 1 131,127
-	A 192,200 0 0 1 157,32
-	H355
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 524 524" enable-background="new 0 0 524 524">
+
+    <defs>
+      <filter id="white-glow" x="-400%" y="-400%" width="800%" height="800%">
+          <feFlood result="flood" flood-color="#ffffff" flood-opacity="1"></feFlood>
+          <feComposite in="flood" result="mask" in2="SourceGraphic" operator="in"></feComposite>
+          <feMorphology in="mask" result="dilated" operator="dilate" radius="3"></feMorphology>
+          <feGaussianBlur in="dilated" result="blurred" stdDeviation="6"></feGaussianBlur>
+          <feMerge>
+              <feMergeNode in="blurred"></feMergeNode>
+              <feMergeNode in="SourceGraphic"></feMergeNode>
+          </feMerge>
+      </filter>
+    </defs>
+
+<rect x="-400%" y="-400%" width="800%" height="800%" fill="Black" />
+<path id="glass" fill-rule="evenodd" style="fill: #000; filter:url(#white-glow)" d=
+"M145,8
+	a 192,200 0 0 0 -36,82
+	a 222,334 41 0 0 138,236
+	v158
+	h-81
+	a 16,16 0 0 0 0,32
+	h192
+	a 16 16 0 0 0 0,-32
+	h-81
+	v-158
+	a 222,334 -41 0 0 138,-236
+	a 192,200 0 0 0 -36,-82
+	h-234
+m18,30
+	a 192,200 0 0 0 -26,95
+	a 187.5,334 35 0 0 125,159
+	a 187.5,334 -35 0 0 125,-159
+	a 192,200 0 0 0 -26,-95
+	h-198
 z" />
 
-<path id="wine-level" d=
-"M146,128
-	A 168,300 35 0 0 256,270
-	A 168,300 -35 0 0 366,128
+<path id="wine-level" style="fill: #000; filter:url(#white-glow)" d=
+"M156,136
+	a 168,300 35 0 0 106,138
+	a 168,300 -35 0 0 106,-138
 z"/>
+
 </svg>


### PR DESCRIPTION
## [Add white glow to libation_glass.svg](https://github.com/rmcrackan/Libation/commit/ee00417c6ff54b3941633f359686f87d0eadeb7c) (#701) (Modified in [Change glass icon shading](https://github.com/rmcrackan/Libation/commit/167a021eb160b8b7d3e9f753813c515d7bf77eb0))

## [Brighter stoplight colors](https://github.com/rmcrackan/Libation/commit/4b2ce0c2d168bbaf9fd3e4683303319b8abb5d61) (#702)

## [Add custom column widths to chardonnay](https://github.com/rmcrackan/Libation/commit/97f94d8782ddd12dbf1b73f33e45970c416afec2)

Chardonnay users can now manually resize their grid columns. This only became possible in 11.0.1, and it's something I've wanted to do for a while. (I mean, OK, it technically _was_ possible before. But now it's possible without a ton of hacks)

## [Lazy load cover to improve startup time](https://github.com/rmcrackan/Libation/commit/893d68190dfb187d30ecde174d53868ff8c605e9)

If I could turn back time I would have just done this instead of parallelizing grid loading. Loading images into the GUI renderer is far and away the most costly part of creating the grid.

Also some slight refactoring.

## [Fix MessageBox crash when UI has no Screens](https://github.com/rmcrackan/Libation/commit/ff3ac2d6fd23291e940ccb7231814f074f34b6d5) (#708)

Not sure why that error is happening, but this should prevent a crash.

## [Add ability to preview templates on user's books](https://github.com/rmcrackan/Libation/commit/e65b6c76a8d27b4286c03d23e293f4d4b78fd6fa) (#700)

This is pretty cool. There's a new grid context menu item for editing templates using the clicked book as the preview.

## [Update audio duration on library scan](https://github.com/rmcrackan/Libation/commit/fb9b4eb77e9f34275569851ed86522c4368a0343) (#707)