### PR TITLE
Mark macOS app bundle as APPL

### DIFF
--- a/Scripts/Bundle_MacOS.sh
+++ b/Scripts/Bundle_MacOS.sh
@@ -110,6 +110,9 @@ mv $BUNDLE_MACOS/libation.icns $BUNDLE_RESOURCES/libation.icns
 echo "Moving Info.plist file..."
 mv $BUNDLE_MACOS/Info.plist $BUNDLE_CONTENTS/Info.plist
 
+echo "Writing PkgInfo file..."
+printf 'APPL????' > $BUNDLE_CONTENTS/PkgInfo
+
 echo "Moving Libation_DS_Store file..."
 mv $BUNDLE_MACOS/Libation_DS_Store ./Libation_DS_Store
 

--- a/Source/LibationUiBase/LibationContributor.cs
+++ b/Source/LibationUiBase/LibationContributor.cs
@@ -51,6 +51,7 @@ public class LibationContributor
 			GitHubUser("Youssef1313"),
 			GitHubUser("niontrix"),
 			GitHubUser("CryptoJones"),
+			GitHubUser("m-j-r"),
 		]);
 
 	private LibationContributor(string name, LibationContributorType type, Uri link)

--- a/Source/LoadByOS/MacOSConfigApp/Info.plist
+++ b/Source/LoadByOS/MacOSConfigApp/Info.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>CFBundlePackageType</key>
+	<string>APPL</string>
 	<key>CFBundleExecutable</key>
 	<string>Libation</string>
 	<key>CFBundleName</key>


### PR DESCRIPTION
Mark macOS app bundle as APPL so Gatekeeper and Homebrew cask audits accept it.

Thanks, @m-j-r !