### PR TITLE
#1744 Make Explorer folder icons reliable

### DIFF
--- a/Source/FileLiberator/DownloadDecryptBook.cs
+++ b/Source/FileLiberator/DownloadDecryptBook.cs
@@ -79,7 +79,8 @@ public class DownloadDecryptBook : AudioDecodable, IProcessable<DownloadDecryptB
 			//Verbose logging inside getDestinationDirectory
 			var finalStorageDir = getDestinationDirectory(libraryBook);
 
-			//post-download tasks done in parallel.
+			// Post-download tasks (parallel). Folder icon runs afterward so it does not race cover/metadata work
+			// or a still-warming Amazon image cache for the 300x300 asset.
 			Serilog.Log.Verbose("Starting post-liberation finalization tasks");
 			var moveFilesTask = Task.Run(() => MoveFilesToBooksDir(libraryBook, finalStorageDir, result.ResultFiles, cancellationToken));
 			Task[] finalTasks =
@@ -88,7 +89,6 @@ public class DownloadDecryptBook : AudioDecodable, IProcessable<DownloadDecryptB
 				Task.Run(() => DownloadCoverArt(finalStorageDir, downloadOptions, cancellationToken)),
 				Task.Run(() => DownloadRecordsAsync(api, finalStorageDir, downloadOptions, cancellationToken)),
 				Task.Run(() => DownloadMetadataAsync(api, finalStorageDir, downloadOptions, cancellationToken)),
-				Task.Run(() => WindowsDirectory.SetCoverAsFolderIcon(libraryBook.Book.PictureId, finalStorageDir, cancellationToken))
 			];
 
 			try
@@ -99,25 +99,25 @@ public class DownloadDecryptBook : AudioDecodable, IProcessable<DownloadDecryptB
 			catch (Exception ex)
 			{
 				Serilog.Log.Verbose(ex, "An error occurred in the post-liberation finalization tasks");
-				//Swallow DownloadCoverArt, DownloadRecordsAsync, DownloadMetadataAsync, and SetCoverAsFolderIcon exceptions.
+				//Swallow DownloadCoverArt, DownloadRecordsAsync, and DownloadMetadataAsync exceptions.
 				//Only fail if the downloaded audio files failed to move to Books directory
 				if (moveFilesTask.IsFaulted)
 					throw;
 			}
-			finally
+
+			if (moveFilesTask.IsCompletedSuccessfully && !cancellationToken.IsCancellationRequested)
 			{
-				if (moveFilesTask.IsCompletedSuccessfully && !cancellationToken.IsCancellationRequested)
+				await Task.Run(() => WindowsDirectory.SetCoverAsFolderIcon(libraryBook.Book.PictureId, finalStorageDir, cancellationToken), cancellationToken);
+
+				Serilog.Log.Verbose("Updating liberated status for {@Book}", libraryBook.LogFriendly());
+				await libraryBook.UpdateBookStatusAsync(LiberatedStatus.Liberated, Configuration.LibationVersion, audioFormat, audioVersion);
+				Serilog.Log.Verbose("Setting directory time for {@Book}", libraryBook.LogFriendly());
+				SetDirectoryTime(libraryBook, finalStorageDir);
+				Serilog.Log.Verbose("Deleting cache files for {@Book}", libraryBook.LogFriendly());
+				foreach (var cacheFile in result.CacheFiles.Where(f => File.Exists(f.FilePath)))
 				{
-					Serilog.Log.Verbose("Updating liberated status for {@Book}", libraryBook.LogFriendly());
-					await libraryBook.UpdateBookStatusAsync(LiberatedStatus.Liberated, Configuration.LibationVersion, audioFormat, audioVersion);
-					Serilog.Log.Verbose("Setting directory time for {@Book}", libraryBook.LogFriendly());
-					SetDirectoryTime(libraryBook, finalStorageDir);
-					Serilog.Log.Verbose("Deleting cache files for {@Book}", libraryBook.LogFriendly());
-					foreach (var cacheFile in result.CacheFiles.Where(f => File.Exists(f.FilePath)))
-					{
-						//Delete cache files only after the download/decrypt operation completes successfully.
-						FileUtility.SaferDelete(cacheFile.FilePath);
-					}
+					//Delete cache files only after the download/decrypt operation completes successfully.
+					FileUtility.SaferDelete(cacheFile.FilePath);
 				}
 			}
 

--- a/Source/LibationFileManager/WindowsDirectory.cs
+++ b/Source/LibationFileManager/WindowsDirectory.cs
@@ -5,43 +5,83 @@ namespace LibationFileManager;
 
 public static class WindowsDirectory
 {
+	const int FolderIconMaxAttempts = 5;
+
 	public static void SetCoverAsFolderIcon(string? pictureId, string directory, CancellationToken cancellationToken)
-	{
-		try
+    {
+        //Currently only works for Windows and macOS
+        if (!Configuration.Instance.UseCoverAsFolderIcon)
+			return;
+		if (string.IsNullOrEmpty(pictureId))
 		{
-			//Currently only works for Windows and macOS
-			if (!Configuration.Instance.UseCoverAsFolderIcon)
-				return;
-			if (string.IsNullOrEmpty(pictureId))
-			{
-				Serilog.Log.Logger.Warning("No picture ID provided to set cover art as folder icon. {@DebugInfo}", new { directory });
-				return;
-			}
+			Serilog.Log.Logger.Warning("No picture ID provided to set cover art as folder icon. {@DebugInfo}", new { directory });
+			return;
+        }
 
-			// Load JPEG bytes from Images cache (or download). Prefer bytes → ICO so we never depend on a
-			// path that might not exist when Amazon omits Content-Length or another downloader left a stale cache entry.
-			var jpegBytes = PictureStorage.GetPictureSynchronously(new(pictureId, PictureSize._300x300), cancellationToken);
-			if (jpegBytes.Length == 0)
-			{
-				Serilog.Log.Logger.Warning("Cover art unavailable for folder icon (empty image). {@DebugInfo}", new { directory, pictureId });
-				return;
-			}
+        // Load JPEG bytes from Images cache (or download). Prefer bytes → ICO so we never depend on a
+        // path that might not exist when Amazon omits Content-Length or another downloader left a stale cache entry.
 
-			InteropFactory.Create().SetFolderIcon(imageJpegBytes: jpegBytes, directory: directory);
-		}
-		catch (Exception ex)
+        for (var attempt = 1; attempt <= FolderIconMaxAttempts; attempt++)
 		{
-			// Failure to 'set cover as folder icon' should not be considered a failure to download the book
-			Serilog.Log.Logger.Error(ex, "Error setting cover art as folder icon. {@DebugInfo}", new { directory });
+			cancellationToken.ThrowIfCancellationRequested();
 
 			try
 			{
-				InteropFactory.Create().DeleteFolderIcon(directory);
+				var jpegBytes = PictureStorage.GetPictureSynchronously(new(pictureId, PictureSize._300x300), cancellationToken);
+				if (jpegBytes.Length == 0)
+				{
+					if (attempt < FolderIconMaxAttempts)
+					{
+						Serilog.Log.Logger.Debug("Folder icon: empty 300x300 image on attempt {Attempt}/{Max}; retrying after delay. {@DebugInfo}", attempt, FolderIconMaxAttempts, new { directory, pictureId });
+						DelayBetweenFolderIconRetries(cancellationToken, attempt);
+						continue;
+					}
+
+					Serilog.Log.Logger.Warning(
+						"Could not set Explorer folder icon after {MaxAttempts} attempts: the 300x300 cover image never became available (empty or missing). The audiobook download itself is unaffected. Check your network to Amazon images, disk space under Libation's Images folder, or try liberating again. {@DebugInfo}",
+						FolderIconMaxAttempts, new { directory, pictureId });
+					TryDeleteFolderIcon(directory);
+					return;
+				}
+
+				InteropFactory.Create().SetFolderIcon(imageJpegBytes: jpegBytes, directory: directory);
+				return;
 			}
-			catch
+			catch (Exception ex)
 			{
-				Serilog.Log.Logger.Error(ex, "Error rolling back: setting cover art as folder icon. {@DebugInfo}", new { directory });
+				if (attempt < FolderIconMaxAttempts)
+				{
+					Serilog.Log.Logger.Debug(ex, "Folder icon: attempt {Attempt}/{Max} failed; retrying after delay. {@DebugInfo}", attempt, FolderIconMaxAttempts, new { directory, pictureId });
+					DelayBetweenFolderIconRetries(cancellationToken, attempt);
+					continue;
+				}
+
+				Serilog.Log.Logger.Error(ex,
+					"Could not set Explorer folder icon after {MaxAttempts} attempts (decode, ICO conversion, or writing desktop.ini/Icon.ico failed). The audiobook download itself should still be fine; try liberating again, or check folder permissions if the library is on removable media. {@DebugInfo}",
+					FolderIconMaxAttempts, new { directory, pictureId });
+				TryDeleteFolderIcon(directory);
+				return;
 			}
+		}
+	}
+
+	static void DelayBetweenFolderIconRetries(CancellationToken cancellationToken, int attemptAfterFailure)
+	{
+		// 100, 200, 400, 800 ms; bounded backoff without Task.Delay allocation on hot path
+		var ms = 100 * (1 << (attemptAfterFailure - 1));
+		if (ms > 0)
+			cancellationToken.WaitHandle.WaitOne(ms);
+	}
+
+	static void TryDeleteFolderIcon(string directory)
+	{
+		try
+		{
+			InteropFactory.Create().DeleteFolderIcon(directory);
+		}
+		catch (Exception ex)
+		{
+			Serilog.Log.Logger.Error(ex, "Error rolling back folder icon files. {@DebugInfo}", new { directory });
 		}
 	}
 }


### PR DESCRIPTION
#1744 Make Explorer folder icons reliable by running them after other post-download work, retrying briefly when the 300×300 cover or ICO write fails, and logging clear, actionable messages when it still cannot succeed.