### PR TITLE
Fix database lock from -wal and -whm files

### DIFF
--- a/Source/AppScaffolding/LibationScaffolding.cs
+++ b/Source/AppScaffolding/LibationScaffolding.cs
@@ -90,6 +90,7 @@ namespace AppScaffolding
 			{
 				config.LoadPersistentSettings(config.LibationFiles.SettingsFilePath);
 			}
+			DeleteOpenSqliteFiles(config);
 			AudibleApiStorage.EnsureAccountsSettingsFileExists();
 
 			//
@@ -100,6 +101,19 @@ namespace AppScaffolding
             Migrations.migrate_to_v11_5_0(config);
 			Migrations.migrate_to_v11_6_5(config);
 			Migrations.migrate_to_v12_0_1(config);
+		}
+
+		/// <summary>
+		/// Delete shared memory and write-ahead log SQLite database files which may prevent access to the database.
+		/// </summary>
+		private static void DeleteOpenSqliteFiles(Configuration config)
+		{
+			var walFile = SqliteStorage.DatabasePath + "-wal";
+			var shmFile = SqliteStorage.DatabasePath + "-shm";
+			if (File.Exists(walFile))
+				FileManager.FileUtility.SaferDelete(walFile);
+			if (File.Exists(shmFile))
+				FileManager.FileUtility.SaferDelete(shmFile);
 		}
 
 		/// <summary>Initialize logging. Wire-up events. Run after migration</summary>

--- a/Source/LibationFileManager/SqliteStorage.cs
+++ b/Source/LibationFileManager/SqliteStorage.cs
@@ -5,7 +5,7 @@ namespace LibationFileManager
 	public static class SqliteStorage
 	{
 		// not customizable. don't move to config
-		private static string databasePath => Path.Combine(Configuration.Instance.LibationFiles.Location, "LibationContext.db");
-		public static string ConnectionString => $"Data Source={databasePath};Foreign Keys=False;Pooling=False;";
+		public static string DatabasePath => Path.Combine(Configuration.Instance.LibationFiles.Location, "LibationContext.db");
+		public static string ConnectionString => $"Data Source={DatabasePath};Foreign Keys=False;Pooling=False;";
 	}
 }


### PR DESCRIPTION
Delete LibationContext.db-shm and LibationContext.db-wal files as part of startup routine.

This addresses issues #1338, #1417, and #1365.