### PR TITLE
Place examples in their own line

### DIFF
--- a/Documentation/NamingTemplates.md
+++ b/Documentation/NamingTemplates.md
@@ -94,8 +94,11 @@ As an example, this folder template will place all Liberated podcasts into a "Po
 `<if podcast->Podcasts<-if podcast><!if podcast->Books<-if podcast>\<title>`
 
 This example will add a number if the `<series#\>` tag has a value:
+
 `<has series#><series#><-has>`
+
 And this example will customize the title based on whether the book has a subtitle:
+
 `<audible title><has audible subtitle->-<audible subtitle><-has>`
 
 # Tag Formatters


### PR DESCRIPTION
Markdown collapses single line breaks, so this change makes it so the examples will have their own lines. This helps readers of the documentation to quickly understand what the actual templating syntax is.

| Before | After |
| ------- | ------- |
| <img alt="before" src="https://github.com/user-attachments/assets/39753dfd-90d5-4647-9a12-0ed220c37d3a" /> | <img alt="after" src="https://github.com/user-attachments/assets/d83c4a8b-2632-44dd-b50c-32c0e45e3f41" /> |
