### PR TITLE
Add multiselect feature and a bugfix

### DIFF
--- a/Source/LibationAvalonia/Controls/DataGridContextMenus.cs
+++ b/Source/LibationAvalonia/Controls/DataGridContextMenus.cs
@@ -2,6 +2,7 @@
 using Avalonia.Controls;
 using LibationUiBase.GridView;
 using System;
+using System.Linq;
 using System.Reflection;
 
 namespace LibationAvalonia.Controls
@@ -12,11 +13,13 @@ namespace LibationAvalonia.Controls
 		private static readonly ContextMenu ContextMenu = new();
 		private static readonly AvaloniaList<Control> MenuItems = new();
 		private static readonly PropertyInfo OwningColumnProperty;
+		private static readonly PropertyInfo OwningGridProperty;
 
 		static DataGridContextMenus()
 		{
 			ContextMenu.ItemsSource = MenuItems;
 			OwningColumnProperty = typeof(DataGridCell).GetProperty("OwningColumn", BindingFlags.Instance | BindingFlags.NonPublic);
+			OwningGridProperty = typeof(DataGridColumn).GetProperty("OwningGrid", BindingFlags.Instance | BindingFlags.NonPublic);
 		}
 
 		public static void AttachContextMenu(this DataGridCell cell)
@@ -30,19 +33,35 @@ namespace LibationAvalonia.Controls
 
 		private static void Cell_ContextRequested(object sender, ContextRequestedEventArgs e)
 		{
-			if (sender is DataGridCell cell && cell.DataContext is IGridEntry entry)
+			if (sender is DataGridCell cell &&
+				cell.DataContext is IGridEntry clickedEntry &&
+				OwningColumnProperty.GetValue(cell) is DataGridColumn column &&
+				OwningGridProperty.GetValue(column) is DataGrid grid)
 			{
+				var allSelected = grid.SelectedItems.OfType<IGridEntry>().ToArray();
+				var clickedIndex = Array.IndexOf(allSelected, clickedEntry);
+				if (clickedIndex == -1)
+				{
+					//User didn't right-click on a selected cell
+					grid.SelectedItem = clickedEntry;
+					allSelected = [clickedEntry];
+				}
+				else if (clickedIndex > 0)
+				{
+					//Ensure the clicked entry is first in the list
+					(allSelected[0], allSelected[clickedIndex]) = (allSelected[clickedIndex], allSelected[0]);
+				}
+
 				var args = new DataGridCellContextMenuStripNeededEventArgs
 				{
-					Column = OwningColumnProperty.GetValue(cell) as DataGridColumn,
-					GridEntry = entry,
+					Column = column,
+					Grid = grid,
+					GridEntries = allSelected,
 					ContextMenu = ContextMenu
 				};
 
 				args.ContextMenuItems.Clear();
-
 				CellContextMenuStripNeeded?.Invoke(sender, args);
-
 				e.Handled = args.ContextMenuItems.Count == 0;
 			}
 			else
@@ -61,10 +80,37 @@ namespace LibationAvalonia.Controls
 		private static string GetCellValue(DataGridColumn column, object item)
 			=> GetCellValueMethod.Invoke(column, new object[] { item, column.ClipboardContentBinding })?.ToString() ?? "";
 
-		public string CellClipboardContents => GetCellValue(Column, GridEntry);
-		public DataGridColumn Column { get; init; }
-		public IGridEntry GridEntry { get; init; }
-		public ContextMenu ContextMenu { get; init; }
+		public string CellClipboardContents => GetCellValue(Column, GridEntries[0]);
+		public string GetRowClipboardContents()
+		{
+			if (GridEntries is null || GridEntries.Length == 0)
+				return string.Empty;
+			else if (GridEntries.Length == 1)
+				return HeaderNames + Environment.NewLine + GetRowClipboardContents(GridEntries[0]);
+			else
+				return string.Join(Environment.NewLine, GridEntries.Select(GetRowClipboardContents).Prepend(HeaderNames));
+		}
+
+		private string HeaderNames
+			=> string.Join("\t",
+				Grid.Columns
+				.Where(c => c.IsVisible)
+				.OrderBy(c => c.DisplayIndex)
+				.Select(c => RemoveLineBreaks(c.Header.ToString())));
+
+		private static string RemoveLineBreaks(string text)
+			=> text.Replace("\r\n", "").Replace('\r', ' ').Replace('\n', ' ');
+
+		private string GetRowClipboardContents(IGridEntry gridEntry)
+		{
+			var contents = Grid.Columns.Where(c => c.IsVisible).OrderBy(c => c.DisplayIndex).Select(c => RemoveLineBreaks(GetCellValue(c, gridEntry))).ToArray();
+			return string.Join("\t", contents);
+		}
+
+		public required DataGrid Grid { get; init; }
+		public required DataGridColumn Column { get; init; }
+		public required IGridEntry[] GridEntries { get; init; }
+		public required ContextMenu ContextMenu { get; init; }
 		public AvaloniaList<Control> ContextMenuItems
 			=> ContextMenu.ItemsSource as AvaloniaList<Control>;
 	}

--- a/Source/LibationAvalonia/ViewModels/ProcessQueueViewModel.cs
+++ b/Source/LibationAvalonia/ViewModels/ProcessQueueViewModel.cs
@@ -91,19 +91,19 @@ namespace LibationAvalonia.ViewModels
 
 		public decimal SpeedLimitIncrement { get; private set; }
 
-		private async void Queue_CompletedCountChanged(object? sender, int e)
+		private void Queue_CompletedCountChanged(object? sender, int e)
 		{
 			int errCount = Queue.Completed.Count(p => p.Result is ProcessBookResult.FailedAbort or ProcessBookResult.FailedSkip or ProcessBookResult.FailedRetry or ProcessBookResult.ValidationFail);
 			int completeCount = Queue.Completed.Count(p => p.Result is ProcessBookResult.Success);
 
 			ErrorCount = errCount;
 			CompletedCount = completeCount;
-			await Dispatcher.UIThread.InvokeAsync(() => this.RaisePropertyChanged(nameof(Progress)));
+			Dispatcher.UIThread.Invoke(() => this.RaisePropertyChanged(nameof(Progress)));
 		}
-		private async void Queue_QueuededCountChanged(object? sender, int cueCount)
+		private void Queue_QueuededCountChanged(object? sender, int cueCount)
 		{
 			QueuedCount = cueCount;
-			await Dispatcher.UIThread.InvokeAsync(() => this.RaisePropertyChanged(nameof(Progress)));
+			Dispatcher.UIThread.Invoke(() => this.RaisePropertyChanged(nameof(Progress)));
 		}
 
 		public void WriteLine(string text)

--- a/Source/LibationAvalonia/ViewModels/ProductsDisplayViewModel.cs
+++ b/Source/LibationAvalonia/ViewModels/ProductsDisplayViewModel.cs
@@ -164,6 +164,10 @@ namespace LibationAvalonia.ViewModels
 			if (GridEntries == null)
 				throw new InvalidOperationException($"Must call {nameof(BindToGridAsync)} before calling {nameof(UpdateGridAsync)}");
 
+			//CollectionChanged fires for every book added, and the handler invokes
+			//VisibleCountChanged which triggers Libation to re-count all books.
+			GridEntries.CollectionChanged -= GridEntries_CollectionChanged;
+
 			#region Add new or update existing grid entries
 
 			//Add absent entries to grid, or update existing entry
@@ -214,8 +218,8 @@ namespace LibationAvalonia.ViewModels
 			await Filter(FilterString);
 			GC.Collect(GC.MaxGeneration, GCCollectionMode.Aggressive, true, true);
 
-			if (GridEntries != null)
-				GridEntries.CollectionChanged += GridEntries_CollectionChanged;
+			//Resubscribe after all changes to the list have been made
+			GridEntries.CollectionChanged += GridEntries_CollectionChanged;
 			GridEntries_CollectionChanged();
 		}
 

--- a/Source/LibationAvalonia/Views/MainWindow.axaml.cs
+++ b/Source/LibationAvalonia/Views/MainWindow.axaml.cs
@@ -134,9 +134,9 @@ namespace LibationAvalonia.Views
 				Task.Run(() => vm.ProductsDisplay.BindToGridAsync(initialLibrary)));
 		}
 
-		public void ProductsDisplay_LiberateClicked(object _, LibraryBook libraryBook) => ViewModel.LiberateClicked(libraryBook);
+		public void ProductsDisplay_LiberateClicked(object _, LibraryBook[] libraryBook) => ViewModel.LiberateClicked(libraryBook);
 		public void ProductsDisplay_LiberateSeriesClicked(object _, ISeriesEntry series) => ViewModel.LiberateSeriesClicked(series);
-		public void ProductsDisplay_ConvertToMp3Clicked(object _, LibraryBook libraryBook) => ViewModel.ConvertToMp3Clicked(libraryBook);
+		public void ProductsDisplay_ConvertToMp3Clicked(object _, LibraryBook[] libraryBook) => ViewModel.ConvertToMp3Clicked(libraryBook);
 
 		BookDetailsDialog bookDetailsForm;
 		public void ProductsDisplay_TagsButtonClicked(object _, LibraryBook libraryBook)

--- a/Source/LibationWinForms/Form1.Designer.cs
+++ b/Source/LibationWinForms/Form1.Designer.cs
@@ -537,9 +537,9 @@
             this.productsDisplay.TabIndex = 9;
             this.productsDisplay.VisibleCountChanged += new System.EventHandler<int>(this.productsDisplay_VisibleCountChanged);
             this.productsDisplay.RemovableCountChanged += new System.EventHandler<int>(this.productsDisplay_RemovableCountChanged);
-            this.productsDisplay.LiberateClicked += new System.EventHandler<DataLayer.LibraryBook>(this.ProductsDisplay_LiberateClicked);
+            this.productsDisplay.LiberateClicked += ProductsDisplay_LiberateClicked;
             this.productsDisplay.LiberateSeriesClicked += new System.EventHandler<LibationUiBase.GridView.ISeriesEntry>(this.ProductsDisplay_LiberateSeriesClicked);
-            this.productsDisplay.ConvertToMp3Clicked += new System.EventHandler<DataLayer.LibraryBook>(this.ProductsDisplay_ConvertToMp3Clicked);
+            this.productsDisplay.ConvertToMp3Clicked += ProductsDisplay_ConvertToMp3Clicked;
             this.productsDisplay.InitialLoaded += new System.EventHandler(this.productsDisplay_InitialLoaded);
             // 
             // toggleQueueHideBtn

--- a/Source/LibationWinForms/Form1.ProcessQueue.cs
+++ b/Source/LibationWinForms/Form1.ProcessQueue.cs
@@ -23,36 +23,53 @@ namespace LibationWinForms
 			this.Width = width;
 		}
 
-		private void ProductsDisplay_LiberateClicked(object sender, LibraryBook libraryBook)
+		private void ProductsDisplay_LiberateClicked(object sender, LibraryBook[] libraryBooks)
 		{
 			try
 			{
-				if (libraryBook.Book.UserDefinedItem.BookStatus is LiberatedStatus.NotLiberated or LiberatedStatus.PartialDownload)
+				if (libraryBooks.Length == 1)
 				{
-					Serilog.Log.Logger.Information("Begin single book backup of {libraryBook}", libraryBook);
-					SetQueueCollapseState(false);
-					processBookQueue1.AddDownloadDecrypt(libraryBook);
-				}
-				else if (libraryBook.Book.UserDefinedItem.PdfStatus is LiberatedStatus.NotLiberated)
-				{
-					Serilog.Log.Logger.Information("Begin single pdf backup of {libraryBook}", libraryBook);
-					SetQueueCollapseState(false);
-					processBookQueue1.AddDownloadPdf(libraryBook);
-				}
-				else if (libraryBook.Book.Audio_Exists())
-				{
-					// liberated: open explorer to file
-					var filePath = AudibleFileStorage.Audio.GetPath(libraryBook.Book.AudibleProductId);
-					if (!Go.To.File(filePath?.ShortPathName))
+					var item = libraryBooks[0];
+					if (item.Book.UserDefinedItem.BookStatus is LiberatedStatus.NotLiberated or LiberatedStatus.PartialDownload)
 					{
-						var suffix = string.IsNullOrWhiteSpace(filePath) ? "" : $":\r\n{filePath}";
-						MessageBox.Show($"File not found" + suffix);
+						Serilog.Log.Logger.Information("Begin single book backup of {libraryBook}", item);
+						SetQueueCollapseState(false);
+						processBookQueue1.AddDownloadDecrypt(item);
+					}
+					else if (item.Book.UserDefinedItem.PdfStatus is LiberatedStatus.NotLiberated)
+					{
+						Serilog.Log.Logger.Information("Begin single pdf backup of {libraryBook}", item);
+						SetQueueCollapseState(false);
+						processBookQueue1.AddDownloadPdf(item);
+					}
+					else if (item.Book.Audio_Exists())
+					{
+						// liberated: open explorer to file
+						var filePath = AudibleFileStorage.Audio.GetPath(item.Book.AudibleProductId);
+						if (!Go.To.File(filePath?.ShortPathName))
+						{
+							var suffix = string.IsNullOrWhiteSpace(filePath) ? "" : $":\r\n{filePath}";
+							MessageBox.Show($"File not found" + suffix);
+						}
+					}
+				}
+				else
+				{
+					var toLiberate
+						= libraryBooks
+						.Where(x => x.Book.UserDefinedItem.BookStatus is LiberatedStatus.NotLiberated or LiberatedStatus.PartialDownload || x.Book.UserDefinedItem.PdfStatus is LiberatedStatus.NotLiberated)
+						.ToArray();
+
+					if (toLiberate.Length > 0)
+					{
+						SetQueueCollapseState(false);
+						processBookQueue1.AddDownloadDecrypt(toLiberate);
 					}
 				}
 			}
 			catch (Exception ex)
 			{
-				Serilog.Log.Logger.Error(ex, "An error occurred while handling the stop light button click for {libraryBook}", libraryBook);
+				Serilog.Log.Logger.Error(ex, "An error occurred while handling the stop light button click for {libraryBook}", libraryBooks);
 			}
 		}
 
@@ -72,20 +89,21 @@ namespace LibationWinForms
 			}
 		}
 
-		private void ProductsDisplay_ConvertToMp3Clicked(object sender, LibraryBook libraryBook)
+		private void ProductsDisplay_ConvertToMp3Clicked(object sender, LibraryBook[] libraryBooks)
 		{
 			try
 			{
-				if (libraryBook.Book.UserDefinedItem.BookStatus is LiberatedStatus.Liberated)
+				var preLiberated = libraryBooks.Where(lb => lb.Book.UserDefinedItem.BookStatus is LiberatedStatus.Liberated).ToArray();
+				if (preLiberated.Length > 0)
 				{
-					Serilog.Log.Logger.Information("Begin single pdf backup of {libraryBook}", libraryBook);
+					Serilog.Log.Logger.Information("Begin convert {count} books to mp3", preLiberated.Length);
 					SetQueueCollapseState(false);
-					processBookQueue1.AddConvertMp3(libraryBook);
+					processBookQueue1.AddConvertMp3(preLiberated);
 				}
 			}
 			catch (Exception ex)
 			{
-				Serilog.Log.Logger.Error(ex, "An error occurred while handling the stop light button click for {libraryBook}", libraryBook);
+				Serilog.Log.Logger.Error(ex, "An error occurred while handling the stop light button click for {libraryBook}", libraryBooks);
 			}
 		}
 


### PR DESCRIPTION
## [Fix libation hanging on first inport of large libraries](https://github.com/rmcrackan/Libation/commit/bfcd22679561318c29b9f715311bb8f876f621ec)

When updating the grid with a large number of new entries (e.g. the first time a new user scans thir library and all books are added to the grid), Libation freezes as it runs `LibraryCommands.GetCounts()` every time a new entry is added to the grid.

## [Add multi-select context menu support](https://github.com/rmcrackan/Libation/commit/c77f2e2162a0a213b19449e9512e782d1d9d7eb1) (#1195)

The main feature. Multi-select combo box for:
- Copying all selected cells' contents
- bulk setting of download status
- bulk remove books
- bulk download
- bulk convert to mp3

 I also did some mull nullable enabling and fixing.