### PR TITLE
Add native macOS "Check for Updates…" menu item

### DIFF
--- a/Source/LibationAvalonia/Dialogs/AboutDialog.axaml
+++ b/Source/LibationAvalonia/Dialogs/AboutDialog.axaml
@@ -15,7 +15,7 @@
 
 		<controls:LinkLabel Grid.Row="1" FontSize="14" VerticalAlignment="Center" Text="https://getlibation.com" Tapped="Link_getlibation"/>
 		
-		<Button Grid.Row="2" HorizontalAlignment="Stretch" HorizontalContentAlignment="Center" Margin="0,10,0,0"  IsEnabled="{Binding CanCheckForUpgrade}" Content="{Binding UpgradeButtonText}" Click="CheckForUpgrade_Click" />
+		<Button Grid.Row="2" HorizontalAlignment="Stretch" HorizontalContentAlignment="Center" Margin="0,10,0,0"  IsEnabled="{Binding UpdateChecker.CanCheckForUpgrade}" Content="{Binding UpdateChecker.UpgradeButtonText}" Click="CheckForUpgrade_Click" />
 
 		<Canvas Grid.Row="3" Margin="0,30,0,20" Width="280" Height="220">
 			<Path Stretch="None" Fill="{DynamicResource IconFill}" Data="{DynamicResource LibationCheersIcon}">

--- a/Source/LibationAvalonia/Dialogs/AboutDialog.axaml.cs
+++ b/Source/LibationAvalonia/Dialogs/AboutDialog.axaml.cs
@@ -14,42 +14,22 @@ namespace LibationAvalonia.Dialogs;
 public partial class AboutDialog : DialogWindow
 {
 	private readonly AboutVM _viewModel;
-	public AboutDialog() : base(saveAndRestorePosition: false)
+
+	/// <summary>
+	/// Accepts an optional shared update checker so the About dialog can reflect the same in-flight state
+	/// and outcome text as the native macOS "Check for Updates…" menu item.
+	/// </summary>
+	public AboutDialog(UpdateCheckViewModel? updateChecker = null) : base(saveAndRestorePosition: false)
 	{
 		InitializeComponent();
 
-		DataContext = _viewModel = new AboutVM();
+		DataContext = _viewModel = new AboutVM(updateChecker);
 	}
 
 	private async void CheckForUpgrade_Click(object sender, Avalonia.Interactivity.RoutedEventArgs e)
 	{
 		var mainWindow = Owner as Views.MainWindow;
-
-		var upgrader = new Upgrader();
-		upgrader.DownloadProgress += async (_, e) => await Avalonia.Threading.Dispatcher.UIThread.InvokeAsync(() => mainWindow?.ViewModel?.DownloadProgress = e.ProgressPercentage);
-		upgrader.DownloadCompleted += async (_, _) => await Avalonia.Threading.Dispatcher.UIThread.InvokeAsync(() => mainWindow?.ViewModel?.DownloadProgress = null);
-
-		_viewModel.CanCheckForUpgrade = false;
-		Version? latestVersion = null;
-		var result = await upgrader.CheckForUpgradeAsync(OnUpgradeAvailable);
-
-		_viewModel.CanCheckForUpgrade = true;
-		_viewModel.UpgradeButtonText = result.Outcome switch
-		{
-			VersionCheckOutcome.UpToDate => "Libation is up to date. Check Again.",
-			VersionCheckOutcome.UnableToDetermine => "Unable to check for updates. Try again later.",
-			VersionCheckOutcome.UpdateAvailable when result.UpgradeProperties is { } p => $"Version {p.LatestRelease:3} is available",
-			_ => "Check for Upgrade"
-		};
-
-		async Task OnUpgradeAvailable(UpgradeEventArgs e)
-		{
-			var notificationResult = await new UpgradeNotificationDialog(e.UpgradeProperties, e.CapUpgrade).ShowDialogAsync(this);
-
-			e.Ignore = notificationResult == DialogResult.Ignore;
-			e.InstallUpgrade = notificationResult == DialogResult.OK;
-			latestVersion = e.UpgradeProperties.LatestRelease;
-		}
+		await _viewModel.UpdateChecker.CheckForUpgradeAsync(this, mainWindow);
 	}
 
 	private void ContributorLink_Tapped(object sender, Avalonia.Input.TappedEventArgs e)
@@ -69,14 +49,18 @@ public partial class AboutDialog : DialogWindow
 public class AboutVM : ViewModelBase
 {
 	public string Version { get; }
-	public bool CanCheckForUpgrade { get => field; set => this.RaiseAndSetIfChanged(ref field, value); } = true;
-	public string UpgradeButtonText { get => field; set => this.RaiseAndSetIfChanged(ref field, value); } = "Check for Upgrade";
+
+	/// <summary>
+	/// Shared manual update-check state used by the About button and, on macOS, the app-menu entry.
+	/// </summary>
+	public UpdateCheckViewModel UpdateChecker { get; }
 
 	public IEnumerable<LibationContributor> PrimaryContributors => LibationContributor.PrimaryContributors;
 	public IEnumerable<LibationContributor> AdditionalContributors => LibationContributor.AdditionalContributors;
 
-	public AboutVM()
+	public AboutVM(UpdateCheckViewModel? updateChecker = null)
 	{
+		UpdateChecker = updateChecker ?? new UpdateCheckViewModel();
 		Version = $"Libation {AppScaffolding.LibationScaffolding.Variety} v{AppScaffolding.LibationScaffolding.BuildVersion}";
 	}
 }

--- a/Source/LibationAvalonia/ViewModels/MainVM.Settings.cs
+++ b/Source/LibationAvalonia/ViewModels/MainVM.Settings.cs
@@ -2,6 +2,7 @@
 using LibationFileManager;
 using ReactiveUI;
 using System;
+using System.Linq;
 using System.Threading.Tasks;
 
 namespace LibationAvalonia.ViewModels;
@@ -12,12 +13,41 @@ partial class MainVM
 	public bool MenuBarVisible { get => field; set => this.RaiseAndSetIfChanged(ref field, value); } = !Configuration.IsMacOs;
 	private void Configure_Settings()
 	{
-		if (App.Current is Avalonia.Application app &&
-			NativeMenu.GetMenu(app)?.Items[0] is NativeMenuItem aboutMenu)
+		if (App.Current is not Avalonia.Application app || NativeMenu.GetMenu(app) is not NativeMenu nativeAppMenu)
+			return;
+
+		// Avalonia provides the first native app-menu item on macOS, but we replace its command so it opens
+		// Libation's About dialog instead of a no-op/default implementation.
+		if (nativeAppMenu.Items.Count > 0 && nativeAppMenu.Items[0] is NativeMenuItem aboutMenu)
 			aboutMenu.Command = ReactiveCommand.Create(ShowAboutAsync);
+
+		if (!Configuration.IsMacOs)
+			return;
+
+		var checkForUpdatesMenuItem = nativeAppMenu.Items
+			.OfType<NativeMenuItem>()
+			.FirstOrDefault(item => string.Equals(item.Header?.ToString(), "Check for Updates…", StringComparison.Ordinal));
+
+		if (checkForUpdatesMenuItem is null)
+		{
+			checkForUpdatesMenuItem = new NativeMenuItem
+			{
+				Header = "Check for Updates…",
+				Command = ReactiveCommand.CreateFromTask(CheckForUpdatesAsync)
+			};
+			// Keep the native-style update entry close to About, where macOS users expect to find it.
+			nativeAppMenu.Items.Insert(1, checkForUpdatesMenuItem);
+		}
+
+		UpdateChecker.AttachNativeMenuItem(checkForUpdatesMenuItem);
 	}
 
-	public Task ShowAboutAsync() => new LibationAvalonia.Dialogs.AboutDialog().ShowDialog(MainWindow);
+	/// <summary>
+	/// Manual update checks use the main window both as the dialog owner and as the surface for the shared
+	/// bottom status-bar progress indicator.
+	/// </summary>
+	public Task CheckForUpdatesAsync() => UpdateChecker.CheckForUpgradeAsync(MainWindow, MainWindow);
+	public Task ShowAboutAsync() => new LibationAvalonia.Dialogs.AboutDialog(UpdateChecker).ShowDialog(MainWindow);
 	public Task ShowAccountsAsync() => new LibationAvalonia.Dialogs.AccountsDialog().ShowDialog(MainWindow);
 	public Task ShowSettingsAsync() => new LibationAvalonia.Dialogs.SettingsDialog().ShowDialog(MainWindow);
 	public Task ShowTrashBinAsync() => new LibationAvalonia.Dialogs.TrashBinDialog().ShowDialog(MainWindow);

--- a/Source/LibationAvalonia/ViewModels/MainVM.cs
+++ b/Source/LibationAvalonia/ViewModels/MainVM.cs
@@ -14,6 +14,7 @@ public partial class MainVM : ViewModelBase
 	public Task? BindToGridTask { get; set; }
 	public ProcessQueueViewModel ProcessQueue { get; } = new ProcessQueueViewModel();
 	public ProductsDisplayViewModel ProductsDisplay { get; } = new() { SearchEngine = MainSearchEngine.Instance };
+	public UpdateCheckViewModel UpdateChecker { get; } = new();
 
 	public double? DownloadProgress { get => field; set => this.RaiseAndSetIfChanged(ref field, value); }
 

--- a/Source/LibationAvalonia/ViewModels/UpdateCheckViewModel.cs
+++ b/Source/LibationAvalonia/ViewModels/UpdateCheckViewModel.cs
@@ -1,0 +1,90 @@
+using AppScaffolding;
+using Avalonia.Controls;
+using Avalonia.Threading;
+using LibationAvalonia.Dialogs;
+using LibationAvalonia.Views;
+using LibationUiBase;
+using LibationUiBase.Forms;
+using System.Threading.Tasks;
+
+namespace LibationAvalonia.ViewModels;
+
+/// <summary>
+/// Coordinates the Avalonia-only "check for updates" UX so the About dialog and the macOS app menu
+/// share the same in-flight state, status text, and upgrade prompt behavior.
+/// </summary>
+public class UpdateCheckViewModel : ViewModelBase
+{
+	private NativeMenuItem? nativeMenuItem;
+
+	/// <summary>
+	/// Prevents overlapping release checks from the About dialog button and the native macOS menu item.
+	/// </summary>
+	public bool CanCheckForUpgrade
+	{
+		get => field;
+		private set
+		{
+			this.RaiseAndSetIfChanged(ref field, value);
+			// Native menu items are not data-bound, so keep the macOS app-menu item in sync manually.
+			if (nativeMenuItem is not null)
+				nativeMenuItem.IsEnabled = value;
+		}
+	} = true;
+
+	/// <summary>
+	/// Mirrors the existing About dialog button copy so manual checks can report the most recent outcome.
+	/// </summary>
+	public string UpgradeButtonText { get => field; private set => this.RaiseAndSetIfChanged(ref field, value); } = "Check for Upgrade";
+
+	/// <summary>
+	/// Registers the native macOS app-menu item so its enabled state tracks the shared update-check state.
+	/// </summary>
+	public void AttachNativeMenuItem(NativeMenuItem menuItem)
+	{
+		nativeMenuItem = menuItem;
+		nativeMenuItem.IsEnabled = CanCheckForUpgrade;
+	}
+
+	/// <summary>
+	/// Runs a user-initiated update check and, when a new release is available, presents the existing
+	/// upgrade dialog owned by <paramref name="owner"/>. <paramref name="mainWindow"/> is optional so
+	/// callers can still forward progress to the main window's status bar when available.
+	/// </summary>
+	public async Task CheckForUpgradeAsync(Window owner, MainWindow? mainWindow = null)
+	{
+		if (!CanCheckForUpgrade)
+			return;
+
+		CanCheckForUpgrade = false;
+
+		var upgrader = new Upgrader();
+		upgrader.DownloadProgress += async (_, e) => await Dispatcher.UIThread.InvokeAsync(() => mainWindow?.ViewModel?.DownloadProgress = e.ProgressPercentage);
+		upgrader.DownloadCompleted += async (_, _) => await Dispatcher.UIThread.InvokeAsync(() => mainWindow?.ViewModel?.DownloadProgress = null);
+		upgrader.UpgradeFailed += async (_, _) => await Dispatcher.UIThread.InvokeAsync(() => mainWindow?.ViewModel?.DownloadProgress = null);
+
+		try
+		{
+			var result = await upgrader.CheckForUpgradeAsync(OnUpgradeAvailable);
+			UpgradeButtonText = result.Outcome switch
+			{
+				VersionCheckOutcome.UpToDate => "Libation is up to date. Check Again.",
+				VersionCheckOutcome.UnableToDetermine => "Unable to check for updates. Try again later.",
+				VersionCheckOutcome.UpdateAvailable when result.UpgradeProperties is { } p => $"Version {p.LatestRelease:3} is available",
+				_ => "Check for Upgrade"
+			};
+		}
+		finally
+		{
+			CanCheckForUpgrade = true;
+		}
+
+		async Task OnUpgradeAvailable(UpgradeEventArgs e)
+		{
+			var notificationResult = await new UpgradeNotificationDialog(e.UpgradeProperties, e.CapUpgrade).ShowDialogAsync(owner);
+
+			e.Ignore = notificationResult == DialogResult.Ignore;
+			e.InstallUpgrade = notificationResult == DialogResult.OK;
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- add a native macOS `Check for Updates…` app-menu item near `About`
- route manual update checks through a shared Avalonia update-check view model
- reuse that shared state in the About dialog so button text and in-flight state stay consistent
- add targeted documentation around the shared updater/menu wiring

## Notes
- non-macOS behavior is unchanged

## Manual verification
- confirm `Libation > Check for Updates…` appears on macOS
- confirm it opens the same update flow as About
- confirm repeated clicks during an active check do not stack
- confirm `About Libation` still works