### PR TITLE
Fix chardonnay window closing (#1065)

### DIFF
--- a/Source/LibationAvalonia/LibationAvalonia.csproj
+++ b/Source/LibationAvalonia/LibationAvalonia.csproj
@@ -74,13 +74,13 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Avalonia.Diagnostics" Version="11.2.1" Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'" />
-		<PackageReference Include="Avalonia" Version="11.2.1" />
-		<PackageReference Include="Avalonia.Controls.DataGrid" Version="11.2.1" />
+		<PackageReference Include="Avalonia.Diagnostics" Version="11.2.2" Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'" />
+		<PackageReference Include="Avalonia" Version="11.2.2" />
+		<PackageReference Include="Avalonia.Controls.DataGrid" Version="11.2.2" />
 		<PackageReference Include="Avalonia.Controls.ItemsRepeater" Version="11.1.5" />
-		<PackageReference Include="Avalonia.Desktop" Version="11.2.1" />
-		<PackageReference Include="Avalonia.ReactiveUI" Version="11.2.1" />
-		<PackageReference Include="Avalonia.Themes.Fluent" Version="11.2.1" />
+		<PackageReference Include="Avalonia.Desktop" Version="11.2.2" />
+		<PackageReference Include="Avalonia.ReactiveUI" Version="11.2.2" />
+		<PackageReference Include="Avalonia.Themes.Fluent" Version="11.2.2" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/Source/LibationAvalonia/Program.cs
+++ b/Source/LibationAvalonia/Program.cs
@@ -46,11 +46,6 @@ namespace LibationAvalonia
 			try
 			{
 				var config = LibationScaffolding.RunPreConfigMigrations();
-
-				//Start as much work in parallel as possible.
-				var classicLifetimeTask = Task.Run(() => new ClassicDesktopStyleApplicationLifetime());
-				var appBuilderTask = Task.Run(BuildAvaloniaApp);
-
 				if (config.LibationSettingsAreValid)
 				{
 					// most migrations go in here
@@ -62,9 +57,7 @@ namespace LibationAvalonia
 					App.LibraryTask = Task.Run(() => DbContexts.GetLibrary_Flat_NoTracking(includeParents: true));
 				}
 
-				appBuilderTask.GetAwaiter().GetResult().SetupWithLifetime(classicLifetimeTask.GetAwaiter().GetResult());
-
-				classicLifetimeTask.Result.Start(null);
+				BuildAvaloniaApp().StartWithClassicDesktopLifetime(null);
 			}
 			catch (Exception ex)
 			{


### PR DESCRIPTION
This was a nasty little bug to track down!
Between versions 11.0.5 and 11.2.1, Avalonia changed how the classic desktop lifetime worked.
Long story short, I removed some of the parallelism (did testing and found it was only saving a few tens of milliseconds) and used Avalonia's built-in `StartWithClassicDesktopLifetime` method.