### PR TITLE
Fix serilog dynamic assembly loading issue (#1310)

### DIFF
--- a/Source/FileLiberator/DownloadDecryptBook.cs
+++ b/Source/FileLiberator/DownloadDecryptBook.cs
@@ -118,6 +118,7 @@ namespace FileLiberator
 			}
 			catch when (cancellationToken.IsCancellationRequested)
 			{
+				Serilog.Log.Logger.Information("Download/Decrypt was cancelled. {@Book}", libraryBook.LogFriendly());
 				return new StatusHandler { "Cancelled" };
 			}
 			finally


### PR DESCRIPTION
This issue was caused because the Serilog.Sinks.ZipFile.dll was still in the program files directory, and by default Serilog tries to load all "serilog.*" dlls dynamically. The error is because Serilog uses "Assembly.Load", and that will fail if the assembly hasn't already been loaded into the AppDomain.