### PR TITLE
set maxdepth to prevent traversal into subdirectories

### DIFF
--- a/Docker/liberate.sh
+++ b/Docker/liberate.sh
@@ -80,7 +80,7 @@ setup_db() {
   # Figure out the right databse file
   if [[ -z "${LIBATION_DB_FILE}" ]];
   then
-    dbCount=$(find "${DBPATH}" -type f -name "${dbpattern}" | wc -l)
+    dbCount=$(find "${DBPATH}" -maxdepth 1 -type f -name "${dbpattern}" | wc -l)
     if [ "${dbCount}" -gt 1 ];
     then
       error "too many database files found, set LIBATION_DB_FILE to the filename you wish to use"


### PR DESCRIPTION
This restricts the `find` command to the `DBPATH` and prevents it from traversing into subdirectories when checking for multiple *.db files. I just encountered this issue because I copy my DB and settings files to a `bak` directory before making any changes and found that in the most recent pull of the container, it wouldn't start up anymore.

```
.
├── AccountsSettings.json
├── bak
│   ├── AccountsSettings.json
│   ├── Settings.json
│   └── LibationContext.db
├── FileLocations.json
├── LibationContext.db
├── SearchEngine
│   ├── _7y6.cfs
│   ├── segments_7w5
│   └── segments.gen
└── Settings.json
```