### PR TITLE
Add AppImage installation instructions

### DIFF
--- a/docs/installation/linux.md
+++ b/docs/installation/linux.md
@@ -31,6 +31,18 @@ sudo dnf5 install ./libation.rpm
 
 ---
 
+### AppImage
+
+- Install via [AppMan](https://github.com/ivan-hc/AppMan) (rootless)
+  ```bash
+  appman -i libation
+  ```
+- Install via [AM](https://github.com/ivan-hc/AM)
+  ```bash
+  am -i libation
+  ```
+Thanks to Package Forge dev [Samuel](https://github.com/Samueru-sama) for [AppImage](https://github.com/pkgforge-dev/Libation-AppImage) maintenence.
+  
 ### Arch Linux
 
 ```bash
@@ -76,6 +88,7 @@ Pacstall is the AUR Ubuntu wishes it had. It takes the concept of the AUR and pu
 ```bash
 pacstall -I libation-deb
 ```
+Thanks to [Tobias Heinlein](https://github.com/niontrix) for Pacstall package maintenance.
 
 ---
 


### PR DESCRIPTION
Added installation instructions for AppImage using AppMan/AM.
There are multiple ways to update AppImage e.g. via [AppImageLauncher](https://github.com/TheAssassin/AppImageLauncher) , [AppImageUpdate](https://github.com/AppImageCommunity/AppImageUpdate). But only mentioned AppMan/AM as it's a package manager. Others require manual interventions.

In nixos case we recommend `nix-shell` as 1st choice similar way in this case `appman` (rootless) is recommended.