### PR TITLE
Exclude docker build report artifact from release packing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,6 +43,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           path: artifacts
+          pattern: "*(Classic-)Libation.*"
 
       - name: Release
         id: release


### PR DESCRIPTION
When I redid the docker build process, it added a new artifact to the workflow that contains a report on the docker image that was built. This was causing an error when the release process was trying to download all of the artifacts for the release. This PR adds a pattern to include only the artifacts that should get included in the release.

You can see a successful run of the fixed workflow at https://github.com/pixil98/Libation/actions/runs/11846675142