### PR TITLE
#1878 : Detect incomplete in-app upgrades, roll back install files, and show clear recovery messages

### DIFF
--- a/Source/AppScaffolding/AppScaffolding.csproj
+++ b/Source/AppScaffolding/AppScaffolding.csproj
@@ -2,7 +2,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
-    <Version>13.4.9</Version>
+    <Version>13.5.0</Version>
     <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>

--- a/Source/LibationAvalonia/App.axaml.cs
+++ b/Source/LibationAvalonia/App.axaml.cs
@@ -157,7 +157,7 @@ public class App : Application
 			catch (Exception ex) when (StartupAssemblyBootstrap.IsInstallFolderAssemblyLoadFailure(ex))
 			{
 				Serilog.Log.Logger.Error(ex, "Failed to load library at startup");
-				var failure = StartupAssemblyBootstrap.GetStartupFailureMessage(ex)!;
+				FatalStartupMessage failure = StartupAssemblyBootstrap.GetStartupFailureMessage(ex)!;
 				await MessageBox.Show(
 					MainWindow,
 					failure.Body,

--- a/Source/LibationAvalonia/App.axaml.cs
+++ b/Source/LibationAvalonia/App.axaml.cs
@@ -47,6 +47,9 @@ public class App : Application
 			MessageBoxBase.ShowAsyncImpl = (owner, message, caption, buttons, icon, defaultButton, saveAndRestorePosition) =>
 				MessageBox.Show(owner as Window, message, caption, buttons, icon, defaultButton, saveAndRestorePosition);
 
+			if (InstallUpgradeManager.TakeStartupRecoveryAlert() is { } recovery)
+				_ = MessageBox.Show(null, recovery.Body, recovery.Title, MessageBoxButtons.OK, MessageBoxIcon.Warning);
+
 			BadBookActionDialogBase.ShowAsyncImpl = (owner, message, caption) =>
 				Dialogs.BadBookActionDialog.ShowAsync(owner as Window, message, caption);
 
@@ -154,11 +157,11 @@ public class App : Application
 			catch (Exception ex) when (StartupAssemblyBootstrap.IsInstallFolderAssemblyLoadFailure(ex))
 			{
 				Serilog.Log.Logger.Error(ex, "Failed to load library at startup");
-				StartupAssemblyBootstrap.TryGetStartupFailureMessage(ex, out var title, out var body);
+				var failure = StartupAssemblyBootstrap.GetStartupFailureMessage(ex)!;
 				await MessageBox.Show(
 					MainWindow,
-					body,
-					title,
+					failure.Body,
+					failure.Title,
 					MessageBoxButtons.OK,
 					MessageBoxIcon.Error);
 				await Dispatcher.UIThread.InvokeAsync(() => MainWindow.OnLibraryLoadedAsync([]));

--- a/Source/LibationAvalonia/Program.cs
+++ b/Source/LibationAvalonia/Program.cs
@@ -53,6 +53,7 @@ static class Program
 		try
 		{
 			var config = LibationScaffolding.RunPreConfigMigrations();
+			StartupAssemblyBootstrap.RecoverFromIncompleteUpgradeIfNeeded();
 			if (config.LibationFiles.SettingsAreValid)
 			{
 				App.RunMigrations(config);
@@ -128,24 +129,17 @@ static class Program
 	{
 		var dispatcher = new DispatcherFrame();
 
-		string caption;
-		string message;
-		if (StartupAssemblyBootstrap.TryGetStartupFailureMessage(exception, out var title, out var body))
-		{
-			caption = title;
-			message = body;
-		}
-		else
-		{
-			caption = "Libation Crash";
-			message = """
+		var fatalMessage = StartupAssemblyBootstrap.GetFatalStartupMessage(
+			exception,
+			new FatalStartupMessage(
+				"Libation Crash",
+				"""
 				Libation encountered a fatal error and must close.
 
 				Please consider reporting this issue on GitHub, including the contents of the LibationCrash.log file created in your user folder.
-				""";
-		}
+				"""));
 
-		var mbAlert = new MessageBoxAlertAdminDialog(message, caption, exception);
+		var mbAlert = new MessageBoxAlertAdminDialog(fatalMessage.Body, fatalMessage.Title, exception);
 		mbAlert.Closed += (_, _) => dispatcher.Continue = false;
 		mbAlert.Show();
 		Dispatcher.UIThread.PushFrame(dispatcher);

--- a/Source/LibationFileManager/FatalStartupMessage.cs
+++ b/Source/LibationFileManager/FatalStartupMessage.cs
@@ -1,4 +1,4 @@
 namespace LibationFileManager;
 
 /// <summary>User-facing title and body for startup failure, recovery, and crash dialogs.</summary>
-public readonly record struct FatalStartupMessage(string Title, string Body);
+public sealed record FatalStartupMessage(string Title, string Body);

--- a/Source/LibationFileManager/FatalStartupMessage.cs
+++ b/Source/LibationFileManager/FatalStartupMessage.cs
@@ -1,0 +1,4 @@
+namespace LibationFileManager;
+
+/// <summary>User-facing title and body for startup failure, recovery, and crash dialogs.</summary>
+public readonly record struct FatalStartupMessage(string Title, string Body);

--- a/Source/LibationFileManager/IInteropFunctions.cs
+++ b/Source/LibationFileManager/IInteropFunctions.cs
@@ -1,4 +1,5 @@
-﻿using System.Diagnostics;
+﻿using System;
+using System.Diagnostics;
 using System.Threading.Tasks;
 
 namespace LibationFileManager;
@@ -10,7 +11,7 @@ public interface IInteropFunctions
 	void DeleteFolderIcon(string directory);
 	Process? RunAsRoot(string exe, string args);
 	/// <summary>Waits for the privileged installer where possible and throws if it fails.</summary>
-	Task InstallUpgradeAsync(string upgradeBundle);
+	Task InstallUpgradeAsync(string upgradeBundle, Version targetVersion);
 	/// <summary>Best-effort sync of installer metadata (e.g. Windows Add/Remove Programs). Never throws.</summary>
 	void TrySyncInstallMetadata();
 	bool CanUpgrade { get; }

--- a/Source/LibationFileManager/InstallUpgradeIntegrityException.cs
+++ b/Source/LibationFileManager/InstallUpgradeIntegrityException.cs
@@ -1,0 +1,11 @@
+using System;
+
+namespace LibationFileManager;
+
+/// <summary>Thrown when an in-app upgrade overlay did not update all required install files.</summary>
+public sealed class InstallUpgradeIntegrityException : Exception
+{
+	public InstallUpgradeIntegrityException(string message) : base(message) { }
+
+	public InstallUpgradeIntegrityException(string message, Exception innerException) : base(message, innerException) { }
+}

--- a/Source/LibationFileManager/InstallUpgradeManager.cs
+++ b/Source/LibationFileManager/InstallUpgradeManager.cs
@@ -1,0 +1,448 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.IO.Compression;
+using System.Linq;
+using System.Reflection;
+using System.Security.Cryptography;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace LibationFileManager;
+
+public readonly record struct UpgradeVerificationResult(
+	bool Success,
+	IReadOnlyList<string> FailedFiles,
+	string Summary);
+
+public sealed record UpgradeRecoveryResult(
+	bool RolledBack,
+	string Title,
+	string Message,
+	IReadOnlyList<string> FailedFiles);
+
+/// <summary>
+/// Backups, verifies, and rolls back flat zip overlay upgrades (Windows ZipExtractor flow).
+/// </summary>
+public static class InstallUpgradeManager
+{
+	public const string UpgradeStateFolderName = ".libation-upgrade";
+	public const string PendingStateFileName = "pending.json";
+	public const string BackupFolderName = "backup";
+
+	public const string LibationUiBaseIntegrityTypeName = "LibationUiBase.ShowBadBookDialogAsyncDelegate";
+
+	private static readonly JsonSerializerOptions JsonOptions = new()
+	{
+		WriteIndented = true,
+		PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+		DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+	};
+
+	private static readonly string[] AlwaysCriticalFileNames =
+	[
+		"LibationUiBase.dll",
+		"LibationFileManager.dll",
+		"AppScaffolding.dll",
+		"Microsoft.EntityFrameworkCore.Sqlite.dll",
+	];
+
+	private static FatalStartupMessage? s_StartupRecoveryAlert;
+
+	public static FatalStartupMessage? TakeStartupRecoveryAlert()
+	{
+		var alert = s_StartupRecoveryAlert;
+		s_StartupRecoveryAlert = null;
+		return alert;
+	}
+
+	public static string GetUpgradeStateDirectory(string installDirectory)
+		=> Path.Combine(installDirectory, UpgradeStateFolderName);
+
+	public static string GetPendingStatePath(string installDirectory)
+		=> Path.Combine(GetUpgradeStateDirectory(installDirectory), PendingStateFileName);
+
+	public static string GetBackupDirectory(string installDirectory)
+		=> Path.Combine(GetUpgradeStateDirectory(installDirectory), BackupFolderName);
+
+	/// <summary>
+	/// Snapshot critical install files and record expected post-upgrade hashes from the upgrade zip.
+	/// Call immediately before launching ZipExtractor.
+	/// </summary>
+	public static void PrepareForUpgrade(string installDirectory, string upgradeBundlePath, Version targetVersion)
+	{
+		ArgumentException.ThrowIfNullOrWhiteSpace(installDirectory);
+		ArgumentException.ThrowIfNullOrWhiteSpace(upgradeBundlePath);
+		ArgumentNullException.ThrowIfNull(targetVersion);
+
+		if (!Directory.Exists(installDirectory))
+			throw new DirectoryNotFoundException($"Install directory not found: {installDirectory}");
+		if (!File.Exists(upgradeBundlePath))
+			throw new FileNotFoundException("Upgrade bundle not found.", upgradeBundlePath);
+
+		var criticalFiles = GetCriticalFileNames(installDirectory);
+		var expectedHashes = BuildExpectedHashesFromZip(upgradeBundlePath, criticalFiles);
+
+		var stateDirectory = GetUpgradeStateDirectory(installDirectory);
+		var backupDirectory = GetBackupDirectory(installDirectory);
+
+		if (Directory.Exists(stateDirectory))
+			Directory.Delete(stateDirectory, recursive: true);
+
+		Directory.CreateDirectory(backupDirectory);
+
+		var backedUpFiles = new List<string>();
+		foreach (var fileName in criticalFiles)
+		{
+			var sourcePath = Path.Combine(installDirectory, fileName);
+			if (!File.Exists(sourcePath))
+				continue;
+
+			var backupPath = Path.Combine(backupDirectory, fileName);
+			Directory.CreateDirectory(Path.GetDirectoryName(backupPath)!);
+			File.Copy(sourcePath, backupPath, overwrite: true);
+			backedUpFiles.Add(fileName);
+		}
+
+		var pending = new PendingUpgradeState
+		{
+			TargetVersion = targetVersion.ToString(),
+			UpgradeBundlePath = upgradeBundlePath,
+			StartedUtc = DateTime.UtcNow,
+			InstallDirectory = installDirectory,
+			BackedUpFiles = backedUpFiles,
+			ExpectedFileHashesSha256 = expectedHashes,
+		};
+
+		var pendingPath = GetPendingStatePath(installDirectory);
+		File.WriteAllText(pendingPath, JsonSerializer.Serialize(pending, JsonOptions));
+
+		Serilog.Log.Logger.Information(
+			"Prepared in-app upgrade to {TargetVersion}. Backed up {BackedUpCount} files to {BackupDirectory}. Expecting {ExpectedCount} install files to match the upgrade package.",
+			targetVersion,
+			backedUpFiles.Count,
+			backupDirectory,
+			expectedHashes.Count);
+	}
+
+	/// <summary>
+	/// If a previous upgrade left a pending marker, verify the install folder and roll back on failure.
+	/// Call at startup before loading UI assemblies.
+	/// </summary>
+	public static UpgradeRecoveryResult? RecoverPendingUpgradeIfNeeded(string installDirectory)
+	{
+		ArgumentException.ThrowIfNullOrWhiteSpace(installDirectory);
+
+		var pendingPath = GetPendingStatePath(installDirectory);
+		if (!File.Exists(pendingPath))
+			return null;
+
+		PendingUpgradeState pending;
+		try
+		{
+			pending = JsonSerializer.Deserialize<PendingUpgradeState>(File.ReadAllText(pendingPath), JsonOptions)
+				?? throw new InvalidDataException("Pending upgrade state was empty.");
+		}
+		catch (Exception ex)
+		{
+			Serilog.Log.Logger.Error(ex, "Could not read pending upgrade state at {PendingPath}. Attempting emergency rollback.", pendingPath);
+			return RollbackAndReport(installDirectory, pendingPath, null, ["Could not read pending upgrade state."], ex.Message);
+		}
+
+		var verification = VerifyInstallMatchesUpgrade(installDirectory, pending.ExpectedFileHashesSha256);
+		if (verification.Success)
+		{
+			CompleteUpgrade(installDirectory);
+			Serilog.Log.Logger.Information(
+				"In-app upgrade to {TargetVersion} verified successfully at startup.",
+				pending.TargetVersion);
+			return null;
+		}
+
+		Serilog.Log.Logger.Error(
+			"Incomplete in-app upgrade detected at startup. Target version {TargetVersion}. {Summary}",
+			pending.TargetVersion,
+			verification.Summary);
+
+		return RollbackAndReport(installDirectory, pendingPath, pending, verification.FailedFiles, verification.Summary);
+	}
+
+	public static UpgradeVerificationResult VerifyInstallMatchesUpgrade(
+		string installDirectory,
+		IReadOnlyDictionary<string, string>? expectedFileHashesSha256 = null)
+	{
+		ArgumentException.ThrowIfNullOrWhiteSpace(installDirectory);
+
+		expectedFileHashesSha256 ??= TryReadPendingExpectedHashes(installDirectory);
+		if (expectedFileHashesSha256 is null || expectedFileHashesSha256.Count == 0)
+			return new UpgradeVerificationResult(true, [], "No pending upgrade verification manifest.");
+
+		var failedFiles = new List<string>();
+		foreach (var (fileName, expectedHash) in expectedFileHashesSha256)
+		{
+			var installPath = Path.Combine(installDirectory, fileName);
+			if (!File.Exists(installPath))
+			{
+				failedFiles.Add($"{fileName}: missing from install folder");
+				continue;
+			}
+
+			var actualHash = ComputeSha256Hex(installPath);
+			if (!string.Equals(actualHash, expectedHash, StringComparison.OrdinalIgnoreCase))
+				failedFiles.Add($"{fileName}: on-disk content does not match upgrade package (file was not replaced)");
+		}
+
+		var typeCheckFailure = VerifyLibationUiBaseIntegrityType(installDirectory);
+		if (typeCheckFailure is not null)
+			failedFiles.Add(typeCheckFailure);
+
+		if (failedFiles.Count == 0)
+			return new UpgradeVerificationResult(true, failedFiles, "Install folder matches upgrade package.");
+
+		var summary =
+			$"Upgrade integrity check failed for {failedFiles.Count} item(s):{Environment.NewLine}"
+			+ string.Join(Environment.NewLine, failedFiles.Select(f => $"  - {f}"));
+
+		return new UpgradeVerificationResult(false, failedFiles, summary);
+	}
+
+	public static void RollbackAfterFailedUpgrade(string installDirectory, string reason)
+	{
+		ArgumentException.ThrowIfNullOrWhiteSpace(installDirectory);
+		ArgumentException.ThrowIfNullOrWhiteSpace(reason);
+
+		var pending = TryReadPendingState(installDirectory);
+		var failedFiles = new[] { reason };
+		RollbackAndReport(installDirectory, GetPendingStatePath(installDirectory), pending, failedFiles, reason);
+	}
+
+	public static UpgradeRecoveryResult TryEmergencyRollback(string installDirectory)
+	{
+		ArgumentException.ThrowIfNullOrWhiteSpace(installDirectory);
+
+		var backupDirectory = GetBackupDirectory(installDirectory);
+		if (!Directory.Exists(backupDirectory))
+			return new UpgradeRecoveryResult(false, string.Empty, string.Empty, []);
+
+		var pending = TryReadPendingState(installDirectory);
+		return RollbackAndReport(
+			installDirectory,
+			GetPendingStatePath(installDirectory),
+			pending,
+			["Emergency rollback triggered by startup assembly load failure."],
+			"Startup assembly load failure.");
+	}
+
+	public static void CompleteUpgrade(string installDirectory)
+	{
+		var stateDirectory = GetUpgradeStateDirectory(installDirectory);
+		if (!Directory.Exists(stateDirectory))
+			return;
+
+		try
+		{
+			Directory.Delete(stateDirectory, recursive: true);
+		}
+		catch (Exception ex)
+		{
+			Serilog.Log.Logger.Warning(ex, "Could not delete upgrade state directory {StateDirectory}", stateDirectory);
+		}
+	}
+
+	public static IReadOnlyList<string> GetCriticalFileNames(string installDirectory)
+	{
+		var files = new HashSet<string>(AlwaysCriticalFileNames, StringComparer.OrdinalIgnoreCase);
+
+		var mainExecutable = Path.GetFileName(Environment.ProcessPath ?? string.Empty);
+		if (!string.IsNullOrWhiteSpace(mainExecutable))
+			files.Add(mainExecutable);
+
+		if (Directory.Exists(installDirectory))
+		{
+			foreach (var configApp in Directory.EnumerateFiles(installDirectory, "*ConfigApp.dll"))
+				files.Add(Path.GetFileName(configApp));
+
+			if (File.Exists(Path.Combine(installDirectory, "ZipExtractor.exe")))
+				files.Add("ZipExtractor.exe");
+		}
+
+		return files.OrderBy(f => f, StringComparer.OrdinalIgnoreCase).ToArray();
+	}
+
+	private static UpgradeRecoveryResult RollbackAndReport(
+		string installDirectory,
+		string pendingPath,
+		PendingUpgradeState? pending,
+		IReadOnlyList<string> failedFiles,
+		string summary)
+	{
+		var restoredFiles = RestoreFromBackup(installDirectory);
+
+		Serilog.Log.Logger.Error(
+			"In-app upgrade failed. Rolled back {RestoredCount} file(s) in {InstallDirectory}. {Summary}",
+			restoredFiles.Count,
+			installDirectory,
+			summary);
+
+		try
+		{
+			if (File.Exists(pendingPath))
+				File.Delete(pendingPath);
+		}
+		catch (Exception ex)
+		{
+			Serilog.Log.Logger.Warning(ex, "Could not delete pending upgrade state at {PendingPath}", pendingPath);
+		}
+
+		var targetVersion = pending?.TargetVersion ?? "unknown";
+		var title = "In-app upgrade failed -- Libation was restored";
+		var message = $"""
+			Libation attempted an in-app upgrade to version {targetVersion}, but one or more install files were not updated correctly.
+
+			Libation restored your previous install files from backup so you can continue using the app.
+
+			Details:
+			{summary}
+
+			Install folder:
+			{installDirectory}
+
+			Your library database, accounts, and settings are stored separately and were not changed.
+
+			To upgrade safely:
+			1. Quit Libation completely.
+			2. Download the latest release zip from GitHub.
+			3. Extract it to a new folder (do not copy files on top of this install folder).
+			4. Run Libation from the new folder.
+
+			More help:
+			{StartupAssemblyBootstrap.TroubleshootIncompleteUpgradeUrl}
+			""";
+
+		s_StartupRecoveryAlert = new FatalStartupMessage(title, message);
+		return new UpgradeRecoveryResult(true, title, message, failedFiles);
+	}
+
+	private static List<string> RestoreFromBackup(string installDirectory)
+	{
+		var backupDirectory = GetBackupDirectory(installDirectory);
+		var restoredFiles = new List<string>();
+
+		if (!Directory.Exists(backupDirectory))
+			return restoredFiles;
+
+		foreach (var backupFile in Directory.EnumerateFiles(backupDirectory, "*", SearchOption.AllDirectories))
+		{
+			var relativePath = Path.GetRelativePath(backupDirectory, backupFile);
+			var targetPath = Path.Combine(installDirectory, relativePath);
+			Directory.CreateDirectory(Path.GetDirectoryName(targetPath)!);
+			File.Copy(backupFile, targetPath, overwrite: true);
+			restoredFiles.Add(relativePath);
+
+			Serilog.Log.Logger.Information("Upgrade rollback restored {FileName}", relativePath);
+		}
+
+		return restoredFiles;
+	}
+
+	private static Dictionary<string, string> BuildExpectedHashesFromZip(string upgradeBundlePath, IReadOnlyList<string> criticalFileNames)
+	{
+		var expected = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+
+		using var zip = ZipFile.OpenRead(upgradeBundlePath);
+		foreach (var fileName in criticalFileNames)
+		{
+			var entry = zip.GetEntry(fileName)
+				?? zip.Entries.FirstOrDefault(e => string.Equals(Path.GetFileName(e.FullName), fileName, StringComparison.OrdinalIgnoreCase));
+
+			if (entry is null)
+			{
+				Serilog.Log.Logger.Warning("Upgrade package does not contain expected file {FileName}", fileName);
+				continue;
+			}
+
+			using var entryStream = entry.Open();
+			expected[fileName] = ComputeSha256Hex(entryStream);
+		}
+
+		if (expected.Count == 0)
+			throw new InstallUpgradeIntegrityException("Upgrade package does not contain any verifiable install files.");
+
+		return expected;
+	}
+
+	private static string ComputeSha256Hex(string path)
+	{
+		using var stream = File.OpenRead(path);
+		return ComputeSha256Hex(stream);
+	}
+
+	private static string ComputeSha256Hex(Stream stream)
+	{
+		var hash = SHA256.HashData(stream);
+		return Convert.ToHexString(hash);
+	}
+
+	private static PendingUpgradeState? TryReadPendingState(string installDirectory)
+	{
+		var pendingPath = GetPendingStatePath(installDirectory);
+		if (!File.Exists(pendingPath))
+			return null;
+
+		try
+		{
+			return JsonSerializer.Deserialize<PendingUpgradeState>(File.ReadAllText(pendingPath), JsonOptions);
+		}
+		catch
+		{
+			return null;
+		}
+	}
+
+	private static IReadOnlyDictionary<string, string>? TryReadPendingExpectedHashes(string installDirectory)
+		=> TryReadPendingState(installDirectory)?.ExpectedFileHashesSha256;
+
+	private static string? VerifyLibationUiBaseIntegrityType(string installDirectory)
+	{
+		var uiBasePath = Path.Combine(installDirectory, "LibationUiBase.dll");
+		if (!File.Exists(uiBasePath))
+			return "LibationUiBase.dll: missing from install folder";
+
+		try
+		{
+			var alreadyLoaded = AppDomain.CurrentDomain
+				.GetAssemblies()
+				.FirstOrDefault(a => string.Equals(a.GetName().Name, "LibationUiBase", StringComparison.OrdinalIgnoreCase));
+
+			var assembly = alreadyLoaded ?? Assembly.LoadFrom(uiBasePath);
+			var integrityType = assembly.GetType(LibationUiBaseIntegrityTypeName, throwOnError: false, ignoreCase: false);
+			if (integrityType is null)
+				return $"{LibationUiBaseIntegrityTypeName}: missing from LibationUiBase.dll (install files are from mixed versions)";
+
+			return null;
+		}
+		catch (BadImageFormatException)
+		{
+			// Non-assembly test doubles and corrupt files are covered by hash verification.
+			return null;
+		}
+		catch (FileLoadException)
+		{
+			return null;
+		}
+		catch (Exception ex)
+		{
+			return $"LibationUiBase.dll: could not verify required type ({ex.Message})";
+		}
+	}
+
+	private sealed class PendingUpgradeState
+	{
+		public string TargetVersion { get; set; } = string.Empty;
+		public string UpgradeBundlePath { get; set; } = string.Empty;
+		public DateTime StartedUtc { get; set; }
+		public string InstallDirectory { get; set; } = string.Empty;
+		public List<string> BackedUpFiles { get; set; } = [];
+		public Dictionary<string, string> ExpectedFileHashesSha256 { get; set; } = new(StringComparer.OrdinalIgnoreCase);
+	}
+}

--- a/Source/LibationFileManager/NullInteropFunctions.cs
+++ b/Source/LibationFileManager/NullInteropFunctions.cs
@@ -16,6 +16,6 @@ public class NullInteropFunctions : IInteropFunctions
 	public bool CanUpgrade => throw new PlatformNotSupportedException();
 	public string ReleaseIdString => throw new PlatformNotSupportedException();
 	public Process RunAsRoot(string exe, string args) => throw new PlatformNotSupportedException();
-	public Task InstallUpgradeAsync(string updateBundle) => throw new PlatformNotSupportedException();
+	public Task InstallUpgradeAsync(string updateBundle, Version targetVersion) => throw new PlatformNotSupportedException();
 	public void TrySyncInstallMetadata() { }
 }

--- a/Source/LibationFileManager/StartupAssemblyBootstrap.cs
+++ b/Source/LibationFileManager/StartupAssemblyBootstrap.cs
@@ -1,5 +1,7 @@
 using System;
 using System.IO;
+using System.Linq;
+using System.Reflection;
 
 namespace LibationFileManager;
 
@@ -11,16 +13,34 @@ public static class StartupAssemblyBootstrap
 	public const string EntityFrameworkCoreSqliteAssemblyFileName = "Microsoft.EntityFrameworkCore.Sqlite.dll";
 	public const int ApplicationControlBlockedHResult = unchecked((int)0x800711C7);
 	private const string TroubleshootApplicationControlUrl = "https://getlibation.com/docs/advanced/troubleshoot#windows-smart-app-control-and-in-app-upgrades";
+	internal const string TroubleshootIncompleteUpgradeUrl = "https://getlibation.com/docs/advanced/troubleshoot#windows-smart-app-control-and-in-app-upgrades";
 
 	/// <summary>
 	/// Registers <see cref="InteropFactory"/> assembly resolution and verifies required install-folder assemblies exist.
-	/// Call before <c>Task.Run</c> loads the library or opens the database on a thread-pool thread.
+	/// Call after <see cref="RecoverFromIncompleteUpgradeIfNeeded"/> and before <c>Task.Run</c> loads the library.
 	/// </summary>
 	public static void PrepareForBackgroundDataAccess()
 	{
 		_ = InteropFactory.InteropFunctionsType;
 		ValidateEntityFrameworkCoreSqlitePresent();
 		TrySyncWindowsInstallMetadata();
+	}
+
+	/// <summary>
+	/// If a zip overlay upgrade was interrupted or incomplete, verify install files and roll back before continuing startup.
+	/// Call once immediately after <c>RunPreConfigMigrations</c>, before assigning UI assembly hooks such as
+	/// <c>BadBookActionDialogBase.ShowAsyncImpl</c>.
+	/// </summary>
+	public static void RecoverFromIncompleteUpgradeIfNeeded()
+	{
+		try
+		{
+			InstallUpgradeManager.RecoverPendingUpgradeIfNeeded(Configuration.ProcessDirectory);
+		}
+		catch (Exception ex)
+		{
+			Serilog.Log.Logger.Error(ex, "Failed while recovering from a pending in-app upgrade");
+		}
 	}
 
 	private static void TrySyncWindowsInstallMetadata()
@@ -102,29 +122,116 @@ public static class StartupAssemblyBootstrap
 		return false;
 	}
 
-	public static bool IsInstallFolderAssemblyLoadFailure(Exception ex) =>
-		IsApplicationControlBlockedAssembly(ex) || IsMissingDependencyAssembly(ex);
+	public static bool IsIncompleteUpgradeAssemblyFailure(Exception ex)
+	{
+		for (var current = ex; current is not null; current = current.InnerException)
+		{
+			if (current is TypeLoadException typeLoadException)
+			{
+				if (ContainsLibationUiBaseReference(typeLoadException.TypeName)
+					|| ContainsLibationUiBaseReference(typeLoadException.Message))
+					return true;
+			}
 
-	public static bool TryGetStartupFailureMessage(Exception ex, out string title, out string body)
+			if (current is ReflectionTypeLoadException reflectionTypeLoadException)
+			{
+				if (ContainsLibationUiBaseReference(reflectionTypeLoadException.Message))
+					return true;
+
+				if (reflectionTypeLoadException.LoaderExceptions?.Any(e =>
+					e is not null && (ContainsLibationUiBaseReference(e.Message) || ContainsLibationUiBaseReference((e as TypeLoadException)?.TypeName))) == true)
+					return true;
+			}
+
+			if (current is FileLoadException { FileName: { Length: > 0 } fileName }
+				&& fileName.Contains("LibationUiBase", StringComparison.OrdinalIgnoreCase))
+				return true;
+		}
+
+		return false;
+	}
+
+	public static bool IsInstallFolderAssemblyLoadFailure(Exception ex) =>
+		IsApplicationControlBlockedAssembly(ex)
+		|| IsMissingDependencyAssembly(ex)
+		|| IsIncompleteUpgradeAssemblyFailure(ex);
+
+	public static FatalStartupMessage? GetStartupFailureMessage(Exception ex)
 	{
 		if (IsApplicationControlBlockedAssembly(ex))
 		{
-			title = "Libation blocked by Windows security";
-			body = GetApplicationControlBlockedMessage(ex);
-			return true;
+			return new FatalStartupMessage(
+				"Libation blocked by Windows security",
+				GetApplicationControlBlockedMessage(ex));
+		}
+
+		if (IsIncompleteUpgradeAssemblyFailure(ex))
+		{
+			return new FatalStartupMessage(
+				"In-app upgrade failed",
+				GetIncompleteUpgradeFailureMessage(ex));
 		}
 
 		if (IsMissingDependencyAssembly(ex))
 		{
-			title = "Library load failed";
-			body = GetLibraryLoadFailureMessage();
-			return true;
+			return new FatalStartupMessage(
+				"Library load failed",
+				GetLibraryLoadFailureMessage());
 		}
 
-		title = string.Empty;
-		body = string.Empty;
-		return false;
+		return null;
 	}
+
+	/// <summary>
+	/// Resolves a user-facing title and body for a fatal startup or crash, including emergency rollback when needed.
+	/// </summary>
+	public static FatalStartupMessage GetFatalStartupMessage(Exception ex, FatalStartupMessage genericFallback)
+	{
+		if (IsIncompleteUpgradeAssemblyFailure(ex))
+		{
+			var recovery = InstallUpgradeManager.TryEmergencyRollback(Configuration.ProcessDirectory);
+			if (recovery.RolledBack)
+			{
+				return new FatalStartupMessage(
+					recovery.Title,
+					recovery.Message + Environment.NewLine + Environment.NewLine + "Please restart Libation.");
+			}
+		}
+
+		return GetStartupFailureMessage(ex) ?? genericFallback;
+	}
+
+	public static string GetIncompleteUpgradeFailureMessage(Exception? ex = null)
+	{
+		var detail = ex?.Message;
+		if (string.IsNullOrWhiteSpace(detail))
+			detail = "(no additional detail)";
+
+		return $"""
+			Libation could not load a required component after an in-app upgrade. This usually means the upgrade overlay did not replace every install file.
+
+			Technical detail:
+			{detail}
+
+			Install folder:
+			{Configuration.ProcessDirectory}
+
+			Your library database, accounts, and settings are stored separately and should be unaffected.
+
+			To recover:
+			1. Quit Libation completely.
+			2. Download the latest release zip from GitHub.
+			3. Extract it to a new folder (do not copy files on top of the old install).
+			4. Run Libation from the new folder.
+
+			If Windows Smart App Control blocked updated files, see:
+			{TroubleshootIncompleteUpgradeUrl}
+			""";
+	}
+
+	private static bool ContainsLibationUiBaseReference(string? text)
+		=> !string.IsNullOrWhiteSpace(text)
+		&& text.Contains("LibationUiBase", StringComparison.OrdinalIgnoreCase);
 
 	public static bool IsMissingDependencyAssembly(Exception ex)
 	{

--- a/Source/LibationUiBase/Upgrader.cs
+++ b/Source/LibationUiBase/Upgrader.cs
@@ -242,8 +242,15 @@ public abstract class UpgraderBase
 				Serilog.Log.Logger.Information($"Begin running auto-upgrader");
 				try
 				{
-					await interop.InstallUpgradeAsync(upgradeBundle);
+					await interop.InstallUpgradeAsync(upgradeBundle, upgradeProperties.LatestRelease);
 					Serilog.Log.Logger.Information($"Completed running auto-upgrader");
+				}
+				catch (InstallUpgradeIntegrityException ex)
+				{
+					Serilog.Log.Logger.Error(ex, "In-app upgrade failed integrity check and was rolled back");
+					OnUpgradeFailed(
+						$"The in-app upgrade did not complete successfully. Libation restored your previous install files from backup.{Environment.NewLine}{Environment.NewLine}{ex.Message}",
+						ex);
 				}
 				catch (Exception ex)
 				{

--- a/Source/LibationWinForms/Form1.cs
+++ b/Source/LibationWinForms/Form1.cs
@@ -73,6 +73,9 @@ public partial class Form1 : Form
 
 	private async void Form1_Shown(object? sender, EventArgs e)
 	{
+		if (InstallUpgradeManager.TakeStartupRecoveryAlert() is { } recovery)
+			MessageBox.Show(this, recovery.Body, recovery.Title, MessageBoxButtons.OK, MessageBoxIcon.Warning);
+
 		if (Configuration.Instance.FirstLaunch)
 		{
 			var result = MessageBox.Show(this, "Would you like a guided tour to get started?", "Libation Walkthrough", MessageBoxButtons.YesNo, MessageBoxIcon.Question, MessageBoxDefaultButton.Button1);

--- a/Source/LibationWinForms/Program.cs
+++ b/Source/LibationWinForms/Program.cs
@@ -47,6 +47,7 @@ static class Program
 			//***********************************************//
 			// Migrations which must occur before configuration is loaded for the first time. Usually ones which alter the Configuration
 			var config = AppScaffolding.LibationScaffolding.RunPreConfigMigrations();
+			StartupAssemblyBootstrap.RecoverFromIncompleteUpgradeIfNeeded();
 			LibationUiBase.Forms.MessageBoxBase.ShowAsyncImpl = ShowMessageBox;
 			BadBookActionDialogBase.ShowAsyncImpl = ShowBadBookActionDialog;
 
@@ -79,21 +80,19 @@ static class Program
 			if (Configuration.Instance.SerilogInitialized)
 				Log.Error(ex, "Fatal error during startup");
 
-			string title;
-			string body;
-			if (!StartupAssemblyBootstrap.TryGetStartupFailureMessage(ex, out title, out body))
-			{
-				title = "Fatal error, pre-logging";
-				body = "An unrecoverable error occurred. Since this error happened before logging could be initialized, this error can not be written to the log file.";
-			}
+			var fatalMessage = StartupAssemblyBootstrap.GetFatalStartupMessage(
+				ex,
+				new FatalStartupMessage(
+					"Fatal error, pre-logging",
+					"An unrecoverable error occurred. Since this error happened before logging could be initialized, this error can not be written to the log file."));
 
 			try
 			{
-				MessageBoxLib.ShowAdminAlert(null, body, title, ex);
+				MessageBoxLib.ShowAdminAlert(null, fatalMessage.Body, fatalMessage.Title, ex);
 			}
 			catch
 			{
-				MessageBox.Show($"{body}\r\n\r\n{ex.Message}\r\n\r\n{ex.StackTrace}", title, MessageBoxButtons.OK, MessageBoxIcon.Error);
+				MessageBox.Show($"{fatalMessage.Body}\r\n\r\n{ex.Message}\r\n\r\n{ex.StackTrace}", fatalMessage.Title, MessageBoxButtons.OK, MessageBoxIcon.Error);
 			}
 			return;
 		}
@@ -215,8 +214,8 @@ static class Program
 		catch (Exception ex) when (StartupAssemblyBootstrap.IsInstallFolderAssemblyLoadFailure(ex))
 		{
 			Log.Error(ex, "Failed to load library at startup");
-			StartupAssemblyBootstrap.TryGetStartupFailureMessage(ex, out var title, out var body);
-			MessageBoxLib.ShowAdminAlert(form, body, title, ex);
+			var failure = StartupAssemblyBootstrap.GetStartupFailureMessage(ex)!;
+			MessageBoxLib.ShowAdminAlert(form, failure.Body, failure.Title, ex);
 			await form.InitLibraryAsync([]);
 		}
 	}

--- a/Source/LibationWinForms/Program.cs
+++ b/Source/LibationWinForms/Program.cs
@@ -214,7 +214,7 @@ static class Program
 		catch (Exception ex) when (StartupAssemblyBootstrap.IsInstallFolderAssemblyLoadFailure(ex))
 		{
 			Log.Error(ex, "Failed to load library at startup");
-			var failure = StartupAssemblyBootstrap.GetStartupFailureMessage(ex)!;
+			FatalStartupMessage failure = StartupAssemblyBootstrap.GetStartupFailureMessage(ex)!;
 			MessageBoxLib.ShowAdminAlert(form, failure.Body, failure.Title, ex);
 			await form.InitLibraryAsync([]);
 		}

--- a/Source/LoadByOS/LinuxConfigApp/LinuxInterop.cs
+++ b/Source/LoadByOS/LinuxConfigApp/LinuxInterop.cs
@@ -33,7 +33,7 @@ internal class LinuxInterop : IInteropFunctions
 	//.deb or .rpm package. Try to detect this by checking if the symlink exists.
 	public bool CanUpgrade => File.Exists("/usr/bin/libation") || File.Exists("/bin/libation");
 
-	public async Task InstallUpgradeAsync(string upgradeBundle)
+	public async Task InstallUpgradeAsync(string upgradeBundle, Version targetVersion)
 	{
 		if (string.IsNullOrWhiteSpace(upgradeBundle) || !File.Exists(upgradeBundle))
 			throw new FileNotFoundException("Upgrade bundle not found.", upgradeBundle);

--- a/Source/LoadByOS/MacOSConfigApp/MacOSInterop.cs
+++ b/Source/LoadByOS/MacOSConfigApp/MacOSInterop.cs
@@ -46,9 +46,9 @@ internal class MacOSInterop : IInteropFunctions
 
 	public string ReleaseIdString => AppScaffolding.LibationScaffolding.ReleaseIdentifier.ToString();
 
-	public Task InstallUpgradeAsync(string upgradeBundle)
+	public Task InstallUpgradeAsync(string upgradeBundle, Version targetVersion)
 	{
-		Serilog.Log.Information($"Extracting upgrade bundle to {AppPath}");
+		Serilog.Log.Information($"Extracting upgrade bundle to {AppPath} (target version {targetVersion})");
 
 		//Upgrade bundle is a DMG
 		return Task.Run(() => Process.Start("open", upgradeBundle.SurroundWithQuotes())?.WaitForExit());

--- a/Source/LoadByOS/WindowsConfigApp/WinInterop.cs
+++ b/Source/LoadByOS/WindowsConfigApp/WinInterop.cs
@@ -33,13 +33,15 @@ internal class WinInterop : IInteropFunctions
 
 	public string ReleaseIdString => AppScaffolding.LibationScaffolding.ReleaseIdentifier.ToString();
 
-	public async Task InstallUpgradeAsync(string upgradeBundle)
+	public async Task InstallUpgradeAsync(string upgradeBundle, Version targetVersion)
 	{
 		const string ExtractorExeName = "ZipExtractor.exe";
 		var thisExe = Environment.ProcessPath;
 		var thisDir = Path.GetDirectoryName(thisExe);
 		if (!File.Exists(thisExe) || !Directory.Exists(thisDir))
 			return;
+
+		InstallUpgradeManager.PrepareForUpgrade(thisDir, upgradeBundle, targetVersion);
 
 		var zipExtractor = Path.Combine(Path.GetTempPath(), ExtractorExeName);
 
@@ -52,10 +54,31 @@ internal class WinInterop : IInteropFunctions
 
 		var proc = StartProcess(zipExtractor, args, elevate: !IsDirectoryWritable(thisDir));
 		if (proc is null)
+		{
+			InstallUpgradeManager.RollbackAfterFailedUpgrade(thisDir, "Could not start ZipExtractor.");
 			throw new InvalidOperationException("Could not start the upgrade process.");
+		}
+
 		await proc.WaitForExitAsync();
 		if (proc.ExitCode != 0)
-			throw new InvalidOperationException($"ZipExtractor exited with code {proc.ExitCode}.");
+		{
+			var message = $"ZipExtractor exited with code {proc.ExitCode}.";
+			InstallUpgradeManager.RollbackAfterFailedUpgrade(thisDir, message);
+			throw new InvalidOperationException(message);
+		}
+
+		var verification = InstallUpgradeManager.VerifyInstallMatchesUpgrade(thisDir);
+		if (!verification.Success)
+		{
+			InstallUpgradeManager.RollbackAfterFailedUpgrade(thisDir, verification.Summary);
+			Serilog.Log.Logger.Error("In-app upgrade failed integrity check before restart. {Summary}", verification.Summary);
+			throw new InstallUpgradeIntegrityException(
+				$"The in-app upgrade did not replace all required install files.{Environment.NewLine}{Environment.NewLine}{verification.Summary}");
+		}
+
+		Serilog.Log.Logger.Information(
+			"In-app upgrade to {TargetVersion} passed pre-restart integrity check. Pending verification will run on next startup.",
+			targetVersion);
 
 		try
 		{

--- a/Source/_Tests/LibationFileManager.Tests/InstallUpgradeManagerTests.cs
+++ b/Source/_Tests/LibationFileManager.Tests/InstallUpgradeManagerTests.cs
@@ -1,0 +1,167 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.IO;
+using System.IO.Compression;
+using System.Linq;
+
+namespace LibationFileManager.Tests;
+
+[TestClass]
+public class InstallUpgradeManagerTests
+{
+	private string _tempRoot = null!;
+	private string _installDir = null!;
+
+	[TestInitialize]
+	public void Setup()
+	{
+		_tempRoot = Path.Combine(Path.GetTempPath(), "LibationUpgradeTests-" + Guid.NewGuid().ToString("N"));
+		_installDir = Path.Combine(_tempRoot, "install");
+		Directory.CreateDirectory(_installDir);
+	}
+
+	[TestCleanup]
+	public void Cleanup()
+	{
+		try
+		{
+			if (Directory.Exists(_tempRoot))
+				Directory.Delete(_tempRoot, recursive: true);
+		}
+		catch { /* best effort */ }
+	}
+
+	[TestMethod]
+	public void PrepareForUpgrade_creates_backup_and_pending_manifest()
+	{
+		WriteInstallFile("LibationUiBase.dll", "old-ui-base");
+		WriteInstallFile("LibationFileManager.dll", "old-file-manager");
+		WriteInstallFile("AppScaffolding.dll", "old-app-scaffolding");
+		WriteInstallFile("Microsoft.EntityFrameworkCore.Sqlite.dll", "old-ef");
+
+		var zipPath = CreateUpgradeZip(
+			("LibationUiBase.dll", "new-ui-base"),
+			("LibationFileManager.dll", "new-file-manager"),
+			("AppScaffolding.dll", "new-app-scaffolding"),
+			("Microsoft.EntityFrameworkCore.Sqlite.dll", "new-ef"));
+
+		InstallUpgradeManager.PrepareForUpgrade(_installDir, zipPath, new Version(9, 9, 9));
+
+		Assert.IsTrue(File.Exists(InstallUpgradeManager.GetPendingStatePath(_installDir)));
+		Assert.IsTrue(File.Exists(Path.Combine(InstallUpgradeManager.GetBackupDirectory(_installDir), "LibationUiBase.dll")));
+		Assert.AreEqual("old-ui-base", File.ReadAllText(Path.Combine(InstallUpgradeManager.GetBackupDirectory(_installDir), "LibationUiBase.dll")));
+	}
+
+	[TestMethod]
+	public void RecoverPendingUpgradeIfNeeded_rolls_back_when_install_files_do_not_match_zip()
+	{
+		WriteInstallFile("LibationUiBase.dll", "old-ui-base");
+		WriteInstallFile("LibationFileManager.dll", "old-file-manager");
+		WriteInstallFile("AppScaffolding.dll", "old-app-scaffolding");
+		WriteInstallFile("Microsoft.EntityFrameworkCore.Sqlite.dll", "old-ef");
+
+		var zipPath = CreateUpgradeZip(
+			("LibationUiBase.dll", "new-ui-base"),
+			("LibationFileManager.dll", "new-file-manager"),
+			("AppScaffolding.dll", "new-app-scaffolding"),
+			("Microsoft.EntityFrameworkCore.Sqlite.dll", "new-ef"));
+
+		InstallUpgradeManager.PrepareForUpgrade(_installDir, zipPath, new Version(9, 9, 9));
+
+		// Simulate a partial overlay: only some files updated.
+		WriteInstallFile("LibationFileManager.dll", "new-file-manager");
+		WriteInstallFile("AppScaffolding.dll", "new-app-scaffolding");
+		WriteInstallFile("Microsoft.EntityFrameworkCore.Sqlite.dll", "new-ef");
+
+		var recovery = InstallUpgradeManager.RecoverPendingUpgradeIfNeeded(_installDir);
+
+		Assert.IsNotNull(recovery);
+		Assert.IsTrue(recovery!.RolledBack);
+		Assert.AreEqual("old-ui-base", File.ReadAllText(Path.Combine(_installDir, "LibationUiBase.dll")));
+		Assert.IsFalse(File.Exists(InstallUpgradeManager.GetPendingStatePath(_installDir)));
+		var recoveryAlert = InstallUpgradeManager.TakeStartupRecoveryAlert();
+		Assert.IsNotNull(recoveryAlert);
+		Assert.AreEqual("In-app upgrade failed -- Libation was restored", recoveryAlert.Value.Title);
+		StringAssert.Contains(recoveryAlert.Value.Body, "LibationUiBase.dll");
+	}
+
+	[TestMethod]
+	public void RecoverPendingUpgradeIfNeeded_completes_when_install_matches_zip()
+	{
+		WriteInstallFile("LibationUiBase.dll", "old-ui-base");
+		WriteInstallFile("LibationFileManager.dll", "old-file-manager");
+		WriteInstallFile("AppScaffolding.dll", "old-app-scaffolding");
+		WriteInstallFile("Microsoft.EntityFrameworkCore.Sqlite.dll", "old-ef");
+
+		var zipPath = CreateUpgradeZip(
+			("LibationUiBase.dll", "new-ui-base"),
+			("LibationFileManager.dll", "new-file-manager"),
+			("AppScaffolding.dll", "new-app-scaffolding"),
+			("Microsoft.EntityFrameworkCore.Sqlite.dll", "new-ef"));
+
+		InstallUpgradeManager.PrepareForUpgrade(_installDir, zipPath, new Version(9, 9, 9));
+
+		WriteInstallFile("LibationUiBase.dll", "new-ui-base");
+		WriteInstallFile("LibationFileManager.dll", "new-file-manager");
+		WriteInstallFile("AppScaffolding.dll", "new-app-scaffolding");
+		WriteInstallFile("Microsoft.EntityFrameworkCore.Sqlite.dll", "new-ef");
+
+		var recovery = InstallUpgradeManager.RecoverPendingUpgradeIfNeeded(_installDir);
+
+		Assert.IsNull(recovery);
+		Assert.IsFalse(Directory.Exists(InstallUpgradeManager.GetUpgradeStateDirectory(_installDir)));
+	}
+
+	[TestMethod]
+	public void VerifyInstallMatchesUpgrade_reports_missing_files()
+	{
+		var zipPath = CreateUpgradeZip(("LibationUiBase.dll", "new-ui-base"));
+		InstallUpgradeManager.PrepareForUpgrade(_installDir, zipPath, new Version(1, 2, 3));
+
+		File.Delete(Path.Combine(_installDir, "LibationUiBase.dll"));
+
+		var verification = InstallUpgradeManager.VerifyInstallMatchesUpgrade(_installDir);
+
+		Assert.IsFalse(verification.Success);
+		Assert.IsTrue(verification.FailedFiles.Any(f => f.Contains("LibationUiBase.dll", StringComparison.OrdinalIgnoreCase)));
+	}
+
+	[TestMethod]
+	public void GetFatalStartupMessage_uses_incomplete_upgrade_body_for_LibationUiBase_TypeLoadException()
+	{
+		var ex = new TypeLoadException("Could not load type 'LibationUiBase.ShowBadBookDialogAsyncDelegate' from assembly 'LibationUiBase'.");
+		var message = StartupAssemblyBootstrap.GetFatalStartupMessage(
+			ex,
+			new FatalStartupMessage("Generic", "Generic body"));
+		Assert.AreEqual("In-app upgrade failed", message.Title);
+		StringAssert.Contains(message.Body, "LibationUiBase");
+	}
+
+	[TestMethod]
+	public void GetStartupFailureMessage_detects_LibationUiBase_TypeLoadException()
+	{
+		var ex = new TypeLoadException("Could not load type 'LibationUiBase.ShowBadBookDialogAsyncDelegate' from assembly 'LibationUiBase'.");
+		Assert.IsTrue(StartupAssemblyBootstrap.IsIncompleteUpgradeAssemblyFailure(ex));
+		var message = StartupAssemblyBootstrap.GetStartupFailureMessage(ex);
+		Assert.IsNotNull(message);
+		Assert.AreEqual("In-app upgrade failed", message.Value.Title);
+		StringAssert.Contains(message.Value.Body, "LibationUiBase");
+	}
+
+	private void WriteInstallFile(string fileName, string contents)
+		=> File.WriteAllText(Path.Combine(_installDir, fileName), contents);
+
+	private static string CreateUpgradeZip(params (string FileName, string Contents)[] files)
+	{
+		var zipPath = Path.Combine(Path.GetTempPath(), "LibationUpgradeTests-" + Guid.NewGuid().ToString("N") + ".zip");
+		using var zip = ZipFile.Open(zipPath, ZipArchiveMode.Create);
+		foreach (var (fileName, contents) in files)
+		{
+			var entry = zip.CreateEntry(fileName);
+			using var writer = new StreamWriter(entry.Open());
+			writer.Write(contents);
+		}
+
+		return zipPath;
+	}
+}

--- a/Source/_Tests/LibationFileManager.Tests/InstallUpgradeManagerTests.cs
+++ b/Source/_Tests/LibationFileManager.Tests/InstallUpgradeManagerTests.cs
@@ -81,8 +81,8 @@ public class InstallUpgradeManagerTests
 		Assert.IsFalse(File.Exists(InstallUpgradeManager.GetPendingStatePath(_installDir)));
 		var recoveryAlert = InstallUpgradeManager.TakeStartupRecoveryAlert();
 		Assert.IsNotNull(recoveryAlert);
-		Assert.AreEqual("In-app upgrade failed -- Libation was restored", recoveryAlert.Value.Title);
-		StringAssert.Contains(recoveryAlert.Value.Body, "LibationUiBase.dll");
+		Assert.AreEqual("In-app upgrade failed -- Libation was restored", recoveryAlert.Title);
+		StringAssert.Contains(recoveryAlert.Body, "LibationUiBase.dll");
 	}
 
 	[TestMethod]
@@ -144,8 +144,8 @@ public class InstallUpgradeManagerTests
 		Assert.IsTrue(StartupAssemblyBootstrap.IsIncompleteUpgradeAssemblyFailure(ex));
 		var message = StartupAssemblyBootstrap.GetStartupFailureMessage(ex);
 		Assert.IsNotNull(message);
-		Assert.AreEqual("In-app upgrade failed", message.Value.Title);
-		StringAssert.Contains(message.Value.Body, "LibationUiBase");
+		Assert.AreEqual("In-app upgrade failed", message.Title);
+		StringAssert.Contains(message.Body, "LibationUiBase");
 	}
 
 	private void WriteInstallFile(string fileName, string contents)


### PR DESCRIPTION
Fixes crash loops after incomplete in-app upgrades (eg #1878 ), where ZipExtractor updated Libation.exe but left stale DLLs like LibationUiBase.dll, causing TypeLoadException on restart.

* Pre-upgrade backup: Before ZipExtractor runs, critical install files are backed up to `.libation-upgrade/backup/` and expected post-upgrade hashes are recorded from the upgrade zip.
* Integrity verification: On startup (and after ZipExtractor when the process survives), install files are checked against the zip manifest and LibationUiBase is probed for required types.
* Automatic rollback: If verification fails, backed-up files are restored, the failure is logged at Error with per-file details, and the user sees a warning dialog.
* Emergency rollback: If startup still hits a LibationUiBase load failure, rollback is attempted from backup before showing a crash/recovery message.