### PR TITLE
Add <title sort>, <title short sort>, <first series sort> template tags (#1620)

### DIFF
--- a/Source/LibationFileManager/Templates/TemplateTags.cs
+++ b/Source/LibationFileManager/Templates/TemplateTags.cs
@@ -25,6 +25,8 @@ public sealed class TemplateTags : ITemplateTag
 	public static TemplateTags Id { get; } = new("id", "Audible ID");
 	public static TemplateTags Title { get; } = new("title", "Full title with subtitle");
 	public static TemplateTags TitleShort { get; } = new("title short", "Title. Stop at first colon");
+	public static TemplateTags TitleSort { get; } = new("title sort", "Full title with subtitle, leading article (A/An/The) removed");
+	public static TemplateTags TitleShortSort { get; } = new("title short sort", "Title without subtitle, leading article (A/An/The) removed");
 	public static TemplateTags AudibleTitle { get; } = new("audible title", "Audible's title (does not include subtitle)");
 	public static TemplateTags AudibleSubtitle { get; } = new("audible subtitle", "Audible's subtitle");
 	public static TemplateTags Author { get; } = new("author", "Author(s)");
@@ -33,6 +35,7 @@ public sealed class TemplateTags : ITemplateTag
 	public static TemplateTags FirstNarrator { get; } = new("first narrator", "First narrator");
 	public static TemplateTags Series { get; } = new("series", "All series to which the book belongs (if any)");
 	public static TemplateTags FirstSeries { get; } = new("first series", "First series");
+	public static TemplateTags FirstSeriesSort { get; } = new("first series sort", "First series name, leading article (A/An/The) removed");
 	public static TemplateTags SeriesNumber { get; } = new("series#", "Number order in series (alias for <first series[{#}]>");
 	public static TemplateTags Minutes { get; } = new("minutes", "Length in minutes");
 	public static TemplateTags Bitrate { get; } = new("bitrate", "Bitrate (kbps) of the last downloaded audiobook");

--- a/Source/LibationFileManager/Templates/Templates.cs
+++ b/Source/LibationFileManager/Templates/Templates.cs
@@ -269,6 +269,8 @@ public abstract class Templates
 		{ TemplateTags.Id, lb => lb.AudibleProductId, v => v },
 		{ TemplateTags.Title, lb => lb.TitleWithSubtitle },
 		{ TemplateTags.TitleShort, lb => GetTitleShort(lb.Title) },
+		{ TemplateTags.TitleSort, lb => StripLeadingArticle(lb.TitleWithSubtitle) },
+		{ TemplateTags.TitleShortSort, lb => StripLeadingArticle(GetTitleShort(lb.Title)) },
 		{ TemplateTags.AudibleTitle, lb => lb.Title },
 		{ TemplateTags.AudibleSubtitle, lb => lb.Subtitle },
 		{ TemplateTags.Author, lb => lb.Authors, NameListFormat.Formatter, NameListFormat.Finalizer },
@@ -277,6 +279,7 @@ public abstract class Templates
 		{ TemplateTags.FirstNarrator, lb => lb.FirstNarrator, CommonFormatters.FormattableFormatter },
 		{ TemplateTags.Series, lb => lb.Series, SeriesListFormat.Formatter, SeriesListFormat.Finalizer },
 		{ TemplateTags.FirstSeries, lb => lb.FirstSeries, CommonFormatters.FormattableFormatter },
+		{ TemplateTags.FirstSeriesSort, lb => StripLeadingArticle(lb.FirstSeries?.ToString()) },
 		{ TemplateTags.SeriesNumber, lb => lb.FirstSeries?.Order, CommonFormatters.FormattableFormatter },
 		{ TemplateTags.Language, lb => lb.Language, CommonFormatters.FormattableFormatter },
 		//Don't allow formatting of LanguageShort
@@ -312,10 +315,13 @@ public abstract class Templates
 		{
 			{ TemplateTags.Title, lb => lb.TitleWithSubtitle },
 			{ TemplateTags.TitleShort, lb => GetTitleShort(lb.Title) },
+			{ TemplateTags.TitleSort, lb => StripLeadingArticle(lb.TitleWithSubtitle) },
+			{ TemplateTags.TitleShortSort, lb => StripLeadingArticle(GetTitleShort(lb.Title)) },
 			{ TemplateTags.AudibleTitle, lb => lb.Title },
 			{ TemplateTags.AudibleSubtitle, lb => lb.Subtitle },
 			{ TemplateTags.Series, lb => lb.Series, SeriesListFormat.Formatter, SeriesListFormat.Finalizer },
 			{ TemplateTags.FirstSeries, lb => lb.FirstSeries, CommonFormatters.FormattableFormatter },
+			{ TemplateTags.FirstSeriesSort, lb => StripLeadingArticle(lb.FirstSeries?.ToString()) },
 		},
 		new PropertyTagCollection<MultiConvertFileProperties>(caseSensitive: true, CommonFormatters.StringFormatter, CommonFormatters.IntegerFormatter, CommonFormatters.DateTimeFormatter)
 		{
@@ -396,6 +402,17 @@ public abstract class Templates
 		=> title != null && title.IndexOf(':') is var i && i >= 0
 			? title[..i]
 			: title;
+
+	private static readonly string[] _sortArticles = ["The ", "A ", "An "];
+
+	private static string? StripLeadingArticle(string? value)
+	{
+		if (value is null) return null;
+		foreach (var article in _sortArticles)
+			if (value.StartsWith(article, StringComparison.OrdinalIgnoreCase))
+				return value[article.Length..];
+		return value;
+	}
 
 	#endregion
 

--- a/Source/LibationFileManager/Templates/Templates.cs
+++ b/Source/LibationFileManager/Templates/Templates.cs
@@ -270,6 +270,8 @@ public abstract partial class Templates
 		{ TemplateTags.Id, lb => lb.AudibleProductId, v => v },
 		{ TemplateTags.Title, lb => lb.TitleWithSubtitle },
 		{ TemplateTags.TitleShort, lb => GetTitleShort(lb.Title) },
+		{ TemplateTags.TitleSort, lb => StripLeadingArticle(lb.TitleWithSubtitle) },
+		{ TemplateTags.TitleShortSort, lb => StripLeadingArticle(GetTitleShort(lb.Title)) },
 		{ TemplateTags.AudibleTitle, lb => lb.Title },
 		{ TemplateTags.AudibleSubtitle, lb => lb.Subtitle },
 		{ TemplateTags.Author, lb => lb.Authors, NameListFormat.Formatter, NameListFormat.Finalizer },
@@ -278,6 +280,7 @@ public abstract partial class Templates
 		{ TemplateTags.FirstNarrator, lb => lb.FirstNarrator, CommonFormatters.FormattableFormatter },
 		{ TemplateTags.Series, lb => lb.Series, SeriesListFormat.Formatter, SeriesListFormat.Finalizer },
 		{ TemplateTags.FirstSeries, lb => lb.FirstSeries, CommonFormatters.FormattableFormatter },
+		{ TemplateTags.FirstSeriesSort, lb => StripLeadingArticle(lb.FirstSeries?.ToString()) },
 		{ TemplateTags.SeriesNumber, lb => lb.FirstSeries?.Order, CommonFormatters.FormattableFormatter },
 		{ TemplateTags.Language, lb => lb.Language, CommonFormatters.FormattableFormatter },
 		//Don't allow formatting of LanguageShort
@@ -313,10 +316,13 @@ public abstract partial class Templates
 		{
 			{ TemplateTags.Title, lb => lb.TitleWithSubtitle },
 			{ TemplateTags.TitleShort, lb => GetTitleShort(lb.Title) },
+			{ TemplateTags.TitleSort, lb => StripLeadingArticle(lb.TitleWithSubtitle) },
+			{ TemplateTags.TitleShortSort, lb => StripLeadingArticle(GetTitleShort(lb.Title)) },
 			{ TemplateTags.AudibleTitle, lb => lb.Title },
 			{ TemplateTags.AudibleSubtitle, lb => lb.Subtitle },
 			{ TemplateTags.Series, lb => lb.Series, SeriesListFormat.Formatter, SeriesListFormat.Finalizer },
 			{ TemplateTags.FirstSeries, lb => lb.FirstSeries, CommonFormatters.FormattableFormatter },
+			{ TemplateTags.FirstSeriesSort, lb => StripLeadingArticle(lb.FirstSeries?.ToString()) },
 		},
 		new PropertyTagCollection<MultiConvertFileProperties>(caseSensitive: true, CommonFormatters.StringFormatter, CommonFormatters.IntegerFormatter, CommonFormatters.DateTimeFormatter)
 		{
@@ -410,6 +416,17 @@ public abstract partial class Templates
 		=> title != null && title.IndexOf(':') is var i && i >= 0
 			? title[..i]
 			: title;
+
+	private static readonly string[] _sortArticles = ["The ", "A ", "An "];
+
+	private static string? StripLeadingArticle(string? value)
+	{
+		if (value is null) return null;
+		foreach (var article in _sortArticles)
+			if (value.StartsWith(article, StringComparison.OrdinalIgnoreCase))
+				return value[article.Length..];
+		return value;
+	}
 
 	#endregion
 

--- a/Source/_Tests/LibationFileManager.Tests/TemplatesTests.cs
+++ b/Source/_Tests/LibationFileManager.Tests/TemplatesTests.cs
@@ -1517,4 +1517,60 @@ namespace Templates_ChapterFile_Tests
 				.Should().Be(expected);
 		}
 	}
+
+	[TestClass]
+	public class SortTags
+	{
+		static LibraryBookDto Book(string titleWithSubtitle, string title, string? seriesName = null)
+		{
+			var dto = Shared.GetLibraryBook(seriesName is null ? null : [new SeriesDto(seriesName, "1", "sid")]);
+			dto.Title = title;
+			dto.TitleWithSubtitle = titleWithSubtitle;
+			return dto;
+		}
+
+		private static string Evaluate(string template, LibraryBookDto dto)
+		{
+			Templates.TryGetTemplate<Templates.FileTemplate>(template, out var t).Should().BeTrue();
+			return t.GetName(dto, new MultiConvertFileProperties { OutputFileName = string.Empty });
+		}
+
+		[TestMethod]
+		[DataRow("The Hobbit", "The Hobbit", "Hobbit")]
+		[DataRow("A Tale of Two Cities", "A Tale of Two Cities", "Tale of Two Cities")]
+		[DataRow("An American in Paris", "An American in Paris", "American in Paris")]
+		[DataRow("Foundation", "Foundation", "Foundation")]          // no article — unchanged
+		[DataRow("Theatre of War", "Theatre of War", "Theatre of War")] // "The" must be whole word
+		public void TitleSort_strips_leading_article(string titleWithSubtitle, string title, string expected)
+			=> Evaluate("<title sort>", Book(titleWithSubtitle, title)).Should().Be(expected);
+
+		[TestMethod]
+		[DataRow("The Hobbit: There and Back Again", "The Hobbit", "Hobbit")]
+		[DataRow("A Tale: Subtitle", "A Tale", "Tale")]
+		[DataRow("Foundation: Prelude", "Foundation", "Foundation")] // no article
+		public void TitleShortSort_strips_leading_article(string titleWithSubtitle, string title, string expected)
+			=> Evaluate("<title short sort>", Book(titleWithSubtitle, title)).Should().Be(expected);
+
+		[TestMethod]
+		[DataRow("The Lord of the Rings", "Lord of the Rings")]
+		[DataRow("A Series of Unfortunate Events", "Series of Unfortunate Events")]
+		[DataRow("An Inspector Calls", "Inspector Calls")]
+		[DataRow("Sherlock Holmes", "Sherlock Holmes")] // no article — unchanged
+		public void FirstSeriesSort_strips_leading_article(string seriesName, string expected)
+			=> Evaluate("<first series sort>", Book("any", "any", seriesName)).Should().Be(expected);
+
+		[TestMethod]
+		public void TitleSort_case_insensitive()
+			=> Evaluate("<title sort>", Book("the hobbit", "the hobbit")).Should().Be("hobbit");
+
+		[TestMethod]
+		public void TitleSort_available_in_chapter_template()
+		{
+			Templates.TryGetTemplate<Templates.ChapterFileTemplate>("<title sort>", out var t).Should().BeTrue();
+			var dto = Shared.GetLibraryBook();
+			dto.TitleWithSubtitle = "The Silmarillion";
+			t.GetName(dto, new MultiConvertFileProperties { OutputFileName = string.Empty })
+				.Should().Be("Silmarillion");
+		}
+	}
 }

--- a/Source/_Tests/LibationFileManager.Tests/TemplatesTests.cs
+++ b/Source/_Tests/LibationFileManager.Tests/TemplatesTests.cs
@@ -1474,4 +1474,60 @@ namespace Templates_ChapterFile_Tests
 				.Should().Be(expected);
 		}
 	}
+
+	[TestClass]
+	public class SortTags
+	{
+		static LibraryBookDto Book(string titleWithSubtitle, string title, string? seriesName = null)
+		{
+			var dto = Shared.GetLibraryBook(seriesName is null ? null : [new SeriesDto(seriesName, "1", "sid")]);
+			dto.Title = title;
+			dto.TitleWithSubtitle = titleWithSubtitle;
+			return dto;
+		}
+
+		private static string Evaluate(string template, LibraryBookDto dto)
+		{
+			Templates.TryGetTemplate<Templates.FileTemplate>(template, out var t).Should().BeTrue();
+			return t.GetName(dto, new MultiConvertFileProperties { OutputFileName = string.Empty });
+		}
+
+		[TestMethod]
+		[DataRow("The Hobbit", "The Hobbit", "Hobbit")]
+		[DataRow("A Tale of Two Cities", "A Tale of Two Cities", "Tale of Two Cities")]
+		[DataRow("An American in Paris", "An American in Paris", "American in Paris")]
+		[DataRow("Foundation", "Foundation", "Foundation")]          // no article — unchanged
+		[DataRow("Theatre of War", "Theatre of War", "Theatre of War")] // "The" must be whole word
+		public void TitleSort_strips_leading_article(string titleWithSubtitle, string title, string expected)
+			=> Evaluate("<title sort>", Book(titleWithSubtitle, title)).Should().Be(expected);
+
+		[TestMethod]
+		[DataRow("The Hobbit: There and Back Again", "The Hobbit", "Hobbit")]
+		[DataRow("A Tale: Subtitle", "A Tale", "Tale")]
+		[DataRow("Foundation: Prelude", "Foundation", "Foundation")] // no article
+		public void TitleShortSort_strips_leading_article(string titleWithSubtitle, string title, string expected)
+			=> Evaluate("<title short sort>", Book(titleWithSubtitle, title)).Should().Be(expected);
+
+		[TestMethod]
+		[DataRow("The Lord of the Rings", "Lord of the Rings")]
+		[DataRow("A Series of Unfortunate Events", "Series of Unfortunate Events")]
+		[DataRow("An Inspector Calls", "Inspector Calls")]
+		[DataRow("Sherlock Holmes", "Sherlock Holmes")] // no article — unchanged
+		public void FirstSeriesSort_strips_leading_article(string seriesName, string expected)
+			=> Evaluate("<first series sort>", Book("any", "any", seriesName)).Should().Be(expected);
+
+		[TestMethod]
+		public void TitleSort_case_insensitive()
+			=> Evaluate("<title sort>", Book("the hobbit", "the hobbit")).Should().Be("hobbit");
+
+		[TestMethod]
+		public void TitleSort_available_in_chapter_template()
+		{
+			Templates.TryGetTemplate<Templates.ChapterFileTemplate>("<title sort>", out var t).Should().BeTrue();
+			var dto = Shared.GetLibraryBook();
+			dto.TitleWithSubtitle = "The Silmarillion";
+			t.GetName(dto, new MultiConvertFileProperties { OutputFileName = string.Empty })
+				.Should().Be("Silmarillion");
+		}
+	}
 }

--- a/Source/_Tests/LibationFileManager.Tests/TemplatesTests.cs
+++ b/Source/_Tests/LibationFileManager.Tests/TemplatesTests.cs
@@ -1480,7 +1480,7 @@ namespace Templates_ChapterFile_Tests
 	{
 		static LibraryBookDto Book(string titleWithSubtitle, string title, string? seriesName = null)
 		{
-			var dto = Shared.GetLibraryBook(seriesName is null ? null : [new SeriesDto(seriesName, "1", "sid")]);
+			var dto = GetLibraryBook(seriesName is null ? null : [new SeriesDto(seriesName, "1", "sid")]);
 			dto.Title = title;
 			dto.TitleWithSubtitle = titleWithSubtitle;
 			return dto;
@@ -1524,7 +1524,7 @@ namespace Templates_ChapterFile_Tests
 		public void TitleSort_available_in_chapter_template()
 		{
 			Templates.TryGetTemplate<Templates.ChapterFileTemplate>("<title sort>", out var t).Should().BeTrue();
-			var dto = Shared.GetLibraryBook();
+			var dto = GetLibraryBook();
 			dto.TitleWithSubtitle = "The Silmarillion";
 			t.GetName(dto, new MultiConvertFileProperties { OutputFileName = string.Empty })
 				.Should().Be("Silmarillion");

--- a/Source/_Tests/LibationFileManager.Tests/TemplatesTests.cs
+++ b/Source/_Tests/LibationFileManager.Tests/TemplatesTests.cs
@@ -1523,7 +1523,7 @@ namespace Templates_ChapterFile_Tests
 	{
 		static LibraryBookDto Book(string titleWithSubtitle, string title, string? seriesName = null)
 		{
-			var dto = Shared.GetLibraryBook(seriesName is null ? null : [new SeriesDto(seriesName, "1", "sid")]);
+			var dto = GetLibraryBook(seriesName is null ? null : [new SeriesDto(seriesName, "1", "sid")]);
 			dto.Title = title;
 			dto.TitleWithSubtitle = titleWithSubtitle;
 			return dto;
@@ -1567,7 +1567,7 @@ namespace Templates_ChapterFile_Tests
 		public void TitleSort_available_in_chapter_template()
 		{
 			Templates.TryGetTemplate<Templates.ChapterFileTemplate>("<title sort>", out var t).Should().BeTrue();
-			var dto = Shared.GetLibraryBook();
+			var dto = GetLibraryBook();
 			dto.TitleWithSubtitle = "The Silmarillion";
 			t.GetName(dto, new MultiConvertFileProperties { OutputFileName = string.Empty })
 				.Should().Be("Silmarillion");


### PR DESCRIPTION
## Summary

Adds three new template tags that strip a leading English article (A / An / The, case-insensitive) from the resolved value:

| Tag | Example input | Output |
|---|---|---|
| `<title sort>` | The Hobbit: There and Back Again | Hobbit: There and Back Again |
| `<title short sort>` | The Hobbit: There and Back Again | Hobbit |
| `<first series sort>` | The Lord of the Rings | Lord of the Rings |

Words that merely start with "The", "A", or "An" but aren't whole-word articles are untouched (e.g. "Theatre of War" → "Theatre of War").

## Usage examples

Folder template that files under the sort letter:
```
<title sort short> [<id>]
```
Mixed template that puts the full title in the filename but sorts by the stripped form in the directory:
```
<if series-><first series sort>\<-if series><title sort> [<id>]
```

## Changes

- **`TemplateTags.cs`** — three new `TemplateTags` static properties
- **`Templates.cs`** — `StripLeadingArticle()` private helper; registered in `filePropertyTags` (used by Folder, File, and ChapterFile templates) and the `chapterPropertyTags` inner collection
- **`TemplatesTests.cs`** — new `SortTags` test class: 14 cases covering all three tags, no-article pass-through, case-insensitivity, and availability in the chapter template

Closes #1620

🤖 Generated with [Claude Code](https://claude.com/claude-code)