### PR TITLE
Fix arm64 Windows zip artifact name in CI matrix

### DIFF
--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -41,6 +41,7 @@ jobs:
           - architecture: arm64
             ui: Avalonia
             release_name: chardonnay
+            artifact_stem: Libation
     steps:
       - uses: actions/checkout@v6
       


### PR DESCRIPTION
Adds \artifact_stem: Libation\ to the arm64 include entry.