### PR TITLE
fixed quoting errors in format-strings

### DIFF
--- a/Source/FileManager/NamingTemplate/CommonFormatters.cs
+++ b/Source/FileManager/NamingTemplate/CommonFormatters.cs
@@ -236,7 +236,7 @@ public static partial class CommonFormatters
 					i++;
 				}
 
-				i--; // skipped one to much as outer loop advances as well
+				i--; // skipped one too much as outer loop advances as well
 				continue;
 			}
 

--- a/Source/FileManager/NamingTemplate/CommonFormatters.cs
+++ b/Source/FileManager/NamingTemplate/CommonFormatters.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Globalization;
+using System.Text;
 using System.Text.RegularExpressions;
 using System.Threading;
 
@@ -67,7 +68,7 @@ public static partial class CommonFormatters
 		// is this function is called from toString implementation of the IFormattable interface, we only get a IFormatProvider
 		var culture = GetCultureInfo(provider);
 		var oldUiCulture = Thread.CurrentThread.CurrentUICulture;
-		var result = CollapseSpacesAndTrimRegex().Replace(TagFormatRegex().Replace(templateString, GetValueForMatchingTag), "");
+		var result = CollapseSpacesAndTrimRegex().Replace(TagFormatRegex().ReplaceWithGaps(templateString, GetValueForMatchingTag, Unescape), "");
 		Thread.CurrentThread.CurrentUICulture = oldUiCulture;
 		return result;
 
@@ -103,7 +104,24 @@ public static partial class CommonFormatters
 	// The tagname may be followed by an optional format specifier separated by a colon.
 	// All other parts of the template string are left untouched as well as the braces where the tagname is unknown.
 	// TemplateStringFormatter will use a dictionary to lookup the tagname and the corresponding value getter.
-	[GeneratedRegex("""\{(?<tag>[A-Z0-9]+|#)(?:@(?<lang>[a-z-]+))?(?::(?<format>(?:\\.|'(?:[^']|'')*'|"(?:[^"]|"")*"|.)*?))?\}""", RegexOptions.IgnoreCase)]
+	[GeneratedRegex("""
+	                (?x)                          # option x: ignore all unescaped whitespace in pattern and allow comments starting with #
+	                (?<=\G(?:                     # We lookbehind up to the start or the end of the last match for a tag format.
+	                    \\.                       # - '\' escapes always the next character. Especially further '\' and the opening '{'
+	                    | '[^']*'                 # - allow 'string' to be included in the format, with '' being an escaped ' character
+	                    | "[^"]*"                 # - allow "string" to be included in the format, with "" being an escaped " character
+	                    | [^\\'"]                 # - match any other character. This will not catch the tag format at first. Because ...
+	                ) *? )                        # With *? the pattern above tries not to consume the tag format.
+	                \{ (?<tag> [A-Z0-9]+ | \#)    # Capture the tags name as '<tag>'. It is always enclosed in '{' and '}'. It may only contain letters and numbers or be a single '#'.
+	                    (?:@(?<lang>[a-z-]+))?    # Introduced by '@' the tag name may optionally be followed by a language specifier captured in a group called '<lang>'.
+	                    (?::(?<format>(?:
+	                        \\.                   # - '\' escapes always the next character. Especially further '\' and the closing '}'
+	                        | '[^']*'             # - allow 'string' to be included in the format
+	                        | "[^"]*"             # - allow "string" to be included in the format
+	                        | .
+	                    ) *? ))?
+	                \}
+	                """, RegexOptions.IgnoreCase)]
 	public static partial Regex TagFormatRegex();
 
 	public static string FormattableFormatter(ITemplateTag _, IFormattable? value, string? formatString, CultureInfo? culture)
@@ -171,38 +189,98 @@ public static partial class CommonFormatters
 		return StringFormatter(templateTag, language, "3u", culture);
 	}
 
+	public static string Unescape(string valueSpan)
+	{
+		return Unescape(valueSpan, ['\'', '"']);
+	}
+
+	public static string Unescape(ReadOnlySpan<char> valueSpan, ReadOnlySpan<char> quoteChars, bool unquoteBackslash = true, bool unescapeDoubleQuotesInsideQuotes = true)
+	{
+		if (valueSpan.IsEmpty) return "";
+		
+		Span<char> search = stackalloc char[quoteChars.Length + 1];
+		search[0] = '\\';
+		quoteChars.CopyTo(search[1..]);
+
+		var first = valueSpan.IndexOfAny(search);
+		if (first < 0)
+			return valueSpan.ToString();
+
+		var sb = new StringBuilder(valueSpan.Length);
+		sb.Append(valueSpan[..first]);
+		for (var i = first; i < valueSpan.Length; i++)
+		{
+			var c = valueSpan[i];
+
+			// scan quotation
+			if (quoteChars.Contains(c))
+			{
+				i++; // skip quote
+
+				while (i < valueSpan.Length)
+				{
+					var inner = valueSpan[i];
+
+					// closing quote?
+					if (inner == c)
+					{
+						i++; // skip
+						if (!unescapeDoubleQuotesInsideQuotes ||
+						    i >= valueSpan.Length ||
+						    valueSpan[i] != c)
+							// end block if no 2nd quote follows or doubled quotes don't have special meaning 
+							break;
+					}
+
+					sb.Append(inner);
+					i++;
+				}
+
+				i--; // skipped one to much as outer loop advances as well
+				continue;
+			}
+
+			if (c == '\\' && unquoteBackslash && i + 1 < valueSpan.Length)
+				i++; // skip backslash and take the next char
+
+			sb.Append(valueSpan[i]);
+		}
+
+		return sb.ToString();
+	}
+
 	// These search for number formats with all notions of escaping and quoting, but all zeros replaced with D, H, or M to indicate that they should be replaced with the total number of
 	// days hours or minutes in the timespan (not just the minutes part). Only one of them is written commented. The others are identical except for the letter D, H or M.
 	// I most cases this regex will only find a straight bunch of D's, H's or M's, but it also allows for more complex formats.
 	[GeneratedRegex("""
-	                (?x)                          # option x: ignore all unescaped whitespace in pattern and allow comments starting with #
-	                (?<=\G(?:                     # We lookbehind up to the start or the end of the last match for a number format.
-	                    \\.                       # - '\' escapes always the next character. Especially further '\' and the closing ']'
-	                    | '(?:[^']|'')*'          # - allow 'string' to be included in the format, with '' being an escaped ' character
-	                    | "(?:[^"]|"")*"          # - allow "string" to be included in the format, with "" being an escaped " character
-	                    | .                       # - match any character. This will not catch the number format at first. Because ...
-	                ) *? )                        # With *? the pattern above tries not to consume the number format.
-	                (?<format>                    # We capture the whole number format in a group called '<format>'.
-	                    (?:\#[\#,.]*)?            # - For grouping a number format may start with `#` and grouping hints `,` or even a decimal point `.`.
-	                    D                         # - At least one unescaped, unquoted uppercase D must be included in the format to indicate that this is a total days format.
-	                    (?:(?:                    # - Before further D's, there may be any combination of escaped characters and quoted strings.
-	                            \\.               # - '\' escapes always the next character. Especially further '\' and the closing ']' 
-	                            | '(?:[^']|'')*'  # - allow 'string' to be included in the format, with '' being an escaped ' character 
-	                            | "(?:[^"]|"")*"  # - allow "string" to be included in the format, with "" being an escaped " character 
-	                        )* [\#,.%‰D]+         # After escaped characters and quoted strings, there needs to be at least one more real number format character (which may be D as well).
-	                    )*                        # This may extend the format several times, for example in `D\:DD` or `D' days 'D\-D`.
-	                    (?:[Ee][+-]?0+)?          # The original number format may end with an optional scientific notation part. This is also optional.
-	                )                             # end of capture group '<format>'
+	                (?x)                   # option x: ignore all unescaped whitespace in pattern and allow comments starting with #
+	                (?<=\G(?:              # We lookbehind up to the start or the end of the last match for a number format.
+	                    \\.                # - '\' escapes always the next character. Especially further '\'
+	                    | '[^']*'          # - allow 'string' to be included in the format
+	                    | "[^"]*"          # - allow "string" to be included in the format
+	                    | [^\\'"]          # - match any other character. This will not catch the number format at first. Because ...
+	                ) *? )                 # With *? the pattern above tries not to consume the number format.
+	                (?<format>             # We capture the whole number format in a group called '<format>'.
+	                    (?:\#[\#,.]*)?     # - For grouping a number format may start with `#` and grouping hints `,` or even a decimal point `.`.
+	                    D                  # - At least one unescaped, unquoted uppercase D must be included in the format to indicate that this is a total days format.
+	                    (?:(?:             # - Before further D's, there may be any combination of escaped characters and quoted strings.
+	                            \\.        # - '\' escapes always the next character. Especially further '\' and the closing ']' 
+	                            | '[^']*'  # - allow 'string' to be included in the format 
+	                            | "[^"]*"  # - allow "string" to be included in the format 
+	                        )* [D%‰\#,.]+  # After escaped characters and quoted strings, there needs to be at least one more real number format character (which may be D as well).
+	                    )*                 # This may extend the format several times, for example in `D\:DD` or `D' days 'D\-D`.
+	                    (?:[Ee][+-]?0+)?   # The original number format may end with an optional scientific notation part. This is also optional.
+	                )                      # end of capture group '<format>'
 	                """)]
 	private static partial Regex RegexMinutesTotalD();
 
-	[GeneratedRegex("""(?<=\G(?:\\.|'(?:[^']|'')*'|"(?:[^"]|"")*"|.)*?)(?<format>(?:#[#,.]*)?H(?:(?:\\.|'(?:[^']|'')*'|"(?:[^"]|"")*")*[H%‰#,.]+)*(?:[Ee][+-]?0+)?)""")]
+	[GeneratedRegex("""(?<=\G(?:\\.|'[^']*'|"[^"]*"|[^\\'"])*?)(?<format>(?:#[#,.]*)?H(?:(?:\\.|'[^']*'|"[^"]*")*[H%‰#,.]+)*(?:[Ee][+-]?0+)?)""")]
 	private static partial Regex RegexMinutesTotalH();
 
-	[GeneratedRegex("""(?<=\G(?:\\.|'(?:[^']|'')*'|"(?:[^"]|"")*"|.)*?)(?<format>(?:#[#,.]*)?M(?:(?:\\.|'(?:[^']|'')*'|"(?:[^"]|"")*")*[M%‰#,.]+)*(?:[Ee][+-]?0+)?)""")]
+	[GeneratedRegex("""(?<=\G(?:\\.|'[^']*'|"[^"]*"|[^\\'"])*?)(?<format>(?:#[#,.]*)?M(?:(?:\\.|'[^']*'|"[^"]*")*[M%‰#,.]+)*(?:[Ee][+-]?0+)?)""")]
 	private static partial Regex RegexMinutesTotalM();
 
 	// Capture all D H or M characters in the number format, so that they can be replaced with zeros.
-	[GeneratedRegex("""(?<=\G(?:\\.|'(?:[^']|'')*'|"(?:[^"]|"")*"|.)*?)[DHM]""")]
+	[GeneratedRegex("""(?<=\G(?:\\.|'[^']*'|"[^"]*"|.)*?)[DHM]""")]
 	private static partial Regex RegexTimeStampToNumberPattern();
 }

--- a/Source/FileManager/NamingTemplate/ConditionalTagCollection[TClass].cs
+++ b/Source/FileManager/NamingTemplate/ConditionalTagCollection[TClass].cs
@@ -219,7 +219,7 @@ public partial class ConditionalTagCollection<TClass>(bool caseSensitive = true)
 				});
 
 			var match = GetMatch(exactName, checkString);
-			var valStr = Unescape(match.Groups["val"]);
+			var valStr = match.UnescapeValue("val");
 			var (evaluator, opGroup) = GetPredicate(exactName, match);
 
 			return (opGroup.Name switch

--- a/Source/FileManager/NamingTemplate/ConditionalTagCollection[TClass].cs
+++ b/Source/FileManager/NamingTemplate/ConditionalTagCollection[TClass].cs
@@ -262,7 +262,7 @@ public partial class ConditionalTagCollection<TClass>(bool caseSensitive = true)
 
 		private static ConditionEvaluator GetPredicateForNumOp(string _, ReadOnlySpan<char> opString)
 		{
-			Func<int?, int?, CultureInfo?, bool> checkInt = opString switch
+			Func<int, int, CultureInfo?, bool> checkInt = opString switch
 			{
 				"#=" => (v1, v2, _) => v1 == v2,
 				"#!=" or "≠" or "≠" => (v1, v2, _) => v1 != v2,
@@ -488,7 +488,7 @@ public partial class ConditionalTagCollection<TClass>(bool caseSensitive = true)
 
 		[GeneratedRegex("""
 		                (?x)                       # option x: ignore all unescaped whitespace in pattern and allow comments starting with #
-		                ^(?>(?<op>(?<list_op>      # anchor at start of line. capture operator in <op>, <list_op> and <num_op> with every char escapable
+		                ^(?>(?<op>(?<list_op>      # anchor at start of line. Capture operator in <op>, <list_op> and <num_op> with every char escapable
 		                          ≡ |  == |      :equals:           # - list operators: ≡ for checking if two lists contain the same items regardless of order
 		                        | ∌ | !>> | ∌  | :not_contains:     # - list operators: ∌ for checking if the first list does not contain any item of the second list
 		                        | ∋ |  >> |      :contains:         # - list operators: ∋ for checking if the first list contains all items of the second list
@@ -509,7 +509,7 @@ public partial class ConditionalTagCollection<TClass>(bool caseSensitive = true)
 		                (?<val>(?(num_op)          # capture value in <val>
 		                	(?:\d)+                # - numerical operators have to be followed by a number
 		                	| (?:\\.|[^\\])+ )     # - string for comparison. May be empty. Capturing also all whitespace up to the end as this must have been escaped.
-		                )?$                         # match to the end
+		                )?$                        # match to the end
 		                """)]
 		private static partial Regex CheckRegex();
 	}

--- a/Source/FileManager/NamingTemplate/PropertyTagCollection[TClass].cs
+++ b/Source/FileManager/NamingTemplate/PropertyTagCollection[TClass].cs
@@ -189,17 +189,18 @@ public class PropertyTagCollection<TClass> : TagCollection
 			: base(templateTag, propertyGetter)
 		{
 			NameMatcher = new Regex($"""
-			                         (?x)                         # option x: ignore all unescaped whitespace in pattern and allow comments starting with #
-			                         ^<                           # tags start with a '<'
-			                         {TagNameForRegex()}          # next the tagname needs to be matched with space being made optional. Also escape all '#'
-			                         (?:\s*                       # optional whitespace
-			                             \[  (?<format>           # optional format details enclosed in '[' and ']'. Capture inner part as <format>.
-			                                     (?:\\.           # - '\' escapes always the next character. Especially further '\' and the closing ']'
-			                                     |'(?:[^']|'')*'  # - allow 'string' to be included in the format, with '' being an escaped ' character
-			                                     |"(?:[^"]|"")*"  # - allow "string" to be included in the format, with "" being an escaped " character
-			                                     |[^\\\]])* )     # - match any character except '\' and ']'. Format may end in whitespace!
-			                             \]                       # - closing the format part
-			                         )?\s*>                       # Tags end with '>'
+			                         (?x)                      # option x: ignore all unescaped whitespace in pattern and allow comments starting with #
+			                         ^<                        # tags start with a '<'
+			                         {TagNameForRegex()}       # next the tagname needs to be matched with space being made optional. Also escape all '#'
+			                         (?:\s*                    # optional whitespace
+			                             \[  (?<format> (?:    # optional format details enclosed in '[' and ']'. Capture inner part as <format>.
+			                                     \\.           # - '\' escapes always the next character. Especially further '\' and the closing ']'
+			                                     | '[^']*'     # - allow 'string' to be included in the format
+			                                     | "[^"]*"     # - allow "string" to be included in the format
+			                                     | [^'"\\\]]   # - match any character except '\' and ']'. Format may end in whitespace!
+			                                 ) * )             # extend up to the next ']'
+			                             \]                    # - closing the format part
+			                         )?\s*>                    # Tags end with '>'
 			                         """
 				, options);
 

--- a/Source/FileManager/NamingTemplate/RegExpExtensions.cs
+++ b/Source/FileManager/NamingTemplate/RegExpExtensions.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Diagnostics.CodeAnalysis;
+using System.Text;
 using System.Text.RegularExpressions;
 
 namespace FileManager.NamingTemplate;
@@ -9,6 +10,8 @@ public static class RegExpExtensions
 	extension(Group group)
 	{
 		public string? ValueOrNull() => group.Success ? group.Value : null;
+		public string? UnescapeValueOrNull() => group.Success ? CommonFormatters.Unescape(group.ValueSpan, []) : null;
+		public string UnescapeValue() => group.Success ? CommonFormatters.Unescape(group.ValueSpan, []) : string.Empty;
 		public ReadOnlySpan<char> ValueSpanOrNull() => group.Success ? group.ValueSpan : null;
 	}
 
@@ -29,6 +32,9 @@ public static class RegExpExtensions
 
 			return int.TryParse(span, out value);
 		}
+
+		public string UnescapeValue(string? groupName = null) => match.Resolve(groupName).UnescapeValue();
+		public string? UnescapeValueOrNull(string? groupName = null) => match.Resolve(groupName).UnescapeValueOrNull();
 	}
 
 	extension(Regex regex)
@@ -43,6 +49,30 @@ public static class RegExpExtensions
 			var m = regex.Match(input);
 			match = m.Success ? m : null;
 			return m.Success;
+		}
+
+		public string ReplaceWithGaps(string input, MatchEvaluator matchEvaluator, Func<string, string> gapEvaluator)
+		{
+			var sb = new StringBuilder(input.Length);
+			var pos = 0;
+
+			foreach (Match m in regex.Matches(input))
+			{
+				// part before match
+				if (m.Index > pos)
+					sb.Append(gapEvaluator(input[pos .. m.Index]));
+
+				// the match itself
+				sb.Append(matchEvaluator(m));
+
+				pos = m.Index + m.Length;
+			}
+
+			// part after last match
+			if (pos < input.Length)
+				sb.Append(gapEvaluator(input[pos..]));
+
+			return sb.ToString();
 		}
 	}
 }

--- a/Source/FileManager/NamingTemplate/TagBase.cs
+++ b/Source/FileManager/NamingTemplate/TagBase.cs
@@ -69,31 +69,6 @@ internal abstract class TagBase(ITemplateTag templateTag, Expression propertyExp
 		return TemplateTag.TagName.Replace(" ", @"\s*").Replace("#", @"\#");
 	}
 
-	protected static string? Unescape(Group? group)
-	{
-		return group?.Success ?? false ? Unescape(group.ValueSpan) : null;
-	}
-
-	protected static string Unescape(ReadOnlySpan<char> valueSpan)
-	{
-		if (valueSpan.IsEmpty) return "";
-
-		var first = valueSpan.IndexOf('\\');
-		if (first < 0)
-			return valueSpan.ToString();
-
-		var sb = new StringBuilder(valueSpan.Length);
-		sb.Append(valueSpan[..first]);
-		for (var i = first; i < valueSpan.Length; i++)
-		{
-			if (valueSpan[i] == '\\' && i + 1 < valueSpan.Length)
-				i++; // skip backslash and take the next char
-			sb.Append(valueSpan[i]);
-		}
-
-		return sb.ToString();
-	}
-
 	public override string ToString()
 	{
 		return $"[Name = {TemplateTag.TagName}, Type = {ReturnType.Name}]";

--- a/Source/LibationFileManager/Templates/IListFormat[TList].cs
+++ b/Source/LibationFileManager/Templates/IListFormat[TList].cs
@@ -53,7 +53,7 @@ internal partial interface IListFormat<TList> where TList : IListFormat<TList>
 	{
 		if (formatString is null) return items.Select(n => n.ToString(null, culture));
 		var format = TList.FormatRegex().Match(formatString).ResolveValue("format");
-		var separator = SeparatorRegex().Match(formatString).ResolveValue("separator");
+		var separator = SeparatorRegex().Match(formatString).UnescapeValueOrNull("separator");
 		var formattedItems = FilteredList(formatString, items).Select(ItemFormatter);
 
 		if (separator is null) return formattedItems;
@@ -96,6 +96,6 @@ internal partial interface IListFormat<TList> where TList : IListFormat<TList>
 	private static partial Regex MaxRegex();
 
 	/// <summary> Separator can be anything </summary>
-	[GeneratedRegex(@"[Ss]eparator\((?<separator>.*?)\)")]
+	[GeneratedRegex("""[Ss]eparator\((?<separator>(?:\\.|'[^']*'|"[^"]*"|[^\\'"])*?)\)""")]
 	private static partial Regex SeparatorRegex();
 }

--- a/Source/LibationFileManager/Templates/NameListFormat.cs
+++ b/Source/LibationFileManager/Templates/NameListFormat.cs
@@ -53,6 +53,6 @@ internal partial class NameListFormat : IListFormat<NameListFormat>
 	private static partial Regex SortTokenizer();
 
 	/// <summary> Format must have at least one of the strings {T}, {F}, {M}, {L}, {S}, or {ID} (optionally with formatting like {L:u})</summary>
-	[GeneratedRegex($@"[Ff]ormat\((?<format>.*?\{{{Token}(?::.*?)?\}}.*?)\)")]
+	[GeneratedRegex($$"""[Ff]ormat\((?<format>(?:\\.|'[^']*'|"[^"]*"|[^\\'"])*?\{{{Token}}(?::.*?)?\}(?:\\.|'[^']*'|"[^"]*"|[^\\'"])*?)\)""")]
 	public static partial Regex FormatRegex();
 }

--- a/Source/LibationFileManager/Templates/SeriesListFormat.cs
+++ b/Source/LibationFileManager/Templates/SeriesListFormat.cs
@@ -53,6 +53,6 @@ internal partial class SeriesListFormat : IListFormat<SeriesListFormat>
 	private static partial Regex SortTokenizer();
 
 	/// <summary> Format must have at least one of the strings {N}, {#}, {ID} (optionally with formatting like {N:u})</summary>
-	[GeneratedRegex($@"[Ff]ormat\((?<format>.*?\{{{Token}(?::.*?)?\}}.*?)\)")]
+	[GeneratedRegex($$"""[Ff]ormat\((?<format>(?:\\.|'[^']*'|""[^""]*""|[^\\'""])*?\{{{Token}}(?::.*?)?\}(?:\\.|'[^']*'|""[^""]*""|[^\\'""])*?)\)""")]
 	public static partial Regex FormatRegex();
 }

--- a/Source/LibationFileManager/Templates/StringListFormat.cs
+++ b/Source/LibationFileManager/Templates/StringListFormat.cs
@@ -53,6 +53,6 @@ internal partial class StringListFormat : IListFormat<StringListFormat>
 	private static partial Regex SortTokenizer();
 
 	/// <summary> Format must have the string {S} (optionally with formatting like {S:u})</summary>
-	[GeneratedRegex($@"[Ff]ormat\((?<format>.*?\{{{Token}(?::.*?)?\}}.*?)\)")]
+	[GeneratedRegex($$"""[Ff]ormat\((?<format>(?:\\.|'[^']*'|"[^"]*"|[^\\'"])*?\{{{Token}}(?::.*?)?\}(?:\\.|'[^']*'|"[^"]*"|[^\\'"])*?)\)""")]
 	public static partial Regex FormatRegex();
 }

--- a/Source/_Tests/FileManager.Tests/CommonFormattersTests.cs
+++ b/Source/_Tests/FileManager.Tests/CommonFormattersTests.cs
@@ -304,6 +304,25 @@ public class CommonFormattersTests
 		Assert.AreEqual("DE", result); // Uppercase, no trim needed
 	}
 
+	[TestMethod]
+	[DataRow("""es\caped chara\cters: \'\"\"\'""", """escaped characters: '""'""")]
+	[DataRow("""e"sca'p'ed" "\st""ri""ng" """, """esca'p'ed \st"ri"ng """)]
+	[DataRow("""e'sca"p"ed' '\st''ri''ng'""", """esca"p"ed \st'ri'ng""")]
+	[DataRow("""open 'esc"a"pe""", """open esc"a"pe""")]
+	[DataRow("""open 'esc"a"pe''""", """open esc"a"pe'""")]
+	[DataRow("""open "esc'a'pe""", "open esc'a'pe")]
+	public void Unescape_Test(string input, string expected)
+	{
+		// GIVEN
+
+		// WHEN
+		var unescaped = CommonFormatters.Unescape(input);
+
+		// THEN
+		Assert.AreEqual(expected, unescaped);
+	}
+	
+
 	private class TestClass
 	{
 		public string? Author { get; set; }

--- a/Source/_Tests/LibationFileManager.Tests/TemplatesTests.cs
+++ b/Source/_Tests/LibationFileManager.Tests/TemplatesTests.cs
@@ -210,9 +210,10 @@ namespace TemplatesTests
 		[DataRow(@"<minutes[D\-M]>", 100, "0-100")]
 		[DataRow(@"<minutes[D\-M]>", 1500, "1-60")]
 		[DataRow(@"<minutes[D\-M]>", 2000, "1-560")]
-		[DataRow(@"<minutes[D\-M]>", 2880, "2-0")]
+		[DataRow(@"<minutes[D'-'M]>", 2880, "2-0")]
 		[DataRow(@"<minutes[DD\-MM]>", 1500, "01-60")]
-		[DataRow(@"<minutes[D\-MMM'{'MM\}]>", 2000, "1-005{60}")]
+		[DataRow("""""<minutes[D\-MMM'{'''MM""""\}]>""""", 2000, "1-005{60}")]
+		[DataRow("""<minutes['no '\D' or H'" and no M "m]>""", 2000, "no D or H and no M 20")]
 		public void MinutesFormat(string template, int minutes, string expected)
 		{
 			var bookDto = GetLibraryBook();
@@ -412,9 +413,13 @@ namespace TemplatesTests
 		//Jon Bon Jovi and Paul Van Doren don't have middle names, so they are sorted to the top.
 		//Since only the middle names of the first 2 names are to be displayed, the name string is empty.
 		[DataRow("<author[sort(M) max(2) separator(; ) format({M})]>", ";")]
+		[DataRow("<author[max(1) format(foo)]>", "Jill Conner Browne")]
+		[DataRow("<author[max(1) format('{M}')]>", "Jill Conner Browne")]
+		[DataRow(@"(<author[separator(\)() format(')['{M}\]\()]>)", "()[Conner]()()[E.]()()[John]()()[Maud]()()[]()()[]()()[]()")]
 		[DataRow("<first author>", "Jill Conner Browne")]
 		[DataRow("<first author[]>", "Jill Conner Browne")]
 		[DataRow("<first author[{L}, {F}]>", "Browne, Jill")]
+		[DataRow("""<first author[\{L}:{L}, '{F}:'{F}, "{M}:"{M}]>""", "{L}:Browne, {F}:Jill, {M}:Conner")]
 		public void NameFormat_formatters(string template, string expected)
 		{
 			var bookDto = GetLibraryBook();
@@ -431,8 +436,7 @@ namespace TemplatesTests
 
 			Templates.TryGetTemplate<Templates.FileTemplate>(template, out var fileTemplate).Should().BeTrue();
 			fileTemplate
-				.GetFilename(bookDto, "", "", culture: null, replacements: Replacements)
-				.PathWithoutPrefix
+				.GetName(bookDto, new MultiConvertFileProperties { OutputFileName = string.Empty })
 				.Should().Be(expected);
 		}
 


### PR DESCRIPTION
Format string in `<author>`, `<narrator>`, `<series>`, and `<tag>` as well as `<first author>`, etc., using a format template where placeholders like `{A}` will be replaced.
These patterns are enclosed by `[...]`, and on lists, there is also `format(...)` surrounding the template.

To specify brackets inside the template, you would need to escape them `\(\{\[` or `"]})"` as an example.

Implementing some tests revealed some bugs. Tests and bug fixes are part of this PR.

Also:
* moved `Unescape()` to `CommonFormatter`
* reduced and fixed patterns like `(?:\\.|'(?:[^']|'')*'|"(?:[^"]|"")*"|.)*?` to `(?:\\.|'[^']*'|"[^"]*"|[^\\'"])*?`
  as there is no need to explicitly capture double quotechars.