### PR TITLE
Skip EF migration lock when no migrations are pending (fixes SQLite scan-hang #1729)

### DIFF
--- a/Source/DataLayer/LibationContextFactory.cs
+++ b/Source/DataLayer/LibationContextFactory.cs
@@ -3,6 +3,7 @@ using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Diagnostics;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Infrastructure;
 using System;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -49,7 +50,15 @@ public class LibationContextFactory
 	{
 		try
 		{
-			context.Database.Migrate();
+			// Migrate() acquires the EF migration lock before checking whether anything is pending.
+			// For SQLite that lock is a row in __EFMigrationsLock with no timeout (SQLite has no
+			// connection-scoped lock that frees on disconnect). A process killed after acquiring the
+			// lock but before releasing it - even during an otherwise no-op Migrate() - orphans the row,
+			// and every later Migrate() then spins forever in SqliteHistoryRepository.AcquireDatabaseLock().
+			// The row is persisted in the db file, so restarting does not clear it. Skipping Migrate()
+			// when nothing is pending keeps the steady-state path off the lock entirely. See #1729.
+			if (context.Database.GetPendingMigrations().Any())
+				context.Database.Migrate();
 		}
 		// SQLITE_READONLY == 8 (https://www.sqlite.org/rescode.html)
 		catch (SqliteException ex) when (ex.SqliteErrorCode == 8 && sqliteDatabaseFilePath is not null)
@@ -63,7 +72,9 @@ public class LibationContextFactory
 	{
 		try
 		{
-			await context.Database.MigrateAsync(cancellationToken);
+			// See ApplyMigrations for why pending migrations are checked before acquiring the lock (#1729).
+			if ((await context.Database.GetPendingMigrationsAsync(cancellationToken)).Any())
+				await context.Database.MigrateAsync(cancellationToken);
 		}
 		// SQLITE_READONLY == 8 (https://www.sqlite.org/rescode.html)
 		catch (SqliteException ex) when (ex.SqliteErrorCode == 8 && sqliteDatabaseFilePath is not null)


### PR DESCRIPTION
## Problem

`LibationCli scan` (and any headless/Docker run) can hang forever: the process stays alive at ~0% CPU, makes no network connections, and never writes `LibationContext.db`. A restart doesn't help — it hangs again on the next scan. This matches the reports in #1729.

## Root cause

`DbContexts.GetContext()` calls `LibationContextFactory.ApplyMigrations()` on **every** context creation, which calls `context.Database.Migrate()`.

`Migrate()` acquires the EF Core migration lock **before** checking whether any migration is pending. For SQLite that lock is a row in the `__EFMigrationsLock` table (`INSERT OR IGNORE INTO "__EFMigrationsLock"("Id","Timestamp") VALUES(1, …)`), released by a `DELETE` on dispose. Unlike SQL Server's `sp_getapplock`, SQLite has no connection-scoped lock that frees automatically on disconnect, and this lock has **no timeout**.

If a process is killed after acquiring the lock but before releasing it — even during an otherwise no-op `Migrate()` (e.g. a container recreate or `kill` during a routine scan) — the lock row is orphaned. Every subsequent `Migrate()` then spins forever in `SqliteHistoryRepository.AcquireDatabaseLock()` (`Thread.Sleep` retry loop). Because the row is persisted in the database file, **restarting the app or rebooting the machine never clears it** — which is exactly the "hangs on scan, reboot doesn't help" behavior reported in #1729.

### Evidence (from a live, reproduced instance)

Managed stack of the hung process:

```
Thread (wedged worker):
  System.Threading.Thread.Sleep(int32)
  Microsoft.EntityFrameworkCore.Sqlite.Migrations.Internal.SqliteHistoryRepository.AcquireDatabaseLock()
  Microsoft.EntityFrameworkCore.Migrations.Internal.Migrator.Migrate(string)
  DataLayer.LibationContextFactory.ApplyMigrations(LibationContext, string)
  ApplicationServices.DbContexts.GetContext()
  ApplicationServices.LibraryCommands.importIntoDb(...)

Thread (main): blocked in Task.SpinThenBlockingWait — .GetAwaiter().GetResult() on the above
```

The database had a single orphaned row in `__EFMigrationsLock` (`Id=1`) and **zero pending migrations** (latest applied migration already present, nothing newer in `DataLayer.Sqlite`). Deleting that row let the scan complete immediately. The hang occurred despite there being nothing to migrate — because the lock is taken before the pending check.

## Fix

Guard `Migrate()` / `MigrateAsync()` behind a pending-migrations check:

```csharp
if (context.Database.GetPendingMigrations().Any())
    context.Database.Migrate();
```

`GetPendingMigrations()` only reads `__EFMigrationsHistory` (returning all migrations as pending when the table doesn't exist yet) and **never acquires the migration lock** — only `Migrate()` does. So the steady-state path (schema already current, which is every run after the first) no longer touches `__EFMigrationsLock` at all, and a stale lock can no longer wedge normal operation.

- First-run schema creation is unchanged (`GetPendingMigrations()` returns all migrations on an empty DB, so `Migrate()` still runs).
- Real migrations on upgrade are unchanged.
- No EF internal/provider APIs are touched; this uses only the public migrations API.

## Known residual (follow-up, not addressed here)

If a migration is *genuinely* pending **and** the lock is already orphaned (e.g. killed during an actual schema upgrade), `Migrate()` is still called and can still hang. A good follow-up would be to detect a stale `__EFMigrationsLock` row and fail fast with a clear diagnostic (or offer an explicit recovery command) instead of spinning forever. That's intentionally out of scope here to keep this change minimal and low-risk.

## Testing

- `dotnet build` of `DataLayer` and `LibationCli` succeeds with 0 errors on .NET 10.
- Verified the recovery on a live instance: clearing the orphaned `__EFMigrationsLock` row unblocked a 2-month-hung scan, which then completed in ~10s; with this guard, the steady-state scan path never acquires the lock.

Fixes #1729.
