### PR TITLE
Bug fixes and UI tweak

### DIFF
--- a/Source/DataLayer/EfClasses/Book.cs
+++ b/Source/DataLayer/EfClasses/Book.cs
@@ -241,7 +241,7 @@ namespace DataLayer
         {
             // don't overwrite with default values
             IsAbridged |= isAbridged;
-            IsSpatial |= isSpatial ?? false;
+            IsSpatial = isSpatial ?? IsSpatial;
             DatePublished = datePublished ?? DatePublished;
             Language = language?.FirstCharToUpper() ?? Language;
         }

--- a/Source/FileLiberator/UtilityExtensions.cs
+++ b/Source/FileLiberator/UtilityExtensions.cs
@@ -5,6 +5,7 @@ using System.Threading.Tasks;
 using AudibleUtilities;
 using DataLayer;
 using Dinah.Core;
+using LibationFileManager;
 using LibationFileManager.Templates;
 
 #nullable enable
@@ -66,7 +67,7 @@ namespace FileLiberator
 				BitRate = libraryBook.Book.UserDefinedItem.LastDownloadedFormat?.BitRate,
 				SampleRate = libraryBook.Book.UserDefinedItem.LastDownloadedFormat?.SampleRate,
 				Channels = libraryBook.Book.UserDefinedItem.LastDownloadedFormat?.ChannelCount,
-				LibationVersion = libraryBook.Book.UserDefinedItem.LastDownloadedVersion?.ToString(3),
+				LibationVersion = libraryBook.Book.UserDefinedItem.LastDownloadedVersion?.ToVersionString(),
 				FileVersion = libraryBook.Book.UserDefinedItem.LastDownloadedFileVersion
 			};
 		}

--- a/Source/LibationAvalonia/Dialogs/AboutDialog.axaml.cs
+++ b/Source/LibationAvalonia/Dialogs/AboutDialog.axaml.cs
@@ -61,7 +61,7 @@ namespace LibationAvalonia.Dialogs
 		private void Link_getlibation(object sender, Avalonia.Input.TappedEventArgs e) => Dinah.Core.Go.To.Url(AppScaffolding.LibationScaffolding.WebsiteUrl);
 
 		private void ViewReleaseNotes_Tapped(object sender, Avalonia.Input.TappedEventArgs e)
-			=> Dinah.Core.Go.To.Url($"{AppScaffolding.LibationScaffolding.RepositoryUrl}/releases/tag/v{AppScaffolding.LibationScaffolding.BuildVersion.ToString(3)}");
+			=> Dinah.Core.Go.To.Url($"{AppScaffolding.LibationScaffolding.RepositoryUrl}/releases/tag/v{AppScaffolding.LibationScaffolding.BuildVersion.ToVersionString()}");
 	}
 
 	public class AboutVM : ViewModelBase

--- a/Source/LibationAvalonia/Dialogs/UpgradeNotificationDialog.axaml.cs
+++ b/Source/LibationAvalonia/Dialogs/UpgradeNotificationDialog.axaml.cs
@@ -1,6 +1,7 @@
 using AppScaffolding;
 using Avalonia.Controls;
 using Dinah.Core;
+using LibationFileManager;
 using LibationUiBase.Forms;
 
 namespace LibationAvalonia.Dialogs
@@ -30,7 +31,7 @@ namespace LibationAvalonia.Dialogs
 
 		public UpgradeNotificationDialog(UpgradeProperties upgradeProperties, bool canUpgrade) : this()
 		{
-			Title = $"Libation version {upgradeProperties.LatestRelease.ToString(3)} is now available.";
+			Title = $"Libation version {upgradeProperties.LatestRelease.ToVersionString()} is now available.";
 			PackageUrl = upgradeProperties.ZipUrl;
 			DownloadLinkText = upgradeProperties.ZipName;
 			ReleaseNotes = upgradeProperties.Notes;

--- a/Source/LibationCli/HelpVerb.cs
+++ b/Source/LibationCli/HelpVerb.cs
@@ -1,6 +1,7 @@
 ﻿using AppScaffolding;
 using CommandLine;
 using CommandLine.Text;
+using LibationFileManager;
 
 namespace LibationCli;
 
@@ -20,7 +21,7 @@ internal class HelpVerb
 	{
 		AutoVersion = false,
 		AutoHelp = false,
-		Heading = $"LibationCli v{LibationScaffolding.BuildVersion.ToString(3)}",
+		Heading = $"LibationCli v{LibationScaffolding.BuildVersion.ToVersionString()}",
 		AdditionalNewLineAfterOption = true,
 		MaximumDisplayWidth = 80
 	};

--- a/Source/LibationCli/Options/VersionOptions.cs
+++ b/Source/LibationCli/Options/VersionOptions.cs
@@ -1,5 +1,6 @@
 ﻿using AppScaffolding;
 using CommandLine;
+using LibationFileManager;
 using System;
 using System.Threading.Tasks;
 
@@ -14,7 +15,7 @@ internal class VersionOptions : OptionsBase
 	protected override Task ProcessAsync()
 	{
 		const string checkingForUpgrade = "Checking for upgrade...";
-		Console.WriteLine($"Libation {LibationScaffolding.Variety} v{LibationScaffolding.BuildVersion.ToString(3)}");
+		Console.WriteLine($"Libation {LibationScaffolding.Variety} v{LibationScaffolding.BuildVersion.ToVersionString()}");
 
 		if (CheckForUpgrade)
 		{
@@ -34,7 +35,7 @@ internal class VersionOptions : OptionsBase
 				else
 				{
 					Console.ForegroundColor = ConsoleColor.Red;
-					ReplaceConsoleText(Console.Out, checkingForUpgrade.Length, $"Upgrade Available: v{upgradeProperties.LatestRelease.ToString(3)}");
+					ReplaceConsoleText(Console.Out, checkingForUpgrade.Length, $"Upgrade Available: v{upgradeProperties.LatestRelease.ToVersionString()}");
 					Console.WriteLine();
 					Console.WriteLine();
 					Console.WriteLine(upgradeProperties.ZipUrl);

--- a/Source/LibationFileManager/Configuration.Environment.cs
+++ b/Source/LibationFileManager/Configuration.Environment.cs
@@ -16,6 +16,11 @@ namespace LibationFileManager
 		MacOS = 0x400000,
 	}
 
+	public static class Estensions
+	{
+		public static string ToVersionString(this Version version) => version.Revision > 1 ? version.ToString(4) : version.ToString(3);
+	}
+
 	public partial class Configuration
     {
 		public static bool IsWindows { get; } = OperatingSystem.IsWindows();

--- a/Source/LibationFileManager/Templates/TemplateEditor[T].cs
+++ b/Source/LibationFileManager/Templates/TemplateEditor[T].cs
@@ -70,7 +70,7 @@ namespace LibationFileManager.Templates
 				Narrators = [new("Stephen Fry", null)],
 				Series = [new("Sherlock Holmes", 1, "B08376S3R2"), new("Some Other Series", 1, "B000000000")],
 				Codec = "AAC-LC",
-				LibationVersion = Configuration.LibationVersion?.ToString(3),
+				LibationVersion = Configuration.LibationVersion?.ToVersionString(),
 				FileVersion = "36217811",
 				BitRate = 128,
 				SampleRate = 44100,

--- a/Source/LibationUiBase/GridView/GridEntry.cs
+++ b/Source/LibationUiBase/GridView/GridEntry.cs
@@ -210,6 +210,24 @@ namespace LibationUiBase.GridView
 			nameof(IsSpatial) => IsSpatial,
 			_ => null
 		};
+		
+		public bool MemberValueIsDefault(string memberName) => memberName switch
+		{
+			nameof(Series) => Book.SeriesLink?.Any() is not true,
+			nameof(SeriesOrder) => string.IsNullOrWhiteSpace(SeriesOrder.OrderString),
+			nameof(MyRating) => RatingIsDefault(Book.UserDefinedItem.Rating),
+			nameof(ProductRating) => RatingIsDefault(Book.Rating),
+			nameof(Authors) => string.IsNullOrWhiteSpace(Authors),
+			nameof(Narrators) => string.IsNullOrWhiteSpace(Narrators),
+			nameof(Description) => string.IsNullOrWhiteSpace(Description),
+			nameof(Category) => string.IsNullOrWhiteSpace(Category),
+			nameof(Misc) => string.IsNullOrWhiteSpace(Misc),
+			nameof(BookTags) => string.IsNullOrWhiteSpace(BookTags),
+			_ => false
+		};
+
+		private static bool RatingIsDefault(Rating rating)
+			=> rating is null || (rating.OverallRating == 0 && rating.PerformanceRating == 0 && rating.StoryRating == 0);
 
 		public IComparer GetMemberComparer(Type memberType)
 			=> memberTypeComparers.TryGetValue(memberType, out IComparer value) ? value : memberTypeComparers[memberType.BaseType];
@@ -340,7 +358,6 @@ namespace LibationUiBase.GridView
 
 			return (await Task.WhenAll(tasks)).SelectMany(a => a).ToList();
 		}
-
 
 		~GridEntry()
 		{

--- a/Source/LibationUiBase/GridView/LastDownloadStatus.cs
+++ b/Source/LibationUiBase/GridView/LastDownloadStatus.cs
@@ -1,4 +1,5 @@
 ﻿using DataLayer;
+using LibationFileManager;
 using System;
 
 namespace LibationUiBase.GridView
@@ -10,7 +11,7 @@ namespace LibationUiBase.GridView
 		public string LastDownloadedFileVersion { get; }
 		public Version LastDownloadedVersion { get; }
 		public DateTime? LastDownloaded { get; }
-		public string ToolTipText => IsValid ? $"Double click to open v{LastDownloadedVersion.ToString(3)} release notes" : "";
+		public string ToolTipText => IsValid ? $"Double click to open v{LastDownloadedVersion.ToVersionString()} release notes" : "";
 
 		public LastDownloadStatus() { }
 		public LastDownloadStatus(UserDefinedItem udi)
@@ -24,14 +25,14 @@ namespace LibationUiBase.GridView
 		public void OpenReleaseUrl()
 		{
 			if (IsValid)
-				Dinah.Core.Go.To.Url($"{AppScaffolding.LibationScaffolding.RepositoryUrl}/releases/tag/v{LastDownloadedVersion.ToString(3)}");
+				Dinah.Core.Go.To.Url($"{AppScaffolding.LibationScaffolding.RepositoryUrl}/releases/tag/v{LastDownloadedVersion.ToVersionString()}");
 		}
 
 		public override string ToString()
 			=> IsValid ? $"""
 				{dateString()} {versionString()}
 				{LastDownloadedFormat}
-				Libation v{LastDownloadedVersion.ToString(3)}
+				Libation v{LastDownloadedVersion.ToVersionString()}
 				""" : "";
 
 		private string versionString() => LastDownloadedFileVersion is string ver ? $"(File v.{ver})" : "";

--- a/Source/LibationUiBase/GridView/RowComparerBase.cs
+++ b/Source/LibationUiBase/GridView/RowComparerBase.cs
@@ -21,15 +21,24 @@ namespace LibationUiBase.GridView
 
 		private int InternalCompare(GridEntry x, GridEntry y)
 		{
-			var val1 = x.GetMemberValue(PropertyName);
-			var val2 = y.GetMemberValue(PropertyName);
+			//Default values (e.g. empty strings) always sort to the end of the list.
+			var val1IsDefault = x.MemberValueIsDefault(PropertyName);
+			var val2IsDefault = y.MemberValueIsDefault(PropertyName);
 
-			var compare = x.GetMemberComparer(val1.GetType()).Compare(val1, val2);
+			if (val1IsDefault && val2IsDefault) return 0;
+			else if (val1IsDefault && !val2IsDefault) return GetSortOrder() is ListSortDirection.Ascending ? 1 : -1;
+			else if (!val1IsDefault && val2IsDefault) return GetSortOrder() is ListSortDirection.Ascending ? -1 : 1;
+			else
+			{
+				var val1 = x.GetMemberValue(PropertyName);
+				var val2 = y.GetMemberValue(PropertyName);
+				var compare = x.GetMemberComparer(val1.GetType()).Compare(val1, val2);
 
-			return compare == 0 && x.Liberate.IsSeries && y.Liberate.IsSeries
-				//Both a and b are series parents and compare as equal, so break the tie.
-				? x.AudibleProductId.CompareTo(y.AudibleProductId)
-				: compare;
+				return compare == 0 && x.Liberate.IsSeries && y.Liberate.IsSeries
+					//Both a and b are series parents and compare as equal, so break the tie.
+					? x.AudibleProductId.CompareTo(y.AudibleProductId)
+					: compare;
+			}
 		}
 
 		public int Compare(GridEntry? geA, GridEntry? geB)

--- a/Source/LibationWinForms/Dialogs/AboutDialog.cs
+++ b/Source/LibationWinForms/Dialogs/AboutDialog.cs
@@ -1,4 +1,5 @@
-﻿using LibationUiBase;
+﻿using LibationFileManager;
+using LibationUiBase;
 using System;
 using System.Linq;
 using System.Threading.Tasks;
@@ -38,7 +39,7 @@ namespace LibationWinForms.Dialogs
 		}
 
 		private void releaseNotesLbl_LinkClicked(object sender, LinkLabelLinkClickedEventArgs e)
-			=> Dinah.Core.Go.To.Url($"{AppScaffolding.LibationScaffolding.RepositoryUrl}/releases/tag/v{AppScaffolding.LibationScaffolding.BuildVersion.ToString(3)}");
+			=> Dinah.Core.Go.To.Url($"{AppScaffolding.LibationScaffolding.RepositoryUrl}/releases/tag/v{AppScaffolding.LibationScaffolding.BuildVersion.ToVersionString()}");
 
 		private async void checkForUpgradeBtn_Click(object sender, EventArgs e)
 		{

--- a/Source/LibationWinForms/Dialogs/UpgradeNotificationDialog.cs
+++ b/Source/LibationWinForms/Dialogs/UpgradeNotificationDialog.cs
@@ -18,7 +18,7 @@ namespace LibationWinForms.Dialogs
 
 		public UpgradeNotificationDialog(UpgradeProperties upgradeProperties) : this()
 		{
-			Text = $"Libation version {upgradeProperties.LatestRelease.ToString(3)} is now available.";
+			Text = $"Libation version {upgradeProperties.LatestRelease.ToVersionString()} is now available.";
 			PackageUrl = upgradeProperties.ZipUrl;
 			packageDlLink.Text = upgradeProperties.ZipName;
 			releaseNotesTbox.Text = upgradeProperties.Notes;			


### PR DESCRIPTION
## [Use proper version string based on build version](https://github.com/rmcrackan/Libation/commit/ca30fd41c61ef5a6d7b834261a31f608942e4fc2)


As discussed in #1315. Replace all occurances of `Version.ToString(3)` with the new [ToVersionString()](https://github.com/rmcrackan/Libation/commit/ca30fd41c61ef5a6d7b834261a31f608942e4fc2#diff-0f16187976135e5a266335124db620240b42af316ddc58cc5856b46085ada45cR21) extension method.

## [Sort columns with null values always at the bottom](https://github.com/rmcrackan/Libation/commit/9bca84dca459712928f734afaad5eb1ac24e8004)

As discussed in #1273, sort null properties at the bottom of the columns.

## [Set IsSpatial field instead of only flipping to true](https://github.com/rmcrackan/Libation/commit/0e4231906a474460bb5bec6b77adedc18231b808) (#1273)

Fix the IsSpatial field not being updated properly. Thankfully it is already a nullable bool, so false really means it's not spatial.