### PR TITLE
Bugfixes and minor improvements

### DIFF
--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -15,6 +15,10 @@ on:
         description: "Skip running unit tests"
         required: false
         default: true
+      architecture:
+        type: string
+        description: "CPU architecture targeted by the build."
+        required: true
 
 env:
   DOTNET_CONFIGURATION: "Release"
@@ -22,8 +26,11 @@ env:
 
 jobs:
   build:
-    name: "${{ matrix.os }}-${{ matrix.release_name }}"
+    name: "${{ matrix.os }}-${{ matrix.release_name }}-${{ inputs.architecture }}"
     runs-on: windows-latest
+    env:
+      OUTPUT_NAME: "${{ matrix.os }}-${{ matrix.release_name }}-${{ inputs.architecture }}"
+      RUNTIME_ID: "win-${{ inputs.architecture }}"
     strategy:
       matrix:
         os: [Windows]
@@ -63,38 +70,42 @@ jobs:
         run: |
           dotnet publish `
               Libation${{ matrix.ui }}/Libation${{ matrix.ui }}.csproj `
+              --runtime ${{ env.RUNTIME_ID }} `
               --configuration ${{ env.DOTNET_CONFIGURATION }} `
-              --output bin/Publish/${{ matrix.os }}-${{ matrix.release_name }} `
+              --output bin/Publish/${{ env.OUTPUT_NAME }} `
               -p:PublishProfile=Libation${{ matrix.ui }}/Properties/PublishProfiles/${{ matrix.os }}Profile.pubxml
           dotnet publish `
               LoadByOS/${{ matrix.os }}ConfigApp/${{ matrix.os }}ConfigApp.csproj `
+              --runtime ${{ env.RUNTIME_ID }} `
               --configuration ${{ env.DOTNET_CONFIGURATION }} `
-              --output bin/Publish/${{ matrix.os }}-${{ matrix.release_name }} `
+              --output bin/Publish/${{ env.OUTPUT_NAME }} `
               -p:PublishProfile=LoadByOS/${{ matrix.os }}ConfigApp/PublishProfiles/${{ matrix.os }}Profile.pubxml
           dotnet publish `
               LibationCli/LibationCli.csproj `
+              --runtime ${{ env.RUNTIME_ID }} `
               --configuration ${{ env.DOTNET_CONFIGURATION }} `
-              --output bin/Publish/${{ matrix.os }}-${{ matrix.release_name }} `
+              --output bin/Publish/${{ env.OUTPUT_NAME }} `
               -p:DefineConstants="${{ matrix.release_name }}" `
               -p:PublishProfile=LibationCli/Properties/PublishProfiles/${{ matrix.os }}Profile.pubxml
           dotnet publish `
               Hangover${{ matrix.ui }}/Hangover${{ matrix.ui }}.csproj `
+              --runtime ${{ env.RUNTIME_ID }} `
               --configuration ${{ env.DOTNET_CONFIGURATION }} `
-              --output bin/Publish/${{ matrix.os }}-${{ matrix.release_name }} `
+              --output bin/Publish/${{ env.OUTPUT_NAME }} `
               -p:PublishProfile=Hangover${{ matrix.ui }}/Properties/PublishProfiles/${{ matrix.os }}Profile.pubxml
 
       - name: Zip artifact
         id: zip
         working-directory: ./Source/bin/Publish
         run: |
-          $bin_dir = "${{ matrix.os }}-${{ matrix.release_name }}\"
+          $bin_dir = "${{ env.OUTPUT_NAME }}\"
           $delfiles = @(
             "WindowsConfigApp.exe",
             "WindowsConfigApp.runtimeconfig.json",
             "WindowsConfigApp.deps.json"
             )
           foreach ($file in $delfiles){ if (test-path $bin_dir$file){ Remove-Item $bin_dir$file } }
-          $artifact="${{ matrix.prefix }}Libation.${{ steps.get_version.outputs.version }}-" + "${{ matrix.os }}".ToLower() + "-${{ matrix.release_name }}"
+          $artifact="${{ matrix.prefix }}Libation.${{ steps.get_version.outputs.version }}-" + "${{ matrix.os }}".ToLower() + "-${{ matrix.release_name }}-${{ inputs.architecture }}"
           "artifact=$artifact" >> $env:GITHUB_OUTPUT
           Compress-Archive -Path "${bin_dir}*" -DestinationPath "$artifact.zip"
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,10 +18,14 @@ on:
 
 jobs:
   windows:
+    strategy:
+      matrix:
+        architecture: [x64]
     uses: ./.github/workflows/build-windows.yml
     with:
       version_override: ${{ inputs.version_override }}
       run_unit_tests: ${{ inputs.run_unit_tests }}
+      architecture: ${{ matrix.architecture }}
 
   linux:
     strategy:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,7 +49,7 @@ jobs:
         id: release
         uses: softprops/action-gh-release@v2
         with:
-          name: Libation ${{ needs.prerelease.outputs.version }}
+          name: Libation v${{ needs.prerelease.outputs.version }}
           body: <Put a body here>
           token: ${{ secrets.GITHUB_TOKEN }}
           draft: true

--- a/.releaseindex.json
+++ b/.releaseindex.json
@@ -1,10 +1,10 @@
 {
-  "WindowsClassic":          "Classic-Libation\\.\\d+\\.\\d+\\.\\d+-win(dows)?-classic\\.zip",
-  "WindowsAvalonia":         "Libation\\.\\d+\\.\\d+\\.\\d+-win(dows)?-chardonnay\\.zip",
-  "LinuxAvalonia":           "Libation\\.\\d+\\.\\d+\\.\\d+-linux-chardonnay-amd64\\.deb",
-  "LinuxAvalonia_RPM":       "Libation\\.\\d+\\.\\d+\\.\\d+-linux-chardonnay-amd64\\.rpm",
-  "MacOSAvalonia":           "Libation\\.\\d+\\.\\d+\\.\\d+-macOS-chardonnay-x64\\.tgz",
-  "LinuxAvalonia_Arm64":     "Libation\\.\\d+\\.\\d+\\.\\d+-linux-chardonnay-arm64\\.deb",
-  "LinuxAvalonia_Arm64_RPM": "Libation\\.\\d+\\.\\d+\\.\\d+-linux-chardonnay-arm64\\.rpm",
-  "MacOSAvalonia_Arm64":     "Libation\\.\\d+\\.\\d+\\.\\d+-macOS-chardonnay-arm64\\.tgz"
+  "WindowsClassic":          "Classic-Libation\\.\\d+\\.\\d+\\.\\d+(?:\\.\\d+)?-win(?:dows)?-classic-x64\\.zip",
+  "WindowsAvalonia":         "Libation\\.\\d+\\.\\d+\\.\\d+(?:\\.\\d+)?-win(?:dows)?-chardonnay-x64\\.zip",
+  "LinuxAvalonia":           "Libation\\.\\d+\\.\\d+\\.\\d+(?:\\.\\d+)?-linux-chardonnay-amd64\\.deb",
+  "LinuxAvalonia_RPM":       "Libation\\.\\d+\\.\\d+\\.\\d+(?:\\.\\d+)?-linux-chardonnay-amd64\\.rpm",
+  "MacOSAvalonia":           "Libation\\.\\d+\\.\\d+\\.\\d+(?:\\.\\d+)?-macOS-chardonnay-x64\\.tgz",
+  "LinuxAvalonia_Arm64":     "Libation\\.\\d+\\.\\d+\\.\\d+(?:\\.\\d+)?-linux-chardonnay-arm64\\.deb",
+  "LinuxAvalonia_Arm64_RPM": "Libation\\.\\d+\\.\\d+\\.\\d+(?:\\.\\d+)?-linux-chardonnay-arm64\\.rpm",
+  "MacOSAvalonia_Arm64":     "Libation\\.\\d+\\.\\d+\\.\\d+(?:\\.\\d+)?-macOS-chardonnay-arm64\\.tgz"
 }

--- a/Source/AaxDecrypter/AaxDecrypter.csproj
+++ b/Source/AaxDecrypter/AaxDecrypter.csproj
@@ -13,7 +13,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-	  <PackageReference Include="AAXClean.Codecs" Version="2.0.1.2" />
+	  <PackageReference Include="AAXClean.Codecs" Version="2.0.1.3" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/Source/ApplicationServices/ApplicationServices.csproj
+++ b/Source/ApplicationServices/ApplicationServices.csproj
@@ -5,8 +5,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="CsvHelper" Version="33.0.1" />
-    <PackageReference Include="NPOI" Version="2.7.3" />
+    <PackageReference Include="CsvHelper" Version="33.1.0" />
+    <PackageReference Include="NPOI" Version="2.7.4" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Source/AudibleUtilities/AudibleUtilities.csproj
+++ b/Source/AudibleUtilities/AudibleUtilities.csproj
@@ -6,7 +6,7 @@
 
   <ItemGroup>
     <PackageReference Include="AudibleApi" Version="9.4.1.1" />
-    <PackageReference Include="Google.Protobuf" Version="3.30.2" />
+    <PackageReference Include="Google.Protobuf" Version="3.31.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Source/DataLayer/DataLayer.csproj
+++ b/Source/DataLayer/DataLayer.csproj
@@ -12,12 +12,12 @@
   <ItemGroup>
     <PackageReference Include="Dinah.Core" Version="9.0.1.1" />
     <PackageReference Include="Dinah.EntityFrameworkCore" Version="9.0.0.1" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="9.0.4">
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="9.0.7">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="9.0.4" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="9.0.4">
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="9.0.7" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="9.0.7">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/Source/FileManager/FileManager.csproj
+++ b/Source/FileManager/FileManager.csproj
@@ -6,7 +6,7 @@
 
   <ItemGroup>
     <PackageReference Include="Dinah.Core" Version="9.0.1.1" />
-    <PackageReference Include="Polly" Version="8.5.2" />
+    <PackageReference Include="Polly" Version="8.6.2" />
   </ItemGroup>
 
 	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">

--- a/Source/HangoverAvalonia/HangoverAvalonia.csproj
+++ b/Source/HangoverAvalonia/HangoverAvalonia.csproj
@@ -71,12 +71,12 @@
 	</ItemGroup>
 	<ItemGroup>
 
-		<PackageReference Include="Avalonia" Version="11.3.0" />
-		<PackageReference Include="Avalonia.Desktop" Version="11.3.0" />
+		<PackageReference Include="Avalonia" Version="11.3.2" />
+		<PackageReference Include="Avalonia.Desktop" Version="11.3.2" />
 		<!--Condition below is needed to remove Avalonia.Diagnostics package from build output in Release configuration.-->
-		<PackageReference Condition="'$(Configuration)' == 'Debug'" Include="Avalonia.Diagnostics" Version="11.3.0" />
-		<PackageReference Include="Avalonia.ReactiveUI" Version="11.3.0" />
-		<PackageReference Include="Avalonia.Themes.Fluent" Version="11.3.0" />
+		<PackageReference Condition="'$(Configuration)' == 'Debug'" Include="Avalonia.Diagnostics" Version="11.3.2" />
+		<PackageReference Include="Avalonia.ReactiveUI" Version="11.3.2" />
+		<PackageReference Include="Avalonia.Themes.Fluent" Version="11.3.2" />
 	</ItemGroup>
 	<ItemGroup>
 		<ProjectReference Include="..\HangoverBase\HangoverBase.csproj" />

--- a/Source/LibationAvalonia/Dialogs/MessageBoxWindow.axaml
+++ b/Source/LibationAvalonia/Dialogs/MessageBoxWindow.axaml
@@ -1,12 +1,13 @@
 <Window xmlns="https://github.com/avaloniaui"
 		xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
 		xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-		xmlns:vm="clr-namespace:LibationAvalonia.ViewModels"
+		xmlns:vm="clr-namespace:LibationAvalonia.ViewModels.Dialogs"
 		xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         mc:Ignorable="d" d:DesignWidth="265" d:DesignHeight="110"
 		MinWidth="265" MinHeight="110"
+		x:DataType="vm:MessageBoxViewModel"
         x:Class="LibationAvalonia.Dialogs.MessageBoxWindow"
-        Title="{Binding Caption}" ShowInTaskbar="True">
+        Title="{CompiledBinding Caption}" ShowInTaskbar="True">
 	
 	<Grid ColumnDefinitions="*" RowDefinitions="*,Auto">
 		
@@ -14,14 +15,22 @@
 			<StackPanel DockPanel.Dock="Top" Orientation="Horizontal"
 				VerticalAlignment="Top">
 			
-				<Panel Height="32" Width="32" Grid.Column="0" Margin="5,0,5,0" VerticalAlignment="Top">				
-					<Image IsVisible="{Binding IsAsterisk}" Stretch="Uniform" Source="/Assets/MBIcons/Asterisk_64.png"/>
-					<Image IsVisible="{Binding IsError}" Stretch="Uniform" Source="/Assets/MBIcons/Error_64.png"/>
-					<Image IsVisible="{Binding IsQuestion}" Stretch="Uniform" Source="/Assets/MBIcons/Question_64.png"/>
-					<Image IsVisible="{Binding IsExclamation}" Stretch="Uniform" Source="/Assets/MBIcons/Exclamation_64.png"/>
+				<Panel Height="32" Width="32" Grid.Column="0" Margin="5,0,5,0" VerticalAlignment="Top">
+					<Panel.IsVisible>
+						<MultiBinding Converter="{x:Static BoolConverters.Or}">
+							<CompiledBinding Path="IsAsterisk" />
+							<CompiledBinding Path="IsError" />
+							<CompiledBinding Path="IsQuestion" />
+							<CompiledBinding Path="IsExclamation" />
+						</MultiBinding>
+					</Panel.IsVisible>
+					<Image IsVisible="{CompiledBinding IsAsterisk}" Stretch="Uniform" Source="/Assets/MBIcons/Asterisk_64.png"/>
+					<Image IsVisible="{CompiledBinding IsError}" Stretch="Uniform" Source="/Assets/MBIcons/Error_64.png"/>
+					<Image IsVisible="{CompiledBinding IsQuestion}" Stretch="Uniform" Source="/Assets/MBIcons/Question_64.png"/>
+					<Image IsVisible="{CompiledBinding IsExclamation}" Stretch="Uniform" Source="/Assets/MBIcons/Exclamation_64.png"/>
 				</Panel>
 			
-				<TextBlock Margin="5,0,0,0" Name="messageTextBlock" MinHeight="45" MinWidth="193" TextWrapping="WrapWithOverflow" HorizontalAlignment="Left" VerticalAlignment="Top" FontSize="12" Text="{Binding Message}" />
+				<TextBlock Margin="5,0,0,0" Name="messageTextBlock" MinHeight="45" MinWidth="193" TextWrapping="WrapWithOverflow" HorizontalAlignment="Left" VerticalAlignment="Top" FontSize="12" Text="{CompiledBinding Message}" />
 
 			</StackPanel>
 		</DockPanel>
@@ -35,13 +44,13 @@
 			</DockPanel.Styles>
 			<StackPanel Orientation="Horizontal" HorizontalAlignment="Right" Margin="5" DockPanel.Dock="Bottom">
 				<Button Grid.Column="0" MinWidth="75" MinHeight="28" Name="Button1" Click="Button1_Click" Margin="5">
-					<TextBlock VerticalAlignment="Center" HorizontalAlignment="Center" Text="{Binding Button1Text}"/>
+					<TextBlock VerticalAlignment="Center" HorizontalAlignment="Center" Text="{CompiledBinding Button1Text}"/>
 				</Button>
-				<Button Grid.Column="1" IsVisible="{Binding HasButton2}" MinWidth="75" MinHeight="28" Name="Button2" Click="Button2_Click" Margin="5">
-					<TextBlock VerticalAlignment="Center" HorizontalAlignment="Center" Text="{Binding Button2Text}"/>
+				<Button Grid.Column="1" IsVisible="{CompiledBinding HasButton2}" MinWidth="75" MinHeight="28" Name="Button2" Click="Button2_Click" Margin="5">
+					<TextBlock VerticalAlignment="Center" HorizontalAlignment="Center" Text="{CompiledBinding Button2Text}"/>
 				</Button>
-				<Button Grid.Column="2" IsVisible="{Binding HasButton3}" MinWidth="75" MinHeight="28" Name="Button3" Click="Button3_Click" Margin="5">
-					<TextBlock VerticalAlignment="Center" HorizontalAlignment="Center" Text="{Binding Button3Text}"/>
+				<Button Grid.Column="2" IsVisible="{CompiledBinding HasButton3}" MinWidth="75" MinHeight="28" Name="Button3" Click="Button3_Click" Margin="5">
+					<TextBlock VerticalAlignment="Center" HorizontalAlignment="Center" Text="{CompiledBinding Button3Text}"/>
 				</Button>
 			</StackPanel>
 		</DockPanel>

--- a/Source/LibationAvalonia/LibationAvalonia.csproj
+++ b/Source/LibationAvalonia/LibationAvalonia.csproj
@@ -73,13 +73,13 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Avalonia.Controls.ColorPicker" Version="11.3.0" />
-		<PackageReference Include="Avalonia.Diagnostics" Version="11.3.0" Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'" />
-		<PackageReference Include="Avalonia" Version="11.3.0" />
-		<PackageReference Include="Avalonia.Controls.DataGrid" Version="11.3.0" />
-		<PackageReference Include="Avalonia.Desktop" Version="11.3.0" />
-		<PackageReference Include="Avalonia.ReactiveUI" Version="11.3.0" />
-		<PackageReference Include="Avalonia.Themes.Fluent" Version="11.3.0" />
+		<PackageReference Include="Avalonia.Controls.ColorPicker" Version="11.3.2" />
+		<PackageReference Include="Avalonia.Diagnostics" Version="11.3.2" Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'" />
+		<PackageReference Include="Avalonia" Version="11.3.2" />
+		<PackageReference Include="Avalonia.Controls.DataGrid" Version="11.3.2" />
+		<PackageReference Include="Avalonia.Desktop" Version="11.3.2" />
+		<PackageReference Include="Avalonia.ReactiveUI" Version="11.3.2" />
+		<PackageReference Include="Avalonia.Themes.Fluent" Version="11.3.2" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/Source/LibationAvalonia/ViewModels/MainVM.ProcessQueue.cs
+++ b/Source/LibationAvalonia/ViewModels/MainVM.ProcessQueue.cs
@@ -41,21 +41,25 @@ namespace LibationAvalonia.ViewModels
 				{
 					var item = libraryBooks[0];
 
-					//Remove this item from the queue if it's already present and completed.
-					//Only do this when adding a single book at a time to prevent accidental
-					//extra downloads when queueing in batches.
-					ProcessQueue.RemoveCompleted(item);
+					void initiateSingleDownload()
+					{
+						//Remove this item from the queue if it's already present and completed.
+						//Only do this when adding a single book at a time to prevent accidental
+						//extra downloads when queueing in batches.
+						ProcessQueue.RemoveCompleted(item);
+						setQueueCollapseState(false);
+					}
 
 					if (item.Book.UserDefinedItem.BookStatus is LiberatedStatus.NotLiberated or LiberatedStatus.PartialDownload)
 					{
+						initiateSingleDownload();
 						Serilog.Log.Logger.Information("Begin single book backup of {libraryBook}", item);
-						setQueueCollapseState(false);
 						ProcessQueue.AddDownloadDecrypt(item);
 					}
 					else if (item.Book.UserDefinedItem.PdfStatus is LiberatedStatus.NotLiberated)
 					{
+						initiateSingleDownload();
 						Serilog.Log.Logger.Information("Begin single pdf backup of {libraryBook}", item);
-						setQueueCollapseState(false);
 						ProcessQueue.AddDownloadPdf(item);
 					}
 					else if (item.Book.Audio_Exists())

--- a/Source/LibationAvalonia/Views/ProcessQueueControl.axaml
+++ b/Source/LibationAvalonia/Views/ProcessQueueControl.axaml
@@ -35,6 +35,11 @@
 							VerticalScrollBarVisibility="Auto"
 							AllowAutoHide="False">
 							<ItemsControl ItemsSource="{Binding Items}">
+								<ItemsControl.ItemsPanel>
+									<ItemsPanelTemplate>
+										<VirtualizingStackPanel />
+									</ItemsPanelTemplate>									
+								</ItemsControl.ItemsPanel>
 								<ItemsControl.ItemTemplate>
 									<DataTemplate>
 										<views:ProcessBookControl DataContext="{Binding}" />

--- a/Source/LibationFileManager/LibationFileManager.csproj
+++ b/Source/LibationFileManager/LibationFileManager.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="9.0.4" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="9.0.7" />
     <PackageReference Include="NameParserSharp" Version="1.5.0" />
     <PackageReference Include="Serilog.Exceptions" Version="8.4.0" />
   </ItemGroup>

--- a/Source/LibationUiBase/LibationUiBase.csproj
+++ b/Source/LibationUiBase/LibationUiBase.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-	<PackageReference Include="SixLabors.ImageSharp" Version="3.1.8" />
+	<PackageReference Include="SixLabors.ImageSharp" Version="3.1.10" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Source/LibationWinForms/Form1.ProcessQueue.cs
+++ b/Source/LibationWinForms/Form1.ProcessQueue.cs
@@ -31,21 +31,25 @@ namespace LibationWinForms
 				{
 					var item = libraryBooks[0];
 
-					//Remove this item from the queue if it's already present and completed.
-					//Only do this when adding a single book at a time to prevent accidental
-					//extra downloads when queueing in batches.
-					processBookQueue1.RemoveCompleted(item);
+					void initiateSingleDownload()
+					{
+						//Remove this item from the queue if it's already present and completed.
+						//Only do this when adding a single book at a time to prevent accidental
+						//extra downloads when queueing in batches.
+						processBookQueue1.RemoveCompleted(item);
+						SetQueueCollapseState(false);
+					}
 
 					if (item.Book.UserDefinedItem.BookStatus is LiberatedStatus.NotLiberated or LiberatedStatus.PartialDownload)
 					{
+						initiateSingleDownload();
 						Serilog.Log.Logger.Information("Begin single book backup of {libraryBook}", item);
-						SetQueueCollapseState(false);
 						processBookQueue1.AddDownloadDecrypt(item);
 					}
 					else if (item.Book.UserDefinedItem.PdfStatus is LiberatedStatus.NotLiberated)
 					{
+						initiateSingleDownload();
 						Serilog.Log.Logger.Information("Begin single pdf backup of {libraryBook}", item);
-						SetQueueCollapseState(false);
 						processBookQueue1.AddDownloadPdf(item);
 					}
 					else if (item.Book.Audio_Exists())

--- a/Source/LoadByOS/WindowsConfigApp/WindowsConfigApp.csproj
+++ b/Source/LoadByOS/WindowsConfigApp/WindowsConfigApp.csproj
@@ -26,7 +26,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Web.WebView2" Version="1.0.3240.44" />
+    <PackageReference Include="Microsoft.Web.WebView2" Version="1.0.3351.48" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Source/_Tests/AudibleUtilities.Tests/AudibleUtilities.Tests.csproj
+++ b/Source/_Tests/AudibleUtilities.Tests/AudibleUtilities.Tests.csproj
@@ -6,10 +6,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="FluentAssertions" Version="8.2.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="3.8.3" />
-    <PackageReference Include="MSTest.TestFramework" Version="3.8.3" />
+    <PackageReference Include="FluentAssertions" Version="8.5.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageReference Include="MSTest.TestAdapter" Version="3.9.3" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.9.3" />
     <PackageReference Include="coverlet.collector" Version="6.0.4">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/Source/_Tests/FileLiberator.Tests/FileLiberator.Tests.csproj
+++ b/Source/_Tests/FileLiberator.Tests/FileLiberator.Tests.csproj
@@ -6,10 +6,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="FluentAssertions" Version="8.2.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="3.8.3" />
-    <PackageReference Include="MSTest.TestFramework" Version="3.8.3" />
+    <PackageReference Include="FluentAssertions" Version="8.5.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageReference Include="MSTest.TestAdapter" Version="3.9.3" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.9.3" />
     <PackageReference Include="coverlet.collector" Version="6.0.4">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/Source/_Tests/FileManager.Tests/FileManager.Tests.csproj
+++ b/Source/_Tests/FileManager.Tests/FileManager.Tests.csproj
@@ -7,10 +7,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="FluentAssertions" Version="8.2.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="3.8.3" />
-    <PackageReference Include="MSTest.TestFramework" Version="3.8.3" />
+    <PackageReference Include="FluentAssertions" Version="8.5.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageReference Include="MSTest.TestAdapter" Version="3.9.3" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.9.3" />
     <PackageReference Include="coverlet.collector" Version="6.0.4">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/Source/_Tests/LibationFileManager.Tests/LibationFileManager.Tests.csproj
+++ b/Source/_Tests/LibationFileManager.Tests/LibationFileManager.Tests.csproj
@@ -7,10 +7,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="FluentAssertions" Version="8.2.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="3.8.3" />
-    <PackageReference Include="MSTest.TestFramework" Version="3.8.3" />
+    <PackageReference Include="FluentAssertions" Version="8.5.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageReference Include="MSTest.TestAdapter" Version="3.9.3" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.9.3" />
     <PackageReference Include="coverlet.collector" Version="6.0.4">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/Source/_Tests/LibationFileManager.Tests/TemplatesTests.cs
+++ b/Source/_Tests/LibationFileManager.Tests/TemplatesTests.cs
@@ -117,7 +117,6 @@ namespace TemplatesTests
 		[DataRow("<bitrate>   42   <bitrate>", "", "", "1 8 1 8")]
 		[DataRow(" <bitrate> - <bitrate> ", "", "", "1 8 - 1 8")]
 		[DataRow("4<bitrate> - <bitrate> 4", "", "", "1 8 - 1 8")]
-		[DataRow("4<bitrate> - <bitrate> 4", "", "", "1 8 - 1 8")]
 		[DataRow("<channels><channels><samplerate><channels><channels>", "", "", "100")]
 		[DataRow(" <channels> <channels> <samplerate> <channels> <channels>", "", "", "100")]
 		[DataRow(" <channels> - <channels> <samplerate> <channels> - <channels>", "", "", "- 100 -")]

--- a/Source/_Tests/LibationSearchEngine.Tests/LibationSearchEngine.Tests.csproj
+++ b/Source/_Tests/LibationSearchEngine.Tests/LibationSearchEngine.Tests.csproj
@@ -7,10 +7,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="FluentAssertions" Version="8.2.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="3.8.3" />
-    <PackageReference Include="MSTest.TestFramework" Version="3.8.3" />
+    <PackageReference Include="FluentAssertions" Version="8.5.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageReference Include="MSTest.TestAdapter" Version="3.9.3" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.9.3" />
     <PackageReference Include="coverlet.collector" Version="6.0.4">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/Source/_Tests/LibationSearchEngine.Tests/SearchEngineTests.cs
+++ b/Source/_Tests/LibationSearchEngine.Tests/SearchEngineTests.cs
@@ -61,9 +61,6 @@ namespace SearchEngineTests
 		[DataRow("AudibleProductId:B000000123", "audibleproductid:b000000123")]
 		[DataRow("ProductId:B000000123", "productid:b000000123")]
 
-		// bool keyword. Append :True
-		[DataRow("israted", "israted:True")]
-
 		// bool keyword with [:bool]. Do not add :True
 		[DataRow("israted:True", "israted:True")]
 		[DataRow("isRated:false", "israted:false")]


### PR DESCRIPTION
## [Use virtualized list to improve large queue performance](https://github.com/rmcrackan/Libation/commit/ec497f4f811f4f573c268ca2651df4a123cc638d)

A [recent change I made](https://github.com/rmcrackan/Libation/commit/0df17a2296dfbfeb3afb800a75efb15322b53307) had a side effect that would cause freezing of very large queues.

## [Fix message box text truncation when there is no icon](https://github.com/rmcrackan/Libation/commit/944645379e1ce884e2d9150325cd179370d8254c) (#1294)

## [Only remove a LibraryBook from queue if we are trying to re-download.](https://github.com/rmcrackan/Libation/commit/9f8075041bea23a2685298cfaa7665d18a4b1dd3)

Fix a UI bug that would remove a library book from the queue if a user clicked on the stoplight icon.

## [Update dependencies](https://github.com/rmcrackan/Libation/commit/9b1ce8c1d7419590410f898cab9dacf3b88dc933)

This includes an update to AAXClean which fixes the error in #1272. As I mentioned in that issue, the pictures are not copied to the decrypted file; it's audio-only for now.

## [Prepare Libation for win-arm64 releases](https://github.com/rmcrackan/Libation/commit/2191c1536d580a23db335da26f52a1eebeace012)

- Change the workflows to append the architecture to the windows build file names. (Currently only x64, but easily changable to add arm64 if I ever get around to making native win-arm64 binaries for AAXClean.Codecs.)
- Add the 'v' letter to release titles
- Update .releaseIndex.json to:
  - add support for the '-x64' architecture on windows builds
  - add support for four-part version numbers.
 
[Reduce GitHub API calls when no upgrades are available](https://github.com/rmcrackan/Libation/commit/c9af2bba4bef9a35d376df19af58e8611b883e8a)

Check the latest release's version and return early if it isn't newer than the current build.