### PR TITLE
Thread safety and AccountSettings.json error handling

### DIFF
--- a/Source/AudibleUtilities/AudibleApiStorage.cs
+++ b/Source/AudibleUtilities/AudibleApiStorage.cs
@@ -5,19 +5,58 @@ using Newtonsoft.Json;
 
 namespace AudibleUtilities
 {
+	public class AccountSettingsLoadErrorEventArgs : ErrorEventArgs
+	{
+		/// <summary>
+		/// Create a new, empty <see cref="AccountsSettings"/> file if true, otherwise throw
+		/// </summary>
+		public bool Handled { get; set; }
+		/// <summary>
+		/// The file path of the AccountsSettings.json file
+		/// </summary>
+		public string SettingsFilePath { get; }
+
+		public AccountSettingsLoadErrorEventArgs(string path, Exception exception)
+			: base(exception)
+		{
+			SettingsFilePath = path;
+		}
+	}
+
 	public static class AudibleApiStorage
 	{
 		public static string AccountsSettingsFile => Path.Combine(Configuration.Instance.LibationFiles, "AccountsSettings.json");
+
+		public static event EventHandler<AccountSettingsLoadErrorEventArgs> LoadError;
 
 		public static void EnsureAccountsSettingsFileExists()
 		{
 			// saves. BEWARE: this will overwrite an existing file
 			if (!File.Exists(AccountsSettingsFile))
-				_ = new AccountsSettingsPersister(new AccountsSettings(), AccountsSettingsFile);
+			{
+				//Save the JSON file manually so that AccountsSettingsPersister.Saving and AccountsSettingsPersister.Saved
+				//are not fired. There's no need to fire those events on an empty AccountsSettings file.
+				var accountSerializerSettings = AudibleApi.Authorization.Identity.GetJsonSerializerSettings();
+				File.WriteAllText(AccountsSettingsFile, JsonConvert.SerializeObject(new AccountsSettings(), Formatting.Indented, accountSerializerSettings));
+			}
 		}
 
 		/// <summary>If you use this, be a good citizen and DISPOSE of it</summary>
-		public static AccountsSettingsPersister GetAccountsSettingsPersister() => new AccountsSettingsPersister(AccountsSettingsFile);
+		public static AccountsSettingsPersister GetAccountsSettingsPersister()
+		{
+			try
+			{
+				return new AccountsSettingsPersister(AccountsSettingsFile);
+			}
+			catch (Exception ex)
+			{
+				var args = new AccountSettingsLoadErrorEventArgs(AccountsSettingsFile, ex);
+				LoadError?.Invoke(null, args);
+				if (args.Handled)
+					return GetAccountsSettingsPersister();
+				throw;
+			}
+		}
 
 		public static string GetIdentityTokensJsonPath(this Account account)
 			=> GetIdentityTokensJsonPath(account.AccountId, account.Locale?.Name);

--- a/Source/FileManager/FileUtility.cs
+++ b/Source/FileManager/FileUtility.cs
@@ -157,7 +157,7 @@ namespace FileManager
 		/// <param name="extension">File extension override to use for <paramref name="destination"/></param>
 		/// <param name="overwrite">If <c>false</c> and <paramref name="destination"/> exists, append " (n)" to filename and try again.</param>
 		/// <returns>The actual destination filename</returns>
-		public static string SaferMoveToValidPath(
+		public static LongPath SaferMoveToValidPath(
 			LongPath source,
 			LongPath destination,
 			ReplacementCharacters replacements,

--- a/Source/LibationAvalonia/App.axaml
+++ b/Source/LibationAvalonia/App.axaml
@@ -97,10 +97,13 @@
 				</Setter>
 			</Style>
 			<Style Selector="^[UseCustomTitleBar=true]">
+				<Style Selector="^[CanResize=false] Border#DialogWindowFormBorder">
+					<Setter Property="BorderThickness" Value="2" />
+				</Style>
 				<Setter Property="SystemDecorations" Value="BorderOnly"/>
 				<Setter Property="Template">
 					<ControlTemplate>
-						<Panel Background="{DynamicResource SystemControlBackgroundAltHighBrush}">
+						<Border Name="DialogWindowFormBorder" BorderBrush="{DynamicResource SystemBaseMediumLowColor}" Background="{DynamicResource SystemControlBackgroundAltHighBrush}">
 							<Grid RowDefinitions="30,*">
 								<Border Name="DialogWindowTitleBorder" Margin="5,0" Background="{DynamicResource SystemAltMediumColor}">
 									<Border.Styles>
@@ -134,7 +137,7 @@
 								<Path Stroke="{DynamicResource SystemBaseMediumLowColor}" StrokeThickness="1" VerticalAlignment="Bottom" Stretch="Fill" Data="M0,0 L1,0" />
 								<ContentPresenter Grid.Row="1" Content="{TemplateBinding Content}" />
 							</Grid>
-						</Panel>
+						</Border>
 					</ControlTemplate>
 				</Setter>
 			</Style>

--- a/Source/LibationUiBase/GridView/LibraryBookEntry[TStatus].cs
+++ b/Source/LibationUiBase/GridView/LibraryBookEntry[TStatus].cs
@@ -33,6 +33,10 @@ namespace LibationUiBase.GridView
 			LoadCover();
 		}
 
+		/// <summary>
+		/// Creates <see cref="LibraryBookEntry{TStatus}"/> for all non-episode books in an enumeration of <see cref="LibraryBook"/>.
+		/// </summary>
+		/// <remarks>Can be called from any thread, but requires the calling thread's <see cref="SynchronizationContext.Current"/> to be valid.</remarks>
 		public static async Task<List<IGridEntry>> GetAllProductsAsync(IEnumerable<LibraryBook> libraryBooks)
 		{
 			var products = libraryBooks.Where(lb => lb.Book.IsProduct()).ToArray();

--- a/Source/LibationUiBase/GridView/SeriesEntry[TStatus].cs
+++ b/Source/LibationUiBase/GridView/SeriesEntry[TStatus].cs
@@ -56,6 +56,10 @@ namespace LibationUiBase.GridView
 			LoadCover();
 		}
 
+		/// <summary>
+		/// Creates <see cref="SeriesEntry{TStatus}"/> for all episodic series in an enumeration of <see cref="LibraryBook"/>.
+		/// </summary>
+		/// <remarks>Can be called from any thread, but requires the calling thread's <see cref="SynchronizationContext.Current"/> to be valid.</remarks>
 		public static async Task<List<ISeriesEntry>> GetAllSeriesEntriesAsync(IEnumerable<LibraryBook> libraryBooks)
 		{
 			var seriesBooks = libraryBooks.Where(lb => lb.Book.IsEpisodeParent()).ToArray();


### PR DESCRIPTION
[Add thread safety and comments re threading](https://github.com/rmcrackan/Libation/pull/1172/commits/b36e110b495789626de7b4059cdcb8a1b6cff179)

This is about addressing the threading issue introduced in 12.0.1. In 12.0.2 I added a bunch of UI thread invocations in a shotgun approach because I didn't understand exactly where the error was coming from. Since then, I did a deep dive and figured out exactly where the cross-threading operations were happening. I couldn't reproduce them organically (i.e. by just running Libation), but I could trigger the errors by executing a `Task.Run()` which always executes on a new thread. I was able to find exactly which parts need to be executed on the UI thread and added lots of comments so I hopefully never screw this up again.

[Handle and notify users of invalid account settings file](https://github.com/rmcrackan/Libation/pull/1172/commits/ac036f65f1283cb5c6d533fc339e8eb17e046443)

I added an error handling function which gets triggered if the account settings fail to load. If triggered, Libation will try to back y the accountsettings.json file, create a new, empty file, notify the user of the issue, and continue loading. If Libation is unable to backup the problem accountsettings.json file and create a new one, it notifies the user and throws.

[Add a border around dialogs with CanResize=true](https://github.com/rmcrackan/Libation/pull/1172/commits/981a183992bd8c5465c19ee0886ab14b7c28f7c4)

This is a UI tweak. Dialog windows which are fixed size had no border.