### PR TITLE
Bug fixes and a change to license request logic

### DIFF
--- a/Source/AaxDecrypter/AaxcDownloadConvertBase.cs
+++ b/Source/AaxDecrypter/AaxcDownloadConvertBase.cs
@@ -1,5 +1,6 @@
 ﻿using AAXClean;
 using System;
+using System.Linq;
 using System.Threading.Tasks;
 
 namespace AaxDecrypter
@@ -33,20 +34,33 @@ namespace AaxDecrypter
 		{
 			if (DownloadOptions.InputType is FileType.Dash)
 			{
+				//We may have multiple keys , so use the key whose key ID matches
+				//the dash files default Key ID.
+				var keyIds = DownloadOptions.DecryptionKeys.Select(k => new Guid(k.KeyPart1, bigEndian: true)).ToArray();
+
 				var dash = new DashFile(InputFileStream);
-				dash.SetDecryptionKey(DownloadOptions.AudibleKey, DownloadOptions.AudibleIV);
+				var kidIndex = Array.IndexOf(keyIds, dash.Tenc.DefaultKID);
+
+				if (kidIndex == -1)
+					throw new InvalidOperationException($"None of the {keyIds.Length} key IDs match the dash file's default KeyID of {dash.Tenc.DefaultKID}");
+
+				DownloadOptions.DecryptionKeys[0] = DownloadOptions.DecryptionKeys[kidIndex];
+				var keyId = DownloadOptions.DecryptionKeys[kidIndex].KeyPart1;
+				var key = DownloadOptions.DecryptionKeys[kidIndex].KeyPart2;
+
+				dash.SetDecryptionKey(keyId, key);
 				return dash;
 			}
 			else if (DownloadOptions.InputType is FileType.Aax)
 			{
 				var aax = new AaxFile(InputFileStream);
-				aax.SetDecryptionKey(DownloadOptions.AudibleKey);
+				aax.SetDecryptionKey(DownloadOptions.DecryptionKeys[0].KeyPart1);
 				return aax;
 			}
 			else if (DownloadOptions.InputType is FileType.Aaxc)
 			{
 				var aax = new AaxFile(InputFileStream);
-				aax.SetDecryptionKey(DownloadOptions.AudibleKey, DownloadOptions.AudibleIV);
+				aax.SetDecryptionKey(DownloadOptions.DecryptionKeys[0].KeyPart1, DownloadOptions.DecryptionKeys[0].KeyPart2);
 				return aax;
 			}
 			else throw new InvalidOperationException($"{nameof(DownloadOptions.InputType)} of '{DownloadOptions.InputType}' is unknown.");

--- a/Source/AaxDecrypter/AaxcDownloadConvertBase.cs
+++ b/Source/AaxDecrypter/AaxcDownloadConvertBase.cs
@@ -8,7 +8,7 @@ namespace AaxDecrypter
 	{
 		public event EventHandler<AppleTags> RetrievedMetadata;
 
-		protected Mp4File AaxFile { get; private set; }
+		public Mp4File AaxFile { get; private set; }
 		protected Mp4Operation AaxConversion { get; set; }
 
 		protected AaxcDownloadConvertBase(string outFileName, string cacheDirectory, IDownloadOptions dlOptions)

--- a/Source/AaxDecrypter/AudiobookDownloadBase.cs
+++ b/Source/AaxDecrypter/AudiobookDownloadBase.cs
@@ -204,6 +204,9 @@ namespace AaxDecrypter
 				else
 					throw new InvalidOperationException($"Unknown file type: {fileType}");
 
+				if (tempFilePath != aaxPath)
+					FileUtility.SaferMove(tempFilePath, aaxPath);
+
 				OnFileCreated(aaxPath);
 				OnFileCreated(keyPath);
 			}

--- a/Source/AaxDecrypter/IDownloadOptions.cs
+++ b/Source/AaxDecrypter/IDownloadOptions.cs
@@ -2,15 +2,35 @@
 using System;
 using System.Threading.Tasks;
 
+#nullable enable
 namespace AaxDecrypter
 {
-    public interface IDownloadOptions
+    public class KeyData
+    {
+        public byte[] KeyPart1 { get; }
+        public byte[]? KeyPart2 { get; }
+
+        public KeyData(byte[] keyPart1, byte[]? keyPart2 = null)
+        {
+            KeyPart1 = keyPart1;
+            KeyPart2 = keyPart2;
+        }
+
+        public KeyData(string keyPart1, string? keyPart2 = null)
+        {
+            ArgumentNullException.ThrowIfNull(keyPart1, nameof(keyPart1));
+            KeyPart1 = Convert.FromBase64String(keyPart1);
+            if (keyPart2 != null)
+                KeyPart2 = Convert.FromBase64String(keyPart2);
+        }
+	}    
+
+	public interface IDownloadOptions
     {
         event EventHandler<long> DownloadSpeedChanged;
         string DownloadUrl { get; }
         string UserAgent { get; }
-        string AudibleKey { get; }
-        string AudibleIV { get; }
+		KeyData[]? DecryptionKeys { get; }
         TimeSpan RuntimeLength { get; }
         OutputFormat OutputFormat { get; }
         bool TrimOutputToChapterLength { get; }
@@ -21,14 +41,14 @@ namespace AaxDecrypter
         long DownloadSpeedBps { get; }
         ChapterInfo ChapterInfo { get; }
         bool FixupFile { get; }
-		string AudibleProductId { get; }
-		string Title { get; }
-		string Subtitle { get; }
-		string Publisher { get; }
-		string Language { get; }
-		string SeriesName { get; }
+		string? AudibleProductId { get; }
+		string? Title { get; }
+		string? Subtitle { get; }
+		string? Publisher { get; }
+		string? Language { get; }
+		string? SeriesName { get; }
 		float? SeriesNumber { get; }
-		NAudio.Lame.LameConfig LameConfig { get; }
+		NAudio.Lame.LameConfig? LameConfig { get; }
         bool Downsample { get; }
         bool MatchSourceBitrate { get; }
         bool MoveMoovToBeginning { get; }

--- a/Source/AaxDecrypter/NetworkFileStream.cs
+++ b/Source/AaxDecrypter/NetworkFileStream.cs
@@ -110,14 +110,16 @@ namespace AaxDecrypter
 		#region Downloader
 
 		/// <summary> Update the <see cref="Dinah.Core.IO.JsonFilePersister{T}"/>. </summary>
-		private void OnUpdate()
+		private void OnUpdate(bool waitForWrite = false)
 		{
 			try
 			{
-				if (DateTime.UtcNow > NextUpdateTime)
+				if (waitForWrite || DateTime.UtcNow > NextUpdateTime)
 				{
 					Updated?.Invoke(this, EventArgs.Empty);
 					//JsonFilePersister Will not allow update intervals shorter than 100 milliseconds
+					//If an update is called less than 100 ms since the last update, persister will
+					//sleep the thread until 100 ms has elapsed.
 					NextUpdateTime = DateTime.UtcNow.AddMilliseconds(110);
 				}
 			}
@@ -305,7 +307,7 @@ namespace AaxDecrypter
 			finally
 			{
 				_downloadedPiece.Set();
-				OnUpdate();
+				OnUpdate(waitForWrite: true);
 			}
 		}
 
@@ -402,7 +404,7 @@ namespace AaxDecrypter
 				_cancellationSource?.Dispose();
 				_readFile.Dispose();
 				_writeFile.Dispose();
-				OnUpdate();
+				OnUpdate(waitForWrite: true);
 			}
 
 			disposed = true;

--- a/Source/ApplicationServices/LibraryCommands.cs
+++ b/Source/ApplicationServices/LibraryCommands.cs
@@ -32,7 +32,7 @@ namespace ApplicationServices
             ScanEnd += (_, __) => Scanning = false;
         }
 
-        public static async Task<List<LibraryBook>> FindInactiveBooks(Func<Account, Task<ApiExtended>> apiExtendedfunc, IEnumerable<LibraryBook> existingLibrary, params Account[] accounts)
+        public static async Task<List<LibraryBook>> FindInactiveBooks(IEnumerable<LibraryBook> existingLibrary, params Account[] accounts)
         {
             logRestart();
 
@@ -58,7 +58,7 @@ namespace ApplicationServices
             try
             {
                 logTime($"pre {nameof(scanAccountsAsync)} all");
-                var libraryItems = await scanAccountsAsync(apiExtendedfunc, accounts, libraryOptions);
+                var libraryItems = await scanAccountsAsync(accounts, libraryOptions);
                 logTime($"post {nameof(scanAccountsAsync)} all");
 
                 var totalCount = libraryItems.Count;
@@ -101,7 +101,7 @@ namespace ApplicationServices
         }
 
         #region FULL LIBRARY scan and import
-        public static async Task<(int totalCount, int newCount)> ImportAccountAsync(Func<Account, Task<ApiExtended>> apiExtendedfunc, params Account[]? accounts)
+        public static async Task<(int totalCount, int newCount)> ImportAccountAsync(params Account[]? accounts)
         {
             logRestart();
 
@@ -131,7 +131,7 @@ namespace ApplicationServices
                         | LibraryOptions.ResponseGroupOptions.IsFinished,
 					ImageSizes = LibraryOptions.ImageSizeOptions._500 | LibraryOptions.ImageSizeOptions._1215
                 };
-                var importItems = await scanAccountsAsync(apiExtendedfunc, accounts, libraryOptions);
+                var importItems = await scanAccountsAsync(accounts, libraryOptions);
                 logTime($"post {nameof(scanAccountsAsync)} all");
 
                 var totalCount = importItems.Count;
@@ -262,7 +262,7 @@ namespace ApplicationServices
             return null;
         }
 
-		private static async Task<List<ImportItem>> scanAccountsAsync(Func<Account, Task<ApiExtended>> apiExtendedfunc, Account[] accounts, LibraryOptions libraryOptions)
+		private static async Task<List<ImportItem>> scanAccountsAsync(Account[] accounts, LibraryOptions libraryOptions)
         {
             var tasks = new List<Task<List<ImportItem>>>();
 
@@ -278,7 +278,7 @@ namespace ApplicationServices
                 try
                 {
                     // get APIs in serial b/c of logins. do NOT move inside of parallel (Task.WhenAll)
-                    var apiExtended = await apiExtendedfunc(account);
+                    var apiExtended = await ApiExtended.CreateAsync(account);
 
                     // add scanAccountAsync as a TASK: do not await
                     tasks.Add(scanAccountAsync(apiExtended, account, libraryOptions, archiver));

--- a/Source/AudibleUtilities/Widevine/Cdm.cs
+++ b/Source/AudibleUtilities/Widevine/Cdm.cs
@@ -55,7 +55,7 @@ public class WidevineKey
 		Type = (KeyType)type;
 		Key = key;
 	}
-	public override string ToString() => $"{Convert.ToHexString(Kid.ToByteArray()).ToLower()}:{Convert.ToHexString(Key).ToLower()}";
+	public override string ToString() => $"{Convert.ToHexString(Kid.ToByteArray(bigEndian: true)).ToLower()}:{Convert.ToHexString(Key).ToLower()}";
 }
 
 public partial class Cdm
@@ -192,7 +192,7 @@ public partial class Cdm
 					id = id.Append(new byte[16 - id.Length]);
 				}
 
-				keys[i] = new WidevineKey(new Guid(id), keyContainer.Type, keyBytes);
+				keys[i] = new WidevineKey(new Guid(id,bigEndian: true), keyContainer.Type, keyBytes);
 			}
 			return keys;
 		}

--- a/Source/FileLiberator/DownloadDecryptBook.cs
+++ b/Source/FileLiberator/DownloadDecryptBook.cs
@@ -184,16 +184,13 @@ namespace FileLiberator
                 fileDuration -= TimeSpan.FromMilliseconds(options.ContentMetadata.ChapterInfo.BrandOutroDurationMs);
 
             var durationDelta = fileDuration - options.ChapterInfo.EndOffset;
-            if (durationDelta.TotalMilliseconds > 0)
-            {
-				//only fix chapters which are shorter than the file. Chapters which are longer
-				//than the file will be truncated to match the file length, which is correct.
-				var chapters = options.ChapterInfo.Chapters as List<AAXClean.Chapter>;
-                var lastChapter = chapters[^1];
+			//Remove the last chapter and re-add it with the durationDelta that will
+            //make the chapter's end coincide with the end of the audio file.
+			var chapters = options.ChapterInfo.Chapters as List<AAXClean.Chapter>;
+			var lastChapter = chapters[^1];
 
-                chapters.Remove(lastChapter);
-                options.ChapterInfo.Add(lastChapter.Title, lastChapter.Duration + durationDelta);
-            }
+			chapters.Remove(lastChapter);
+			options.ChapterInfo.Add(lastChapter.Title, lastChapter.Duration + durationDelta);
             
             #endregion
 

--- a/Source/FileLiberator/DownloadOptions.Factory.cs
+++ b/Source/FileLiberator/DownloadOptions.Factory.cs
@@ -51,12 +51,7 @@ public partial class DownloadOptions
 		try
 		{
 			//try to request a widevine content license using the user's spatial audio settings
-			var codecChoice = config.SpatialAudioCodec switch
-			{
-				Configuration.SpatialCodec.EC_3 => Ec3Codec,
-				Configuration.SpatialCodec.AC_4 => Ac4Codec,
-				_ => throw new NotSupportedException($"Unknown value for {nameof(config.SpatialAudioCodec)}")
-			};
+			var codecChoice = config.SpatialAudioCodec is Configuration.SpatialCodec.AC_4 ? Ac4Codec : Ec3Codec;
 
 			var contentLic
 				= await api.GetDownloadLicenseAsync(

--- a/Source/FileLiberator/DownloadOptions.cs
+++ b/Source/FileLiberator/DownloadOptions.cs
@@ -9,27 +9,27 @@ using System.IO;
 using ApplicationServices;
 using LibationFileManager.Templates;
 
+#nullable enable
 namespace FileLiberator
 {
 	public partial class DownloadOptions : IDownloadOptions, IDisposable
 	{
-		public event EventHandler<long> DownloadSpeedChanged;
+		public event EventHandler<long>? DownloadSpeedChanged;
 		public LibraryBook LibraryBook { get; }
 		public LibraryBookDto LibraryBookDto { get; }
 		public string DownloadUrl { get; }
-		public string AudibleKey { get; init; }
-		public string AudibleIV { get; init; }
-		public TimeSpan RuntimeLength { get; init; }
-		public OutputFormat OutputFormat { get; init; }
-		public ChapterInfo ChapterInfo { get; init; }
+		public KeyData[]? DecryptionKeys { get; }
+		public required TimeSpan RuntimeLength { get; init; }
+		public OutputFormat OutputFormat { get; }
+		public required ChapterInfo ChapterInfo { get; init; }
 		public string Title => LibraryBook.Book.Title;
 		public string Subtitle => LibraryBook.Book.Subtitle;
 		public string Publisher => LibraryBook.Book.Publisher;
 		public string Language => LibraryBook.Book.Language;
-		public string AudibleProductId => LibraryBookDto.AudibleProductId;
-		public string SeriesName => LibraryBookDto.FirstSeries?.Name;
+		public string? AudibleProductId => LibraryBookDto.AudibleProductId;
+		public string? SeriesName => LibraryBookDto.FirstSeries?.Name;
 		public float? SeriesNumber => LibraryBookDto.FirstSeries?.Number;
-		public NAudio.Lame.LameConfig LameConfig { get; init; }
+		public NAudio.Lame.LameConfig? LameConfig { get; }
 		public string UserAgent => AudibleApi.Resources.Download_User_Agent;
 		public bool TrimOutputToChapterLength => Config.AllowLibationFixup && Config.StripAudibleBrandAudio;
 		public bool StripUnabridged => Config.AllowLibationFixup && Config.StripUnabridged;
@@ -41,15 +41,15 @@ namespace FileLiberator
 		public bool Downsample => Config.AllowLibationFixup && Config.LameDownsampleMono;
 		public bool MatchSourceBitrate => Config.AllowLibationFixup && Config.LameMatchSourceBR && Config.LameTargetBitrate;
 		public bool MoveMoovToBeginning => Config.MoveMoovToBeginning;
-		public AAXClean.FileType? InputType { get; init; }
-		public AudibleApi.Common.DrmType DrmType { get; init; }
-		public AudibleApi.Common.ContentMetadata ContentMetadata { get; init; }
+		public AAXClean.FileType? InputType { get; }
+		public AudibleApi.Common.DrmType DrmType { get; }
+		public AudibleApi.Common.ContentMetadata ContentMetadata { get; }
 
 		public string GetMultipartFileName(MultiConvertFileProperties props)
 		{
 			var baseDir = Path.GetDirectoryName(props.OutputFileName);
 			var extension = Path.GetExtension(props.OutputFileName);
-			return Templates.ChapterFile.GetFilename(LibraryBookDto, props, baseDir, extension);
+			return Templates.ChapterFile.GetFilename(LibraryBookDto, props, baseDir!, extension);
 		}
 
 		public string GetMultipartTitle(MultiConvertFileProperties props)
@@ -92,14 +92,38 @@ namespace FileLiberator
 			GC.SuppressFinalize(this);
 		}
 
-		private DownloadOptions(Configuration config, LibraryBook libraryBook, [System.Diagnostics.CodeAnalysis.NotNull] string downloadUrl)
+		private DownloadOptions(Configuration config, LibraryBook libraryBook, LicenseInfo licInfo)
 		{
 			Config = ArgumentValidator.EnsureNotNull(config, nameof(config));
 			LibraryBook = ArgumentValidator.EnsureNotNull(libraryBook, nameof(libraryBook));
-			DownloadUrl = ArgumentValidator.EnsureNotNullOrEmpty(downloadUrl, nameof(downloadUrl));
-			// no null/empty check for key/iv. unencrypted files do not have them
 
+			ArgumentValidator.EnsureNotNull(licInfo, nameof(licInfo));
+
+			if (licInfo.ContentMetadata.ContentUrl.OfflineUrl is not string licUrl)
+				throw new InvalidDataException("Content license doesn't contain an offline Url");
+
+			DownloadUrl = licUrl;
+			DecryptionKeys = licInfo.DecryptionKeys;
+			DrmType = licInfo.DrmType;
+			ContentMetadata = licInfo.ContentMetadata;
+			InputType
+			= licInfo.DrmType is AudibleApi.Common.DrmType.Widevine ? AAXClean.FileType.Dash
+			: licInfo.DrmType is AudibleApi.Common.DrmType.Adrm && licInfo.DecryptionKeys?.Length == 1 && licInfo.DecryptionKeys[0].KeyPart1.Length == 8 && licInfo.DecryptionKeys[0].KeyPart2 is null ? AAXClean.FileType.Aax
+			: licInfo.DrmType is AudibleApi.Common.DrmType.Adrm && licInfo.DecryptionKeys?.Length == 1 && licInfo.DecryptionKeys[0].KeyPart1.Length == 32 && licInfo.DecryptionKeys[0].KeyPart2?.Length == 32 ? AAXClean.FileType.Aaxc
+			: null;
+
+			//If DrmType is not Adrm or Widevine, the delivered file is an unencrypted mp3.
+			OutputFormat
+				= licInfo.DrmType is not AudibleApi.Common.DrmType.Adrm and not AudibleApi.Common.DrmType.Widevine ||
+				(config.AllowLibationFixup && config.DecryptToLossy && licInfo.ContentMetadata.ContentReference.Codec != Ac4Codec)
+				? OutputFormat.Mp3
+				: OutputFormat.M4b;
+
+			LameConfig = OutputFormat == OutputFormat.Mp3 ? GetLameOptions(config) : null;
+
+			// no null/empty check for key/iv. unencrypted files do not have them
 			LibraryBookDto = LibraryBook.ToDto();
+			LibraryBookDto.Codec = licInfo.ContentMetadata.ContentReference.Codec;
 
 			cancellation =
 				config

--- a/Source/FileLiberator/DownloadOptions.cs
+++ b/Source/FileLiberator/DownloadOptions.cs
@@ -31,16 +31,16 @@ namespace FileLiberator
 		public float? SeriesNumber => LibraryBookDto.FirstSeries?.Number;
 		public NAudio.Lame.LameConfig LameConfig { get; init; }
 		public string UserAgent => AudibleApi.Resources.Download_User_Agent;
-		public bool TrimOutputToChapterLength => config.AllowLibationFixup && config.StripAudibleBrandAudio;
-		public bool StripUnabridged => config.AllowLibationFixup && config.StripUnabridged;
-		public bool CreateCueSheet => config.CreateCueSheet;
-		public bool DownloadClipsBookmarks => config.DownloadClipsBookmarks;
-		public long DownloadSpeedBps => config.DownloadSpeedLimit;
-		public bool RetainEncryptedFile => config.RetainAaxFile;
-		public bool FixupFile => config.AllowLibationFixup;
-		public bool Downsample => config.AllowLibationFixup && config.LameDownsampleMono;
-		public bool MatchSourceBitrate => config.AllowLibationFixup && config.LameMatchSourceBR && config.LameTargetBitrate;
-		public bool MoveMoovToBeginning => config.MoveMoovToBeginning;
+		public bool TrimOutputToChapterLength => Config.AllowLibationFixup && Config.StripAudibleBrandAudio;
+		public bool StripUnabridged => Config.AllowLibationFixup && Config.StripUnabridged;
+		public bool CreateCueSheet => Config.CreateCueSheet;
+		public bool DownloadClipsBookmarks => Config.DownloadClipsBookmarks;
+		public long DownloadSpeedBps => Config.DownloadSpeedLimit;
+		public bool RetainEncryptedFile => Config.RetainAaxFile;
+		public bool FixupFile => Config.AllowLibationFixup;
+		public bool Downsample => Config.AllowLibationFixup && Config.LameDownsampleMono;
+		public bool MatchSourceBitrate => Config.AllowLibationFixup && Config.LameMatchSourceBR && Config.LameTargetBitrate;
+		public bool MoveMoovToBeginning => Config.MoveMoovToBeginning;
 		public AAXClean.FileType? InputType { get; init; }
 		public AudibleApi.Common.DrmType DrmType { get; init; }
 		public AudibleApi.Common.ContentMetadata ContentMetadata { get; init; }
@@ -59,7 +59,7 @@ namespace FileLiberator
 		{
 			if (DownloadClipsBookmarks)
 			{
-				var format = config.ClipsBookmarksFileFormat;
+				var format = Config.ClipsBookmarksFileFormat;
 
 				var formatExtension = format.ToString().ToLowerInvariant();
 				var filePath = Path.ChangeExtension(fileName, formatExtension);
@@ -84,7 +84,7 @@ namespace FileLiberator
 			return string.Empty;
 		}
 
-		private readonly Configuration config;
+		public Configuration Config { get; }
 		private readonly IDisposable cancellation;
 		public void Dispose()
 		{
@@ -94,7 +94,7 @@ namespace FileLiberator
 
 		private DownloadOptions(Configuration config, LibraryBook libraryBook, [System.Diagnostics.CodeAnalysis.NotNull] string downloadUrl)
 		{
-			this.config = ArgumentValidator.EnsureNotNull(config, nameof(config));
+			Config = ArgumentValidator.EnsureNotNull(config, nameof(config));
 			LibraryBook = ArgumentValidator.EnsureNotNull(libraryBook, nameof(libraryBook));
 			DownloadUrl = ArgumentValidator.EnsureNotNullOrEmpty(downloadUrl, nameof(downloadUrl));
 			// no null/empty check for key/iv. unencrypted files do not have them

--- a/Source/FileLiberator/UtilityExtensions.cs
+++ b/Source/FileLiberator/UtilityExtensions.cs
@@ -20,9 +20,15 @@ namespace FileLiberator
 			account: libraryBook.Account.ToMask()
 			);
 
+		public static Func<Account, Task<ApiExtended>>? ApiExtendedFunc { get; set; }
+
 		public static async Task<AudibleApi.Api> GetApiAsync(this LibraryBook libraryBook)
 		{
-			var apiExtended = await ApiExtended.CreateAsync(libraryBook.Account, libraryBook.Book.Locale);
+			Account account;
+			using (var accounts = AudibleApiStorage.GetAccountsSettingsPersister())
+				account = accounts.AccountsSettings.GetAccount(libraryBook.Account, libraryBook.Book.Locale);
+
+			var apiExtended = await ApiExtended.CreateAsync(account);
 			return apiExtended.Api;
 		}
 

--- a/Source/LibationAvalonia/Controls/Settings/Audio.axaml.cs
+++ b/Source/LibationAvalonia/Controls/Settings/Audio.axaml.cs
@@ -31,10 +31,29 @@ namespace LibationAvalonia.Controls.Settings
 				if (!accounts.AccountsSettings.Accounts.Any(a => a.IdentityTokens.DeviceType == AudibleApi.Resources.DeviceType))
 				{
 					if (VisualRoot is Window parent)
-						await MessageBox.Show(parent,
-						"Your must remove account(s) from Libation and then re-add them to enable widwvine content.",
+					{
+						var choice = await MessageBox.Show(parent,
+						"In order to enable widevine content, Libation will need to log into your accounts again.\r\n\r\n" +
+						"Do you want Libation to clear your current account settings and prompt you to login before the next download?",
 						"Widevine Content Unavailable",
-						MessageBoxButtons.OK);
+						MessageBoxButtons.YesNo,
+						MessageBoxIcon.Question,
+						MessageBoxDefaultButton.Button2);
+
+						if (choice == DialogResult.Yes)
+						{
+							foreach (var account in accounts.AccountsSettings.Accounts.ToArray())
+							{
+								if (account.IdentityTokens.DeviceType != AudibleApi.Resources.DeviceType)
+								{
+									accounts.AccountsSettings.Delete(account);
+									var acc = accounts.AccountsSettings.Upsert(account.AccountId, account.Locale.Name);
+									acc.AccountName = account.AccountName;
+								}
+							}
+							return;
+						}
+					}
 
 					_viewModel.UseWidevine = false;
 				}

--- a/Source/LibationAvalonia/Dialogs/Login/AvaloniaLoginChoiceEager.cs
+++ b/Source/LibationAvalonia/Dialogs/Login/AvaloniaLoginChoiceEager.cs
@@ -9,10 +9,6 @@ namespace LibationAvalonia.Dialogs.Login
 {
 	public class AvaloniaLoginChoiceEager : ILoginChoiceEager
 	{
-		/// <summary>Convenience method. Recommended when wiring up Winforms to <see cref="ApplicationServices.LibraryCommands.ImportAccountAsync"/></summary>
-		public static async Task<ApiExtended> ApiExtendedFunc(Account account)
-			=> await ApiExtended.CreateAsync(account, new AvaloniaLoginChoiceEager(account));
-
 		public ILoginCallback LoginCallback { get; }
 
 		private readonly Account _account;

--- a/Source/LibationAvalonia/ViewModels/MainVM.Import.cs
+++ b/Source/LibationAvalonia/ViewModels/MainVM.Import.cs
@@ -201,7 +201,7 @@ namespace LibationAvalonia.ViewModels
 		{
 			try
 			{
-				var (totalProcessed, newAdded) = await LibraryCommands.ImportAccountAsync(LibationAvalonia.Dialogs.Login.AvaloniaLoginChoiceEager.ApiExtendedFunc, accounts);
+				var (totalProcessed, newAdded) = await LibraryCommands.ImportAccountAsync(accounts);
 
 				// this is here instead of ScanEnd so that the following is only possible when it's user-initiated, not automatic loop
 				if (Configuration.Instance.ShowImportedStats && newAdded > 0)

--- a/Source/LibationAvalonia/ViewModels/MainVM.ScanAuto.cs
+++ b/Source/LibationAvalonia/ViewModels/MainVM.ScanAuto.cs
@@ -27,7 +27,7 @@ namespace LibationAvalonia.ViewModels
 				// in autoScan, new books SHALL NOT show dialog
 				try
 				{
-					await LibraryCommands.ImportAccountAsync(LibationAvalonia.Dialogs.Login.AvaloniaLoginChoiceEager.ApiExtendedFunc, accounts);
+					await LibraryCommands.ImportAccountAsync(accounts);
 				}
 				catch (OperationCanceledException)
 				{

--- a/Source/LibationAvalonia/ViewModels/ProductsDisplayViewModel.cs
+++ b/Source/LibationAvalonia/ViewModels/ProductsDisplayViewModel.cs
@@ -431,7 +431,7 @@ namespace LibationAvalonia.ViewModels
 					.Select(lbe => lbe.LibraryBook)
 					.Where(lb => !lb.Book.HasLiberated());
 
-				var removedBooks = await LibraryCommands.FindInactiveBooks(AvaloniaLoginChoiceEager.ApiExtendedFunc, lib, accounts);
+				var removedBooks = await LibraryCommands.FindInactiveBooks(lib, accounts);
 
 				var removable = allBooks.Where(lbe => removedBooks.Any(rb => rb.Book.AudibleProductId == lbe.AudibleProductId)).ToList();
 

--- a/Source/LibationAvalonia/Views/MainWindow.axaml.cs
+++ b/Source/LibationAvalonia/Views/MainWindow.axaml.cs
@@ -21,6 +21,7 @@ namespace LibationAvalonia.Views
 		public MainWindow()
 		{
 			DataContext = new MainVM(this);
+			ApiExtended.LoginChoiceFactory = account => new Dialogs.Login.AvaloniaLoginChoiceEager(account);
 
 			AudibleApiStorage.LoadError += AudibleApiStorage_LoadError;
 			InitializeComponent();

--- a/Source/LibationCli/Options/ScanOptions.cs
+++ b/Source/LibationCli/Options/ScanOptions.cs
@@ -32,7 +32,7 @@ namespace LibationCli
 				: $"Scanning Audible library: {_accounts.Length} accounts. This may take a few minutes per account.";
 			Console.WriteLine(intro);
 
-			var (TotalBooksProcessed, NewBooksAdded) = await LibraryCommands.ImportAccountAsync((a) => ApiExtended.CreateAsync(a), _accounts);
+			var (TotalBooksProcessed, NewBooksAdded) = await LibraryCommands.ImportAccountAsync(_accounts);
 
 			Console.WriteLine("Scan complete.");
 			Console.WriteLine($"Total processed: {TotalBooksProcessed}");

--- a/Source/LibationFileManager/Configuration.PersistentSettings.cs
+++ b/Source/LibationFileManager/Configuration.PersistentSettings.cs
@@ -257,7 +257,7 @@ namespace LibationFileManager
 		}
 
 		[Description("Use widevine DRM")]
-		public bool UseWidevine { get => GetNonString(defaultValue: true); set => SetNonString(value); }
+		public bool UseWidevine { get => GetNonString(defaultValue: false); set => SetNonString(value); }
 
 		[Description("Request Spatial Audio")]
 		public bool RequestSpatial { get => GetNonString(defaultValue: true); set => SetNonString(value); }

--- a/Source/LibationUiBase/LibationContributor.cs
+++ b/Source/LibationUiBase/LibationContributor.cs
@@ -41,7 +41,8 @@ public class LibationContributor
 			GitHubUser("muchtall"),
 			GitHubUser("ScubyG"),
 			GitHubUser("patienttruth"),
-			GitHubUser("stickystyle")
+			GitHubUser("stickystyle"),
+			GitHubUser("cherez"),
 		]);
 
 	private LibationContributor(string name, LibationContributorType type,Uri link)

--- a/Source/LibationWinForms/Dialogs/Login/WinformLoginChoiceEager.cs
+++ b/Source/LibationWinForms/Dialogs/Login/WinformLoginChoiceEager.cs
@@ -9,17 +9,11 @@ namespace LibationWinForms.Login
 {
 	public class WinformLoginChoiceEager : WinformLoginBase, ILoginChoiceEager
 	{
-		/// <summary>Convenience method. Recommended when wiring up Winforms to <see cref="ApplicationServices.LibraryCommands.ImportAccountAsync"/></summary>
-		public static Func<Account, Task<ApiExtended>> CreateApiExtendedFunc(IWin32Window owner) => a => ApiExtendedFunc(a, owner);
-
-		private static async Task<ApiExtended> ApiExtendedFunc(Account account, IWin32Window owner)
-			=> await ApiExtended.CreateAsync(account, new WinformLoginChoiceEager(account, owner));
-
 		public ILoginCallback LoginCallback { get; private set; }
 
 		private Account _account { get; }
 
-		private WinformLoginChoiceEager(Account account, IWin32Window owner) : base(owner)
+		public WinformLoginChoiceEager(Account account, IWin32Window owner) : base(owner)
 		{
 			_account = Dinah.Core.ArgumentValidator.EnsureNotNull(account, nameof(account));
 			LoginCallback = new WinformLoginCallback(_account, owner);

--- a/Source/LibationWinForms/Dialogs/SettingsDialog.AudioSettings.cs
+++ b/Source/LibationWinForms/Dialogs/SettingsDialog.AudioSettings.cs
@@ -206,10 +206,28 @@ namespace LibationWinForms.Dialogs
 
 				if (!accounts.AccountsSettings.Accounts.Any(a => a.IdentityTokens.DeviceType == AudibleApi.Resources.DeviceType))
 				{
-					MessageBox.Show(this,
-						"Your must remove account(s) from Libation and then re-add them to enable widwvine content.",
+					var choice = MessageBox.Show(this,
+						"In order to enable widevine content, Libation will need to log into your accounts again.\r\n\r\n" +
+						"Do you want Libation to clear your current account settings and prompt you to login before the next download?",
 						"Widevine Content Unavailable",
-						MessageBoxButtons.OK);
+						MessageBoxButtons.YesNo,
+						MessageBoxIcon.Question,
+						MessageBoxDefaultButton.Button2);
+
+					if (choice == DialogResult.Yes)
+					{
+						foreach (var account in accounts.AccountsSettings.Accounts.ToArray())
+						{
+							if (account.IdentityTokens.DeviceType != AudibleApi.Resources.DeviceType)
+							{
+								accounts.AccountsSettings.Delete(account);
+								var acc = accounts.AccountsSettings.Upsert(account.AccountId, account.Locale.Name);
+								acc.AccountName = account.AccountName;
+							}
+						}
+
+						return;
+					}
 
 					useWidevineCbox.Checked = false;
 					return;

--- a/Source/LibationWinForms/Form1.ScanAuto.cs
+++ b/Source/LibationWinForms/Form1.ScanAuto.cs
@@ -32,7 +32,7 @@ namespace LibationWinForms
 				// in autoScan, new books SHALL NOT show dialog
 				try
 				{
-					Task importAsync() => LibraryCommands.ImportAccountAsync(Login.WinformLoginChoiceEager.CreateApiExtendedFunc(this), accounts);
+					Task importAsync() => LibraryCommands.ImportAccountAsync(accounts);
 					if (InvokeRequired)
 						await Invoke(importAsync);
 					else

--- a/Source/LibationWinForms/Form1.ScanManual.cs
+++ b/Source/LibationWinForms/Form1.ScanManual.cs
@@ -74,7 +74,7 @@ namespace LibationWinForms
 		{
 			try
 			{
-				var (totalProcessed, newAdded) = await LibraryCommands.ImportAccountAsync(Login.WinformLoginChoiceEager.CreateApiExtendedFunc(this), accounts);
+				var (totalProcessed, newAdded) = await LibraryCommands.ImportAccountAsync(accounts);
 
 				// this is here instead of ScanEnd so that the following is only possible when it's user-initiated, not automatic loop
 				if (Configuration.Instance.ShowImportedStats && newAdded > 0)

--- a/Source/LibationWinForms/Form1.cs
+++ b/Source/LibationWinForms/Form1.cs
@@ -4,8 +4,11 @@ using System.Linq;
 using System.Threading.Tasks;
 using System.Windows.Forms;
 using ApplicationServices;
+using AudibleUtilities;
 using DataLayer;
 using LibationFileManager;
+using LibationWinForms.Login;
+using Octokit;
 
 namespace LibationWinForms
 {
@@ -56,6 +59,7 @@ namespace LibationWinForms
 					=> Invoke(() => productsDisplay.DisplayAsync(fullLibrary));
 			}
 			Shown += Form1_Shown;
+			ApiExtended.LoginChoiceFactory = account => new WinformLoginChoiceEager(account, this);
 		}
 
 		private void Form1_FormClosing(object sender, FormClosingEventArgs e)

--- a/Source/LibationWinForms/GridView/ProductsDisplay.cs
+++ b/Source/LibationWinForms/GridView/ProductsDisplay.cs
@@ -351,7 +351,7 @@ namespace LibationWinForms.GridView
 					.Select(lbe => lbe.LibraryBook)
 					.Where(lb => !lb.Book.HasLiberated());
 
-				var removedBooks = await LibraryCommands.FindInactiveBooks(Login.WinformLoginChoiceEager.CreateApiExtendedFunc(this), lib, accounts);
+				var removedBooks = await LibraryCommands.FindInactiveBooks(lib, accounts);
 
 				var removable = allBooks.Where(lbe => removedBooks.Any(rb => rb.Book.AudibleProductId == lbe.AudibleProductId)).ToList();
 


### PR DESCRIPTION
## [Fix dash files not being saved](https://github.com/rmcrackan/Libation/commit/28ba62aead001dd0245976a0552eba8f57351f1b) (#1236)

I fixed this for aaxc files, but then broke it for dash files. It now works for all encrypted file types.

## [Pad final chapter to prevent truncation from incorrect chapter info](https://github.com/rmcrackan/Libation/commit/b11a4887d7ae919428ce7ea522440c1b444dbd7e) (#1246)

As I described in that issue, incorrect chapter markers which are shorter than the audiobook will no longer truncate the audio file.

## [Use Libation settings to decide which DRM is downloaded.](https://github.com/rmcrackan/Libation/commit/19db226f5ac778e46cf65ecc5f36820d27badff8)

Since I added the fine-grained options for downloading widevine content in 12.4, it makes sense to only use those options to dictate which content Libation tries to download. I removed the fallback to traditional ADRM. If for whatever reason widevine content becomes unavailable, users can uncheck the "Use widevine DRM" option to revert back to the ADRM-onyl downloads.

