### PR TITLE
Fixed stack overflow crash when movifying large databases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,13 +51,8 @@ jobs:
         with:
           name: Libation ${{ needs.prerelease.outputs.version }}
           body: <Put a body here>
+          token: ${{ secrets.GITHUB_TOKEN }}
           draft: true
           prerelease: false
-
-      - name: Upload release assets
-        uses: dwenegar/upload-release-assets@v2
-        env:
-          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
-        with:
-          release_id: "${{ steps.release.outputs.id }}"
-          assets_path: ./artifacts
+          files: |
+            artifacts/*/*

--- a/Source/AppScaffolding/LibationScaffolding.cs
+++ b/Source/AppScaffolding/LibationScaffolding.cs
@@ -279,8 +279,11 @@ namespace AppScaffolding
 
         private static void wireUpSystemEvents(Configuration configuration)
 		{
-			LibraryCommands.LibrarySizeChanged += (_, __) => SearchEngineCommands.FullReIndex();
-			LibraryCommands.BookUserDefinedItemCommitted += (_, books) => SearchEngineCommands.UpdateBooks(books);
+			LibraryCommands.LibrarySizeChanged += (object _, List<DataLayer.LibraryBook> libraryBooks)
+				=> SearchEngineCommands.FullReIndex(libraryBooks);
+
+			LibraryCommands.BookUserDefinedItemCommitted += (_, books)
+				=> SearchEngineCommands.UpdateBooks(books);
 		}
 
 		public static UpgradeProperties GetLatestRelease()

--- a/Source/ApplicationServices/LibraryCommands.cs
+++ b/Source/ApplicationServices/LibraryCommands.cs
@@ -222,7 +222,7 @@ namespace ApplicationServices
             {
                 int qtyChanged = await Task.Run(() => SaveContext(context));
                 if (qtyChanged > 0)
-                    await Task.Run(finalizeLibrarySizeChange);
+                    await Task.Run(() => finalizeLibrarySizeChange(context));
                 return qtyChanged;
             }
             catch (Exception ex)
@@ -329,7 +329,7 @@ namespace ApplicationServices
 
             // this is any changes at all to the database, not just new books
             if (qtyChanges > 0)
-                await Task.Run(() => finalizeLibrarySizeChange());
+                await Task.Run(() => finalizeLibrarySizeChange(context));
             logTime("importIntoDbAsync -- post finalizeLibrarySizeChange");
 
             return newCount;
@@ -378,7 +378,7 @@ namespace ApplicationServices
 
                 var qtyChanges = context.SaveChanges();
                 if (qtyChanges > 0)
-                    finalizeLibrarySizeChange();
+                    finalizeLibrarySizeChange(context);
 
                 return qtyChanges;
             }
@@ -407,7 +407,7 @@ namespace ApplicationServices
 
                 var qtyChanges = context.SaveChanges();
                 if (qtyChanges > 0)
-                    finalizeLibrarySizeChange();
+                    finalizeLibrarySizeChange(context);
 
                 return qtyChanges;
             }
@@ -432,7 +432,7 @@ namespace ApplicationServices
 
                 var qtyChanges = context.SaveChanges();
 				if (qtyChanges > 0)
-					finalizeLibrarySizeChange();
+					finalizeLibrarySizeChange(context);
 
 				return qtyChanges;
             }
@@ -445,9 +445,9 @@ namespace ApplicationServices
         #endregion
 
         // call this whenever books are added or removed from library
-        private static void finalizeLibrarySizeChange()
+        private static void finalizeLibrarySizeChange(LibationContext context)
         {
-            var library = DbContexts.GetLibrary_Flat_NoTracking(includeParents: true);
+            var library = context.GetLibrary_Flat_NoTracking(includeParents: true);
             LibrarySizeChanged?.Invoke(null, library);
         }
 

--- a/Source/ApplicationServices/SearchEngineCommands.cs
+++ b/Source/ApplicationServices/SearchEngineCommands.cs
@@ -48,6 +48,8 @@ namespace ApplicationServices
 		}
 
 		public static void FullReIndex() => performSafeCommand(fullReIndex);
+		public static void FullReIndex(List<LibraryBook> libraryBooks)
+			=> performSafeCommand(se => fullReIndex(se, libraryBooks.WithoutParents()));
 
 		internal static void UpdateUserDefinedItems(LibraryBook book) => performSafeCommand(e =>
 			{
@@ -94,8 +96,11 @@ namespace ApplicationServices
 		private static void fullReIndex(SearchEngine engine)
 		{
 			var library = DbContexts.GetLibrary_Flat_NoTracking();
-			engine.CreateNewIndex(library);
+			fullReIndex(engine, library);
 		}
+
+		private static void fullReIndex(SearchEngine engine, IEnumerable<LibraryBook> libraryBooks)
+		=> engine.CreateNewIndex(libraryBooks);
 		#endregion
 	}
 }

--- a/Source/DataLayer/LibationContextFactory.cs
+++ b/Source/DataLayer/LibationContextFactory.cs
@@ -6,6 +6,7 @@ namespace DataLayer
     public class LibationContextFactory : DesignTimeDbContextFactoryBase<LibationContext>
     {
         protected override LibationContext CreateNewInstance(DbContextOptions<LibationContext> options) => new LibationContext(options);
-        protected override void UseDatabaseEngine(DbContextOptionsBuilder optionsBuilder, string connectionString) => optionsBuilder.UseSqlite(connectionString);
+        protected override void UseDatabaseEngine(DbContextOptionsBuilder optionsBuilder, string connectionString)
+            => optionsBuilder.UseSqlite(connectionString, ob => ob.UseQuerySplittingBehavior(QuerySplittingBehavior.SplitQuery));
     }
 }

--- a/Source/DataLayer/QueryObjects/BookQueries.cs
+++ b/Source/DataLayer/QueryObjects/BookQueries.cs
@@ -44,7 +44,11 @@ namespace DataLayer
 
         public static bool IsEpisodeParent(this Book book)
             => book.ContentType is ContentType.Parent;
-        public static bool HasLiberated(this Book book)
+
+        public static IEnumerable<LibraryBook> WithoutParents(this IEnumerable<LibraryBook> libraryBooks)
+            => libraryBooks.Where(lb => !lb.Book.IsEpisodeParent());
+
+		public static bool HasLiberated(this Book book)
             => book.UserDefinedItem.BookStatus is LiberatedStatus.Liberated ||
             book.UserDefinedItem.PdfStatus is not null and LiberatedStatus.Liberated;
     }

--- a/Source/DataLayer/QueryObjects/LibraryBookQueries.cs
+++ b/Source/DataLayer/QueryObjects/LibraryBookQueries.cs
@@ -21,8 +21,8 @@ namespace DataLayer
                 .AsNoTrackingWithIdentityResolution()
                 .GetLibrary()
                 .AsEnumerable()
-                .Where(lb => !lb.Book.IsEpisodeParent() || includeParents)
-                .ToList();
+				.Where(c => !c.Book.IsEpisodeParent() || includeParents)
+				.ToList();
 
         public static LibraryBook GetLibraryBook_Flat_NoTracking(this LibationContext context, string productId)
             => context
@@ -91,7 +91,7 @@ namespace DataLayer
         }
 #nullable disable
 
-        public static IEnumerable<LibraryBook> FindChildren(this IEnumerable<LibraryBook> bookList, LibraryBook parent)
+        public static List<LibraryBook> FindChildren(this IEnumerable<LibraryBook> bookList, LibraryBook parent)
             => bookList
             .Where(
                 lb => 

--- a/Source/LibationAvalonia/App.axaml.cs
+++ b/Source/LibationAvalonia/App.axaml.cs
@@ -1,8 +1,6 @@
 ﻿using ApplicationServices;
 using Avalonia;
-using Avalonia.Controls;
 using Avalonia.Controls.ApplicationLifetimes;
-using Avalonia.Input;
 using Avalonia.Markup.Xaml;
 using Avalonia.Media;
 using Avalonia.Platform;
@@ -14,14 +12,13 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Threading.Tasks;
-using ReactiveUI;
-using DataLayer;
+using Avalonia.Threading;
 
 namespace LibationAvalonia
 {
 	public class App : Application
 	{
-		public static Window MainWindow { get; private set; }
+		public static MainWindow MainWindow { get; private set; }
 		public static IBrush ProcessQueueBookFailedBrush { get; private set; }
 		public static IBrush ProcessQueueBookCompletedBrush { get; private set; }
 		public static IBrush ProcessQueueBookCancelledBrush { get; private set; }
@@ -216,9 +213,15 @@ namespace LibationAvalonia
 			LoadStyles();
 			var mainWindow = new MainWindow();
 			desktop.MainWindow = MainWindow = mainWindow;
-			mainWindow.OnLibraryLoaded(LibraryTask.GetAwaiter().GetResult());
+			mainWindow.Loaded += MainWindow_Loaded;
 			mainWindow.RestoreSizeAndLocation(Configuration.Instance);
 			mainWindow.Show();
+		}
+
+		private static async void MainWindow_Loaded(object sender, Avalonia.Interactivity.RoutedEventArgs e)
+		{
+			var library = await LibraryTask;
+			await Dispatcher.UIThread.InvokeAsync(() => MainWindow.OnLibraryLoadedAsync(library));
 		}
 
 		private static void LoadStyles()

--- a/Source/LibationAvalonia/ViewModels/MainVM.cs
+++ b/Source/LibationAvalonia/ViewModels/MainVM.cs
@@ -20,7 +20,7 @@ namespace LibationAvalonia.ViewModels
 			MainWindow = mainWindow;
 
 			ProductsDisplay.RemovableCountChanged += (_, removeCount) => RemoveBooksButtonText = removeCount == 1 ? "Remove 1 Book from Libation" : $"Remove {removeCount} Books from Libation";
-			LibraryCommands.LibrarySizeChanged += async (_, _) => await ProductsDisplay.UpdateGridAsync(DbContexts.GetLibrary_Flat_NoTracking(includeParents: true));
+			LibraryCommands.LibrarySizeChanged += LibraryCommands_LibrarySizeChanged;
 
 			Configure_NonUI();
 			Configure_BackupCounts();
@@ -32,6 +32,12 @@ namespace LibationAvalonia.ViewModels
 			Configure_ScanAuto();
 			Configure_Settings();
 			Configure_VisibleBooks();
+		}
+
+		private async void LibraryCommands_LibrarySizeChanged(object sender, System.EventArgs e)
+		{
+			var fullLibrary = await System.Threading.Tasks.Task.Run(() => DbContexts.GetLibrary_Flat_NoTracking(includeParents: true));
+			await ProductsDisplay.UpdateGridAsync(fullLibrary);
 		}
 
 		private static string menufyText(string header) => Configuration.IsMacOs ? header : $"_{header}";

--- a/Source/LibationAvalonia/ViewModels/MainVM.cs
+++ b/Source/LibationAvalonia/ViewModels/MainVM.cs
@@ -1,7 +1,9 @@
 ﻿using ApplicationServices;
+using DataLayer;
 using LibationAvalonia.Views;
 using LibationFileManager;
 using ReactiveUI;
+using System.Collections.Generic;
 
 namespace LibationAvalonia.ViewModels
 {
@@ -34,9 +36,8 @@ namespace LibationAvalonia.ViewModels
 			Configure_VisibleBooks();
 		}
 
-		private async void LibraryCommands_LibrarySizeChanged(object sender, System.EventArgs e)
+		private async void LibraryCommands_LibrarySizeChanged(object sender, List<LibraryBook> fullLibrary)
 		{
-			var fullLibrary = await System.Threading.Tasks.Task.Run(() => DbContexts.GetLibrary_Flat_NoTracking(includeParents: true));
 			await ProductsDisplay.UpdateGridAsync(fullLibrary);
 		}
 

--- a/Source/LibationAvalonia/ViewModels/ProductsDisplayViewModel.cs
+++ b/Source/LibationAvalonia/ViewModels/ProductsDisplayViewModel.cs
@@ -28,7 +28,13 @@ namespace LibationAvalonia.ViewModels
 		/// <summary>Grid entries included in the filter set. If null, all grid entries are shown</summary>
 		private HashSet<IGridEntry> FilteredInGridEntries;
 		public string FilterString { get; private set; }
-		public DataGridCollectionView GridEntries { get; private set; }
+
+		private DataGridCollectionView _gridEntries;
+		public DataGridCollectionView GridEntries
+		{
+			get => _gridEntries;
+			private set => this.RaiseAndSetIfChanged(ref _gridEntries, value);
+		}
 
 		private bool _removeColumnVisible;
 		public bool RemoveColumnVisible { get => _removeColumnVisible; private set => this.RaiseAndSetIfChanged(ref _removeColumnVisible, value); }

--- a/Source/LibationAvalonia/Views/MainWindow.axaml.cs
+++ b/Source/LibationAvalonia/Views/MainWindow.axaml.cs
@@ -13,7 +13,6 @@ namespace LibationAvalonia.Views
 {
 	public partial class MainWindow : ReactiveWindow<MainVM>
 	{
-		public event EventHandler<List<LibraryBook>> LibraryLoaded;
 		public MainWindow()
 		{
 			DataContext = new MainVM(this);
@@ -66,6 +65,7 @@ namespace LibationAvalonia.Views
 			if (QuickFilters.UseDefault)
 				await ViewModel.PerformFilter(QuickFilters.Filters.FirstOrDefault());
 
+			await ViewModel.SetBackupCountsAsync(initialLibrary);
 			await ViewModel.ProductsDisplay.BindToGridAsync(initialLibrary);
 		}
 

--- a/Source/LibationAvalonia/Views/MainWindow.axaml.cs
+++ b/Source/LibationAvalonia/Views/MainWindow.axaml.cs
@@ -23,7 +23,6 @@ namespace LibationAvalonia.Views
 
 			Opened += MainWindow_Opened;
 			Closing += MainWindow_Closing;
-			LibraryLoaded += MainWindow_LibraryLoaded;
 
 			KeyBindings.Add(new KeyBinding { Command = ReactiveCommand.Create(selectAndFocusSearchBox), Gesture = new KeyGesture(Key.F, Configuration.IsMacOs ? KeyModifiers.Meta : KeyModifiers.Control) });
 
@@ -56,21 +55,20 @@ namespace LibationAvalonia.Views
 			this.SaveSizeAndLocation(Configuration.Instance);
 		}
 
-		private async void MainWindow_LibraryLoaded(object sender, List<LibraryBook> dbBooks)
-		{
-			if (QuickFilters.UseDefault)
-				await ViewModel.PerformFilter(QuickFilters.Filters.FirstOrDefault());
-
-			await ViewModel.ProductsDisplay.BindToGridAsync(dbBooks);
-		}
-
 		private void selectAndFocusSearchBox()
 		{
 			filterSearchTb.SelectAll();
 			filterSearchTb.Focus();
 		}
 
-		public void OnLibraryLoaded(List<LibraryBook> initialLibrary) => LibraryLoaded?.Invoke(this, initialLibrary);
+		public async System.Threading.Tasks.Task OnLibraryLoadedAsync(List<LibraryBook> initialLibrary)
+		{
+			if (QuickFilters.UseDefault)
+				await ViewModel.PerformFilter(QuickFilters.Filters.FirstOrDefault());
+
+			await ViewModel.ProductsDisplay.BindToGridAsync(initialLibrary);
+		}
+
 		public void ProductsDisplay_LiberateClicked(object _, LibraryBook libraryBook) => ViewModel.LiberateClicked(libraryBook);
 		public void ProductsDisplay_LiberateSeriesClicked(object _, ISeriesEntry series) => ViewModel.LiberateSeriesClicked(series);
 		public void ProductsDisplay_ConvertToMp3Clicked(object _, LibraryBook libraryBook) => ViewModel.ConvertToMp3Clicked(libraryBook);

--- a/Source/LibationUiBase/GridView/LibraryBookEntry[TStatus].cs
+++ b/Source/LibationUiBase/GridView/LibraryBookEntry[TStatus].cs
@@ -40,30 +40,17 @@ namespace LibationUiBase.GridView
 
 			int parallelism = int.Max(1, Environment.ProcessorCount - 1);
 
-			(int numPer, int rem) = int.DivRem(products.Length, parallelism);
-			if (rem != 0) numPer++;
+			(int batchSize, int rem) = int.DivRem(products.Length, parallelism);
+			if (rem != 0) batchSize++;
 
-			var tasks = new Task<IGridEntry[]>[parallelism];
 			var syncContext = SynchronizationContext.Current;
 
-			for (int i = 0; i < parallelism; i++)
+			//Asynchronously create an ILibraryBookEntry for every book in the library
+			var tasks = products.Chunk(batchSize).Select(batch => Task.Run(() =>
 			{
-				int start = i * numPer;
-				tasks[i] = Task.Run(() =>
-				{
-					SynchronizationContext.SetSynchronizationContext(syncContext);
-
-					int length = int.Min(numPer, products.Length - start);
-					if (length < 1) return Array.Empty<IGridEntry>();
-
-					var result = new IGridEntry[length];
-
-					for (int j = 0; j < length; j++)
-						result[j] = new LibraryBookEntry<TStatus>(products[start + j]);
-
-					return result;
-				});
-			}
+				SynchronizationContext.SetSynchronizationContext(syncContext);
+				return batch.Select(lb => new LibraryBookEntry<TStatus>(lb) as IGridEntry);
+			}));
 
 			return (await Task.WhenAll(tasks)).SelectMany(a => a).ToList();
 		}

--- a/Source/LibationUiBase/GridView/LibraryBookEntry[TStatus].cs
+++ b/Source/LibationUiBase/GridView/LibraryBookEntry[TStatus].cs
@@ -33,10 +33,11 @@ namespace LibationUiBase.GridView
 			LoadCover();
 		}
 
-
 		public static async Task<List<IGridEntry>> GetAllProductsAsync(IEnumerable<LibraryBook> libraryBooks)
 		{
 			var products = libraryBooks.Where(lb => lb.Book.IsProduct()).ToArray();
+			if (products.Length == 0)
+				return [];
 
 			int parallelism = int.Max(1, Environment.ProcessorCount - 1);
 

--- a/Source/LibationWinForms/Form1.BackupCounts.cs
+++ b/Source/LibationWinForms/Form1.BackupCounts.cs
@@ -17,7 +17,9 @@ namespace LibationWinForms
 			beginPdfBackupsToolStripMenuItem.Format(0);
 
             LibraryCommands.LibrarySizeChanged += setBackupCounts;
-            LibraryCommands.BookUserDefinedItemCommitted += setBackupCounts;
+			//Pass null to the runner to get the whole library.
+			LibraryCommands.BookUserDefinedItemCommitted += (_, _)
+				=> setBackupCounts(null, null);
 
 			updateCountsBw.DoWork += UpdateCountsBw_DoWork;
 			updateCountsBw.RunWorkerCompleted += exportMenuEnable;
@@ -28,12 +30,12 @@ namespace LibationWinForms
 
 		private bool runBackupCountsAgain;
 
-		private void setBackupCounts(object _, object __)
+		private void setBackupCounts(object _, List<LibraryBook> libraryBooks)
 		{
 			runBackupCountsAgain = true;
 
 			if (!updateCountsBw.IsBusy)
-				updateCountsBw.RunWorkerAsync();
+				updateCountsBw.RunWorkerAsync(libraryBooks);
 		}
 
 		private void UpdateCountsBw_DoWork(object sender, System.ComponentModel.DoWorkEventArgs e)
@@ -41,11 +43,7 @@ namespace LibationWinForms
 			while (runBackupCountsAgain)
 			{
 				runBackupCountsAgain = false;
-
-				if (e.Argument is not IEnumerable<LibraryBook> lbs)
-					lbs = DbContexts.GetLibrary_Flat_NoTracking();
-
-				e.Result = LibraryCommands.GetCounts(lbs);
+				e.Result = LibraryCommands.GetCounts(e.Argument as IEnumerable<LibraryBook>);
 			}
 		}
 

--- a/Source/LibationWinForms/Form1.cs
+++ b/Source/LibationWinForms/Form1.cs
@@ -52,7 +52,8 @@ namespace LibationWinForms
 
 			// Configure_Grid(); // since it's just this, can keep here. If it needs more, then give grid it's own 'partial class Form1'
 			{
-				LibraryCommands.LibrarySizeChanged += (_, __) => Invoke(() => productsDisplay.DisplayAsync());
+				LibraryCommands.LibrarySizeChanged += (object _, List<LibraryBook> fullLibrary)
+					=> Invoke(() => productsDisplay.DisplayAsync(fullLibrary));
 			}
 			Shown += Form1_Shown;
 		}
@@ -75,7 +76,7 @@ namespace LibationWinForms
 		public async Task InitLibraryAsync(List<LibraryBook> libraryBooks)
 		{
 			runBackupCountsAgain = true;
-			updateCountsBw.RunWorkerAsync(libraryBooks.Where(b => !b.Book.IsEpisodeParent()));
+			updateCountsBw.RunWorkerAsync(libraryBooks);
 			await productsDisplay.DisplayAsync(libraryBooks);
 		}
 


### PR DESCRIPTION
This is mostly to address #1158

The [DbContext.Attach](https://learn.microsoft.com/en-us/dotnet/api/microsoft.entityframeworkcore.dbcontext.attach?view=efcore-9.0#microsoft-entityframeworkcore-dbcontext-attach-1(-0)) recursively traverses the database looking for referenced entities that are not being tracked, and starts tracking them. The recurrsion will cause a stack overflow with large DBs. 

The solution is to use [DbContext.Entry](https://learn.microsoft.com/en-us/dotnet/api/microsoft.entityframeworkcore.dbcontext.entry?view=efcore-9.0) and then manually [Reference](https://learn.microsoft.com/en-us/dotnet/api/microsoft.entityframeworkcore.changetracking.entityentry-1.reference?view=efcore-9.0) related properties.

Also, I was looking through some of my other code, winged (as one does looking at something one wrote year(s) ago), and refactored it.

EDIT* I also edited the release.yml workflow to remove the [dwenegar/upload-release-assets](https://github.com/dwenegar/upload-release-assets) package because it's redundant with softprops/action-gh-release@v2. I could have sworn it was out of support (because I just did had to do something similar this week for one of my projects), but it now it looks like it is supported. Oh well, it's still redundant.