### PR TITLE
#1711 : Linux/Docker: the default in-progress download/decrypt folder…

### DIFF
--- a/Source/LibationFileManager/AudibleFileStorage.cs
+++ b/Source/LibationFileManager/AudibleFileStorage.cs
@@ -31,14 +31,39 @@ public abstract class AudibleFileStorage
 	{
 		try
 		{
-			return (DateTime.UtcNow - lastInProgressFail) < RetryInProgressInterval ? null
-				: new DirectoryInfo(Configuration.Instance.InProgress).CreateSubdirectoryEx(subDirectory);
+			if ((DateTime.UtcNow - lastInProgressFail) < RetryInProgressInterval)
+				return null;
+
+			var parent = new DirectoryInfo(Configuration.Instance.InProgress);
+			var dir = parent.CreateSubdirectoryEx(subDirectory);
+
+			// On Unix, lock down the parent and the subdir to the current user (0700).
+			// Prevents other local users from reading partial downloads / decrypted artifacts
+			// when InProgress lives on a world-traversable filesystem like /tmp.
+			TrySetOwnerOnlyMode(parent.FullName);
+			TrySetOwnerOnlyMode(dir.FullName);
+
+			return dir;
 		}
 		catch (Exception ex)
 		{
 			Serilog.Log.Error(ex, "Error creating subdirectory in {InProgress}", Configuration.Instance.InProgress);
 			lastInProgressFail = DateTime.UtcNow;
 			return null;
+		}
+	}
+
+	private static void TrySetOwnerOnlyMode(string path)
+	{
+		if (OperatingSystem.IsWindows())
+			return;
+		try
+		{
+			File.SetUnixFileMode(path, UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute);
+		}
+		catch
+		{
+			// best-effort. user may have intentionally set their own perms, or the FS may not support it.
 		}
 	}
 

--- a/Source/LibationFileManager/Configuration.KnownDirectories.cs
+++ b/Source/LibationFileManager/Configuration.KnownDirectories.cs
@@ -13,7 +13,10 @@ public partial class Configuration
 	public static string AppDir_Absolute => Path.GetFullPath(Path.Combine(ProcessDirectory, LibationFiles.LIBATION_FILES_KEY));
 	public static string MyDocs => Path.GetFullPath(Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments), "Libation"));
 	public static string MyMusic => Path.GetFullPath(Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.MyMusic), "Libation"));
-	public static string WinTemp => Path.GetFullPath(Path.Combine(Path.GetTempPath(), "Libation"));
+	// Use a per-user subdir so we don't collide with -- or get blocked by -- another local
+	// user's leftover dir on shared-/tmp systems (Linux). On Windows and macOS, GetTempPath
+	// already returns a per-user location, so this is just a harmless extra path segment.
+	public static string WinTemp => Path.GetFullPath(Path.Combine(Path.GetTempPath(), $"Libation-{Environment.UserName}"));
 	public static string UserProfile => Path.GetFullPath(Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), "Libation"));
 	public static string LocalAppData => Path.GetFullPath(Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "Libation"));
 

--- a/Source/LibationUiBase/Upgrader.cs
+++ b/Source/LibationUiBase/Upgrader.cs
@@ -62,8 +62,9 @@ public class Upgrader : UpgraderBase
 		}
 
 		//Silently download the upgrade in the background, save it to a temp file.
-
-		var zipFile = Path.Combine(Path.GetTempPath(), Path.GetFileName(upgradeProperties.ZipUrl));
+		var zipFile = GetUpgradeDownloadPath(upgradeProperties.ZipUrl);
+		if (zipFile is null)
+			return null;
 
 		Serilog.Log.Logger.Information($"Downloading {zipFile}");
 
@@ -98,6 +99,29 @@ public class Upgrader : UpgraderBase
 		catch (Exception ex)
 		{
 			var message = $"Failed to download the upgrade: {upgradeProperties.ZipUrl}";
+			Serilog.Log.Logger.Error(ex, message);
+			OnUpgradeFailed(message, ex);
+			return null;
+		}
+	}
+
+	/// <summary>
+	/// Allocate a fresh per-run temp directory for the upgrade zip and return the full path
+	/// the zip should be downloaded to. Uses a random subdirectory name (and 0700 perms on
+	/// Unix) so we never extract or execute from a predictable, shared-temp location.
+	/// </summary>
+	/// <returns>Destination path for the upgrade zip, or <c>null</c> if the temp directory
+	/// could not be created (in which case the upgrade-failed event has already been raised).</returns>
+	private string? GetUpgradeDownloadPath(string zipUrl)
+	{
+		try
+		{
+			var stagingDir = Directory.CreateTempSubdirectory("Libation-upgrade-").FullName;
+			return Path.Combine(stagingDir, Path.GetFileName(zipUrl));
+		}
+		catch (Exception ex)
+		{
+			var message = "Failed to create a temp directory for the upgrade download.";
 			Serilog.Log.Logger.Error(ex, message);
 			OnUpgradeFailed(message, ex);
 			return null;


### PR DESCRIPTION
#1711 : Linux/Docker: the default in-progress download/decrypt folder is now per-user (/tmp/Libation-<username>) and is created with 0700 permissions, fixing failures caused by leftover /tmp/Libation directories from previous root installs and hardening against another local user reading partial download artifacts. Auto-upgrade downloads now land in a randomly-named per-run temp directory. (Old /tmp/Libation directories can be safely deleted.)