### PR TITLE
Fixed doubled first name in templates

### DIFF
--- a/Source/LibationFileManager/Templates/ContributorDto.cs
+++ b/Source/LibationFileManager/Templates/ContributorDto.cs
@@ -24,10 +24,12 @@ public class ContributorDto : IFormattable
 
 		//Single-word names parse as first names. Use it as last name.
 		var lastName = string.IsNullOrWhiteSpace(HumanName.Last) ? HumanName.First : HumanName.Last;
+  		//Because of the above, if the have only a first name, then we'd double the name as "FirstName FirstName", so clear the first name in that situation.
+  		var firstName = string.IsNullOrWhiteSpace(HumanName.Last) ? HumanName.Last : HumanName.First;
 
 		return format
 			.Replace("{T}", HumanName.Title)
-			.Replace("{F}", HumanName.First)
+			.Replace("{F}", firstName)
 			.Replace("{M}", HumanName.Middle)
 			.Replace("{L}", lastName)
 			.Replace("{S}", HumanName.Suffix)

--- a/Source/_Tests/LibationFileManager.Tests/TemplatesTests.cs
+++ b/Source/_Tests/LibationFileManager.Tests/TemplatesTests.cs
@@ -284,7 +284,7 @@ namespace TemplatesTests
 		[DataRow("Carla Naumburg PhD", "Title=, First=Carla, Middle= Last=Naumburg, Suffix=PhD")]
 		[DataRow("Doug Stanhope and Friends", "Title=, First=Doug, Middle= Last=Stanhope and Friends, Suffix=")]
 		[DataRow("Tamara Lovatt-Smith", "Title=, First=Tamara, Middle= Last=Lovatt-Smith, Suffix=")]
-		[DataRow("Common", "Title=, First=Common, Middle= Last=Common, Suffix=")]
+		[DataRow("Common", "Title=, First=, Middle= Last=Common, Suffix=")]
 		[DataRow("Doug Tisdale Jr.", "Title=, First=Doug, Middle= Last=Tisdale, Suffix=Jr")]
 		[DataRow("Robert S. Mueller III", "Title=, First=Robert, Middle=S. Last=Mueller, Suffix=III")]
 		[DataRow("Frank T Vertosick Jr. MD", "Title=, First=Frank, Middle=T Last=Vertosick, Suffix=Jr. MD")]


### PR DESCRIPTION
v12.3.0 caused a regression with contributors with a single word name, causing the name to be doubled. This was caused by using that name as both the first and last name, so swap the first name with the (blank) last name rather than duplicate them.