### PR TITLE
Allow Non-Windows installations to populate Windows folder artwork

### DIFF
--- a/Source/LibationFileManager/WindowsDirectory.cs
+++ b/Source/LibationFileManager/WindowsDirectory.cs
@@ -15,7 +15,7 @@ namespace LibationFileManager
             try
             {
                 //Currently only works for Windows and macOS
-                if (!Configuration.Instance.UseCoverAsFolderIcon || Configuration.IsLinux)
+                if (!Configuration.Instance.UseCoverAsFolderIcon)
                     return;
 
                 // get path of cover art in Images dir. Download first if not exists


### PR DESCRIPTION
Proposed fix to https://github.com/rmcrackan/Libation/issues/977