### PR TITLE
Add encrypted AccountsSettings token storage with Important settings UI

### DIFF
--- a/Source/AppScaffolding/AppScaffolding.csproj
+++ b/Source/AppScaffolding/AppScaffolding.csproj
@@ -2,7 +2,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
-    <Version>13.5.1</Version>
+    <Version>13.6.0</Version>
     <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>

--- a/Source/AppScaffolding/LibationScaffolding.cs
+++ b/Source/AppScaffolding/LibationScaffolding.cs
@@ -96,6 +96,7 @@ public static class LibationScaffolding
 		}
 		DeleteOpenSqliteFiles(config);
 		AudibleApiStorage.EnsureAccountsSettingsFileExists();
+		IdentityTokenStorageWiring.Apply(config);
 
 		//
 		// migrations go below here

--- a/Source/AudibleUtilities/AccountTokenStorage.cs
+++ b/Source/AudibleUtilities/AccountTokenStorage.cs
@@ -1,0 +1,59 @@
+using AudibleApi.Authorization;
+
+namespace AudibleUtilities;
+
+/// <summary>
+/// Alignment and conversion helpers for identity tokens in <c>AccountsSettings.json</c>.
+/// Preference changes alone do not convert; conversion is explicit via <see cref="ConvertAllAccounts"/>.
+/// </summary>
+public static class AccountTokenStorage
+{
+	/// <summary>
+	/// Compare persisted encryption metadata for all account identities to <paramref name="method"/>.
+	/// </summary>
+	public static TokenStorageAlignment GetAccountsAlignment(TokenStorageMethod method, string? accountsSettingsFile = null)
+	{
+		var path = accountsSettingsFile ?? AudibleApiStorage.AccountsSettingsFile;
+		if (!File.Exists(path))
+			return TokenStorageAlignment.NoApplicableTokens;
+
+		using var persister = new AccountsSettingsPersister(path);
+		var alignments = new List<TokenStorageAlignment>();
+
+		foreach (var account in persister.AccountsSettings.Accounts)
+		{
+			if (account.IdentityTokens is null)
+				continue;
+
+			alignments.Add(IdentityTokenConversion.GetAlignment(account.IdentityTokens, method));
+		}
+
+		return CombineAlignments(alignments);
+	}
+
+	/// <summary>
+	/// Convert every identity in the accounts settings file to <paramref name="method"/>.
+	/// All-or-nothing: failure leaves the original file unchanged.
+	/// </summary>
+	public static IdentityTokenConversionResult ConvertAllAccounts(TokenStorageMethod method, string? accountsSettingsFile = null)
+	{
+		var path = accountsSettingsFile ?? AudibleApiStorage.AccountsSettingsFile;
+		return IdentityTokenConversion.ConvertAllIdentitiesInFile(path, method);
+	}
+
+	private static TokenStorageAlignment CombineAlignments(IReadOnlyList<TokenStorageAlignment> alignments)
+	{
+		if (alignments.Count == 0)
+			return TokenStorageAlignment.NoApplicableTokens;
+		if (alignments.Any(a => a == TokenStorageAlignment.Indeterminate))
+			return TokenStorageAlignment.Indeterminate;
+		if (alignments.All(a => a is TokenStorageAlignment.AllMatch or TokenStorageAlignment.NoApplicableTokens))
+		{
+			return alignments.Any(a => a == TokenStorageAlignment.AllMatch)
+				? TokenStorageAlignment.AllMatch
+				: TokenStorageAlignment.NoApplicableTokens;
+		}
+
+		return TokenStorageAlignment.SomeMismatch;
+	}
+}

--- a/Source/AudibleUtilities/AudibleUtilities.csproj
+++ b/Source/AudibleUtilities/AudibleUtilities.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AudibleApi" Version="10.3.0.1" />
+    <PackageReference Include="AudibleApi" Version="10.3.1.1" />
     <PackageReference Include="Google.Protobuf" Version="3.34.1" />
   </ItemGroup>
 

--- a/Source/AudibleUtilities/AudibleUtilities.csproj
+++ b/Source/AudibleUtilities/AudibleUtilities.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AudibleApi" Version="10.2.0.1" />
+    <PackageReference Include="AudibleApi" Version="10.3.0.1" />
     <PackageReference Include="Google.Protobuf" Version="3.34.1" />
   </ItemGroup>
 

--- a/Source/AudibleUtilities/IdentityTokenStorageWiring.cs
+++ b/Source/AudibleUtilities/IdentityTokenStorageWiring.cs
@@ -1,0 +1,76 @@
+using AudibleApi.Authorization;
+using Dinah.Core.Security;
+using LibationFileManager;
+using System.ComponentModel;
+
+namespace AudibleUtilities;
+
+/// <summary>
+/// Applies Libation's <see cref="Configuration.TokenStorageMethod"/> to AudibleApi identity persistence.
+/// Changing the preference alone does not convert existing tokens.
+/// </summary>
+public static class IdentityTokenStorageWiring
+{
+	public const string ApplicationName = "Libation";
+
+	private static Lock Gate { get; } = new();
+	private static Configuration? _wiredConfig;
+
+	/// <summary>
+	/// Configure AudibleApi token persistence from <paramref name="config"/> and keep it in sync when the preference changes.
+	/// </summary>
+	public static void Apply(Configuration config)
+	{
+		ArgumentNullException.ThrowIfNull(config);
+
+		ConfigureFrom(config);
+
+		lock (Gate)
+		{
+			if (ReferenceEquals(_wiredConfig, config))
+				return;
+
+			if (_wiredConfig is not null)
+				_wiredConfig.PropertyChanged -= OnPropertyChanged;
+
+			_wiredConfig = config;
+			_wiredConfig.PropertyChanged += OnPropertyChanged;
+		}
+	}
+
+	/// <summary>
+	/// Configure AudibleApi from the current preference without attaching change listeners.
+	/// Prefer <see cref="Apply"/> at application startup.
+	/// </summary>
+	public static void ConfigureFrom(Configuration config)
+	{
+		ArgumentNullException.ThrowIfNull(config);
+
+		var method = config.TokenStorageMethod;
+		var store = OsSecretStore.Create(ApplicationName);
+		AesGcmSecretProtector? protector = store.IsAvailable
+			? new AesGcmSecretProtector(store)
+			: null;
+
+		// Encrypted + unavailable store => protector null => fail-closed on encrypt/decrypt.
+		IdentityTokenStorage.Configure(method, protector);
+	}
+
+	/// <summary>True when the OS secret store can hold Libation's encryption master key.</summary>
+	public static bool IsOsSecretStoreAvailable(out string? unavailableReason)
+	{
+		var store = OsSecretStore.Create(ApplicationName);
+		unavailableReason = store.IsAvailable ? null : store.UnavailableReason;
+		return store.IsAvailable;
+	}
+
+	private static void OnPropertyChanged(object? sender, PropertyChangedEventArgs e)
+	{
+		if (e.PropertyName != nameof(Configuration.TokenStorageMethod))
+			return;
+		if (sender is not Configuration config)
+			return;
+
+		ConfigureFrom(config);
+	}
+}

--- a/Source/DataLayer/DataLayer.csproj
+++ b/Source/DataLayer/DataLayer.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
@@ -11,8 +11,8 @@
   </PropertyGroup>
   
   <ItemGroup>
-    <PackageReference Include="Dinah.Core" Version="10.1.0.1" />
-    <PackageReference Include="Dinah.EntityFrameworkCore" Version="10.1.0.1" />
+    <PackageReference Include="Dinah.Core" Version="10.2.0.1" />
+    <PackageReference Include="Dinah.EntityFrameworkCore" Version="10.2.0.1" />
 	<PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.0.1" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.0.7" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.7">

--- a/Source/DataLayer/DataLayer.csproj
+++ b/Source/DataLayer/DataLayer.csproj
@@ -12,7 +12,7 @@
   
   <ItemGroup>
     <PackageReference Include="Dinah.Core" Version="10.1.0.1" />
-    <PackageReference Include="Dinah.EntityFrameworkCore" Version="10.0.0.1" />
+    <PackageReference Include="Dinah.EntityFrameworkCore" Version="10.1.0.1" />
 	<PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.0.1" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.0.7" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.7">

--- a/Source/DataLayer/DataLayer.csproj
+++ b/Source/DataLayer/DataLayer.csproj
@@ -11,7 +11,7 @@
   </PropertyGroup>
   
   <ItemGroup>
-    <PackageReference Include="Dinah.Core" Version="10.0.0.1" />
+    <PackageReference Include="Dinah.Core" Version="10.1.0.1" />
     <PackageReference Include="Dinah.EntityFrameworkCore" Version="10.0.0.1" />
 	<PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.0.1" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.0.7" />

--- a/Source/FileManager/FileManager.csproj
+++ b/Source/FileManager/FileManager.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Dinah.Core" Version="10.0.0.1" />
+    <PackageReference Include="Dinah.Core" Version="10.1.0.1" />
     <PackageReference Include="Polly" Version="8.6.6" />
   </ItemGroup>
 

--- a/Source/FileManager/FileManager.csproj
+++ b/Source/FileManager/FileManager.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Dinah.Core" Version="10.1.0.1" />
+    <PackageReference Include="Dinah.Core" Version="10.2.0.1" />
     <PackageReference Include="Polly" Version="8.6.6" />
   </ItemGroup>
 

--- a/Source/LibationAvalonia/Controls/Settings/Important.axaml
+++ b/Source/LibationAvalonia/Controls/Settings/Important.axaml
@@ -8,7 +8,7 @@
 			 x:DataType="vm:ImportantSettingsVM"
              x:Class="LibationAvalonia.Controls.Settings.Important">
 
-	<Grid RowDefinitions="Auto,Auto,Auto,Auto,*">
+	<Grid RowDefinitions="Auto,Auto,Auto,Auto,Auto,*">
 		<controls:GroupBox
 			Grid.Row="0"
 			Margin="5"
@@ -85,8 +85,41 @@
 			</StackPanel>
 		</CheckBox>
 
+		<controls:GroupBox
+			Grid.Row="2"
+			Margin="5"
+			Label="Authentication tokens">
+			<StackPanel>
+				<CheckBox
+					IsEnabled="{Binding CanEditEncryptTokens}"
+					IsChecked="{Binding EncryptTokens, Mode=TwoWay}">
+					<TextBlock Text="{Binding EncryptTokensText}" TextWrapping="Wrap" />
+				</CheckBox>
+				<TextBlock
+					Margin="24,4,0,0"
+					Foreground="DarkRed"
+					IsVisible="{Binding PlaintextWarningVisible}"
+					Text="{Binding PlaintextWarningText}"
+					TextWrapping="Wrap" />
+				<TextBlock
+					Margin="24,4,0,0"
+					Foreground="DarkRed"
+					IsVisible="{Binding OsStoreUnavailableVisible}"
+					Text="{Binding OsStoreUnavailableMessage}"
+					TextWrapping="Wrap" />
+				<Button
+					Margin="0,10,0,0"
+					HorizontalAlignment="Right"
+					Padding="20,0"
+					Content="{Binding ConvertButtonText}"
+					ToolTip.Tip="{Binding ConvertButtonToolTip}"
+					IsEnabled="{Binding ConvertButtonEnabled}"
+					Command="{Binding ConvertExistingTokensCommand}" />
+			</StackPanel>
+		</controls:GroupBox>
+
 		<StackPanel
-			Grid.Row="2" Margin="5"
+			Grid.Row="3" Margin="5"
 			Orientation="Horizontal">
 
 			<TextBlock
@@ -111,7 +144,7 @@
 		</StackPanel>
 
 		<controls:GroupBox
-			Grid.Row="3"
+			Grid.Row="4"
 			Margin="5"
 			Label="Display Settings">
 			<Grid
@@ -166,7 +199,7 @@
 		</controls:GroupBox>
 
 		<Grid
-			Grid.Row="4"
+			Grid.Row="5"
 			ColumnDefinitions="Auto,Auto,*"
 			Margin="10"
 			VerticalAlignment="Bottom">

--- a/Source/LibationAvalonia/Dialogs/SettingsDialog.axaml.cs
+++ b/Source/LibationAvalonia/Dialogs/SettingsDialog.axaml.cs
@@ -2,6 +2,7 @@ using Avalonia.Controls;
 using FileManager;
 using LibationAvalonia.ViewModels.Settings;
 using LibationFileManager;
+using LibationUiBase;
 using LibationUiBase.Forms;
 using System;
 using System.Threading.Tasks;
@@ -32,7 +33,18 @@ public partial class SettingsDialog : DialogWindow
 
 		#endregion
 
+		var tokenDecision = await settingsDisp.ImportantSettings.PromptOnSaveAsync(this);
+		if (tokenDecision == TokenStorageSaveDecision.Abort)
+			return;
+
 		settingsDisp.SaveSettings(config);
+
+		if (tokenDecision == TokenStorageSaveDecision.SavePreferenceAndConvert)
+		{
+			var converted = await settingsDisp.ImportantSettings.ConvertAfterSaveAsync(this);
+			if (!converted)
+				return;
+		}
 
 		await MessageBox.VerboseLoggingWarning_ShowIfTrue();
 		await base.SaveAndCloseAsync();

--- a/Source/LibationAvalonia/Dialogs/SetupDialog.axaml
+++ b/Source/LibationAvalonia/Dialogs/SetupDialog.axaml
@@ -9,6 +9,7 @@
 		Width="500" Height="350"
 		Icon="/Assets/libation.ico"
         Title="Welcome to Libation"
+		ShowInTaskbar="True"
 		x:DataType="dialogs:SetupDialog">
 
 	<Grid

--- a/Source/LibationAvalonia/ViewModels/Settings/ImportantSettingsVM.cs
+++ b/Source/LibationAvalonia/ViewModels/Settings/ImportantSettingsVM.cs
@@ -1,3 +1,5 @@
+using AudibleApi.Authorization;
+using AudibleUtilities;
 using Dinah.Core;
 using FileManager;
 using LibationFileManager;
@@ -6,6 +8,8 @@ using ReactiveUI;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading.Tasks;
+using System.Windows.Input;
 
 namespace LibationAvalonia.ViewModels.Settings;
 
@@ -13,6 +17,13 @@ public class ImportantSettingsVM : ViewModelBase
 {
 	private EnumDisplay<Configuration.Theme> themeVariant;
 	private readonly Configuration config;
+	private bool encryptTokens;
+	private bool plaintextWarningVisible;
+	private bool convertButtonEnabled;
+	private bool osStoreUnavailableVisible;
+	private string osStoreUnavailableMessage = "";
+	private TokenStorageMethod initialTokenStorageMethod;
+	private bool osSecretStoreAvailable;
 
 	public ImportantSettingsVM(Configuration config)
 	{
@@ -29,7 +40,32 @@ public class ImportantSettingsVM : ViewModelBase
 		GridFontScaleFactor = scaleFactorToLinearRange(config.GridFontScaleFactor);
 
 		themeVariant = Themes.Single(v => v.Value == config.ThemeVariant);
+
+		initialTokenStorageMethod = config.TokenStorageMethod;
+		osSecretStoreAvailable = IdentityTokenStorageWiring.IsOsSecretStoreAvailable(out var unavailableReason);
+		if (!osSecretStoreAvailable)
+		{
+			OsStoreUnavailableVisible = true;
+			OsStoreUnavailableMessage = TokenStorageSettingsUi.OsStoreUnavailableMessage(unavailableReason);
+			encryptTokens = false;
+			CanEditEncryptTokens = false;
+		}
+		else
+		{
+			OsStoreUnavailableVisible = false;
+			encryptTokens = TokenStorageSettingsUi.CheckboxFromMethod(config.TokenStorageMethod);
+			CanEditEncryptTokens = true;
+		}
+
+		RefreshTokenStorageUiState();
+		ConvertExistingTokensCommand = ReactiveCommand.CreateFromTask(ConvertExistingTokensAsync);
 	}
+
+	public async Task<TokenStorageSaveDecision> PromptOnSaveAsync(object? owner)
+		=> await TokenStorageSettingsUi.PromptOnPreferenceSaveAsync(owner, initialTokenStorageMethod, SelectedTokenStorageMethod);
+
+	public async Task<bool> ConvertAfterSaveAsync(object? owner)
+		=> await TokenStorageSettingsUi.RunConversionAsync(owner, SelectedTokenStorageMethod);
 
 	public void SaveSettings(Configuration config)
 	{
@@ -40,6 +76,9 @@ public class ImportantSettingsVM : ViewModelBase
 		config.LastWriteTime = LastWriteTime.Value;
 		config.UseWebView = UseWebView;
 		config.LogLevel = LoggingLevel;
+		config.TokenStorageMethod = SelectedTokenStorageMethod;
+		initialTokenStorageMethod = SelectedTokenStorageMethod;
+		RefreshTokenStorageUiState();
 	}
 
 	public LongPath GetBooksDirectory()
@@ -62,6 +101,24 @@ public class ImportantSettingsVM : ViewModelBase
 		else
 			Go.To.Folder(Configuration.Instance.LibationFiles.Location.ShortPathName);
 	}
+
+	private async Task ConvertExistingTokensAsync()
+	{
+		var converted = await TokenStorageSettingsUi.ConfirmAndConvertAsync(null, SelectedTokenStorageMethod);
+		if (converted)
+			RefreshTokenStorageUiState();
+	}
+
+	private void RefreshTokenStorageUiState()
+	{
+		var method = SelectedTokenStorageMethod;
+		PlaintextWarningVisible = osSecretStoreAvailable && method == TokenStorageMethod.Plaintext;
+		var alignment = AccountTokenStorage.GetAccountsAlignment(method);
+		ConvertButtonEnabled = TokenStorageSettingsUi.IsConvertButtonEnabled(alignment);
+	}
+
+	private TokenStorageMethod SelectedTokenStorageMethod
+		=> TokenStorageSettingsUi.MethodFromCheckbox(EncryptTokens);
 
 	public List<Configuration.KnownDirectories> KnownDirectories { get; } = new()
 	{
@@ -95,6 +152,12 @@ public class ImportantSettingsVM : ViewModelBase
 		.Select(v => new EnumDisplay<Configuration.Theme>(v))
 		.ToArray();
 
+	public string EncryptTokensText { get; } = TokenStorageSettingsUi.CheckboxText;
+	public string PlaintextWarningText { get; } = TokenStorageSettingsUi.PlaintextWarningText;
+	public string ConvertButtonText { get; } = TokenStorageSettingsUi.ConvertButtonText;
+	public string ConvertButtonToolTip { get; } = TokenStorageSettingsUi.ConvertButtonToolTip;
+	public bool CanEditEncryptTokens { get; }
+
 	public string BooksDirectory { get; set; }
 	public bool SavePodcastsToParentFolder { get; set; }
 	public bool OverwriteExisting { get; set; }
@@ -104,6 +167,42 @@ public class ImportantSettingsVM : ViewModelBase
 	public EnumDisplay<Configuration.DateTimeSource> LastWriteTime { get; set; }
 	public bool UseWebView { get; set; }
 	public Serilog.Events.LogEventLevel LoggingLevel { get; set; }
+
+	public bool EncryptTokens
+	{
+		get => encryptTokens;
+		set
+		{
+			this.RaiseAndSetIfChanged(ref encryptTokens, value);
+			RefreshTokenStorageUiState();
+		}
+	}
+
+	public bool PlaintextWarningVisible
+	{
+		get => plaintextWarningVisible;
+		private set => this.RaiseAndSetIfChanged(ref plaintextWarningVisible, value);
+	}
+
+	public bool ConvertButtonEnabled
+	{
+		get => convertButtonEnabled;
+		private set => this.RaiseAndSetIfChanged(ref convertButtonEnabled, value);
+	}
+
+	public bool OsStoreUnavailableVisible
+	{
+		get => osStoreUnavailableVisible;
+		private set => this.RaiseAndSetIfChanged(ref osStoreUnavailableVisible, value);
+	}
+
+	public string OsStoreUnavailableMessage
+	{
+		get => osStoreUnavailableMessage;
+		private set => this.RaiseAndSetIfChanged(ref osStoreUnavailableMessage, value);
+	}
+
+	public ICommand ConvertExistingTokensCommand { get; }
 
 	public EnumDisplay<Configuration.Theme> ThemeVariant
 	{

--- a/Source/LibationFileManager/Configuration.PersistentSettings.cs
+++ b/Source/LibationFileManager/Configuration.PersistentSettings.cs
@@ -1,3 +1,4 @@
+using AudibleApi.Authorization;
 using FileManager;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Converters;
@@ -299,6 +300,13 @@ public partial class Configuration
 	{
 		EC_3,
 		AC_4
+	}
+
+	[Description("Store authentication tokens encrypted using the OS secret store.\r\nUnchecking stores tokens in plaintext in AccountsSettings.json.\r\nChanging this setting does not convert existing tokens until you choose to convert them.")]
+	public TokenStorageMethod TokenStorageMethod
+	{
+		get => GetNonString(defaultValue: TokenStorageMethod.Encrypted);
+		set => SetNonString(value);
 	}
 
 	[Description("Use Widevine DRM")]

--- a/Source/LibationFileManager/Configuration.PersistentSettings.cs
+++ b/Source/LibationFileManager/Configuration.PersistentSettings.cs
@@ -302,7 +302,7 @@ public partial class Configuration
 		AC_4
 	}
 
-	[Description("Store authentication tokens encrypted using the OS secret store.\r\nUnchecking stores tokens in plaintext in AccountsSettings.json.\r\nChanging this setting does not convert existing tokens until you choose to convert them.")]
+	[Description("Store authentication tokens encrypted. Unchecking this option stores tokens in plaintext.")]
 	public TokenStorageMethod TokenStorageMethod
 	{
 		get => GetNonString(defaultValue: TokenStorageMethod.Encrypted);

--- a/Source/LibationFileManager/LibationFileManager.csproj
+++ b/Source/LibationFileManager/LibationFileManager.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AudibleApi" Version="10.3.0.1" />
+    <PackageReference Include="AudibleApi" Version="10.3.1.1" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="10.0.7" />
     <PackageReference Include="NameParserSharp" Version="1.5.0" />
     <PackageReference Include="Serilog.Exceptions" Version="8.4.0" />

--- a/Source/LibationFileManager/LibationFileManager.csproj
+++ b/Source/LibationFileManager/LibationFileManager.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AudibleApi" Version="10.2.0.1" />
+    <PackageReference Include="AudibleApi" Version="10.3.0.1" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="10.0.7" />
     <PackageReference Include="NameParserSharp" Version="1.5.0" />
     <PackageReference Include="Serilog.Exceptions" Version="8.4.0" />

--- a/Source/LibationUiBase/TokenStorageSettingsUi.cs
+++ b/Source/LibationUiBase/TokenStorageSettingsUi.cs
@@ -1,0 +1,210 @@
+using AudibleApi.Authorization;
+using AudibleUtilities;
+using LibationUiBase.Forms;
+using System.Threading.Tasks;
+
+namespace LibationUiBase;
+
+/// <summary>
+/// Shared copy and workflows for Important settings token-storage controls.
+/// </summary>
+public static class TokenStorageSettingsUi
+{
+	public const string CheckboxText
+		= "Store authentication tokens encrypted. Unchecking this option stores tokens in plaintext.";
+
+	public const string PlaintextWarningText
+		= "Authentication tokens will be stored as readable plaintext in AccountsSettings.json.";
+
+	public const string ConvertButtonText = "Update existing stored tokens";
+
+	public const string ConvertButtonToolTip
+		= "Convert existing tokens in AccountsSettings.json to match the currently selected storage method.";
+
+	public const string SavePromptCaption = "Convert existing tokens?";
+	public const string ConvertConfirmCaption = "Confirm token conversion";
+	public const string ConversionFailedCaption = "Token conversion failed";
+	public const string ConversionSucceededCaption = "Tokens updated";
+	public const string OsStoreUnavailableCaption = "Encrypted token storage unavailable";
+
+	public const string SavePromptEncrypted
+		= "New and refreshed authentication tokens will now be stored encrypted. Would you also like to encrypt and re-save existing plaintext tokens?";
+
+	public const string SavePromptPlaintext
+		= "New and refreshed authentication tokens will now be stored in plaintext. Would you also like to decrypt and re-save existing encrypted tokens? This will make those token values readable in the account settings file.";
+
+	public const string StandaloneConfirmEncrypted
+		= "Encrypt and re-save existing plaintext authentication tokens so they match the current setting?";
+
+	public const string StandaloneConfirmPlaintext
+		= "Decrypt and re-save existing encrypted authentication tokens as plaintext? This will make those token values readable in the account settings file.";
+
+	public const string ConversionSucceededMessage
+		= "Existing authentication tokens were updated to match the selected storage method.";
+
+	public static TokenStorageMethod MethodFromCheckbox(bool storeEncrypted)
+		=> storeEncrypted ? TokenStorageMethod.Encrypted : TokenStorageMethod.Plaintext;
+
+	public static bool CheckboxFromMethod(TokenStorageMethod method)
+		=> method == TokenStorageMethod.Encrypted;
+
+	/// <summary>
+	/// Convert is offered for mismatches and indeterminate state.
+	/// Matching / no-token states keep the button disabled.
+	/// </summary>
+	public static bool IsConvertButtonEnabled(TokenStorageAlignment alignment)
+		=> alignment is TokenStorageAlignment.SomeMismatch or TokenStorageAlignment.Indeterminate;
+
+	public static string SavePromptBody(TokenStorageMethod method)
+		=> method == TokenStorageMethod.Encrypted ? SavePromptEncrypted : SavePromptPlaintext;
+
+	public static string StandaloneConfirmBody(TokenStorageMethod method)
+		=> method == TokenStorageMethod.Encrypted ? StandaloneConfirmEncrypted : StandaloneConfirmPlaintext;
+
+	public static string OsStoreUnavailableMessage(string? unavailableReason)
+		=> string.IsNullOrWhiteSpace(unavailableReason)
+			? "Encrypted token storage requires an OS secret store, which is not available. Tokens cannot be stored encrypted."
+			: $"Encrypted token storage requires an OS secret store, which is not available: {unavailableReason}";
+
+	public static string FormatConversionError(IdentityTokenConversionResult result)
+	{
+		var error = string.IsNullOrWhiteSpace(result.Error)
+			? "Token conversion failed."
+			: result.Error!;
+
+		if (result.FailedCategories.Count == 0)
+			return error;
+
+		return $"{error}\r\n\r\nFailed categories: {string.Join(", ", result.FailedCategories)}";
+	}
+
+	/// <summary>
+	/// Decide whether saving a changed preference should also convert existing tokens.
+	/// Cancel / dismiss must never be treated as approval.
+	/// </summary>
+	public static async Task<TokenStorageSaveDecision> PromptOnPreferenceSaveAsync(
+		object? owner,
+		TokenStorageMethod originalMethod,
+		TokenStorageMethod selectedMethod)
+	{
+		if (originalMethod == selectedMethod)
+			return TokenStorageSaveDecision.SavePreferenceOnly;
+
+		if (selectedMethod == TokenStorageMethod.Encrypted
+			&& !IdentityTokenStorageWiring.IsOsSecretStoreAvailable(out var unavailableReason))
+		{
+			await MessageBoxBase.Show(
+				owner,
+				OsStoreUnavailableMessage(unavailableReason),
+				OsStoreUnavailableCaption,
+				MessageBoxButtons.OK,
+				MessageBoxIcon.Error);
+			return TokenStorageSaveDecision.Abort;
+		}
+
+		var alignment = AccountTokenStorage.GetAccountsAlignment(selectedMethod);
+		if (alignment is TokenStorageAlignment.AllMatch or TokenStorageAlignment.NoApplicableTokens)
+			return TokenStorageSaveDecision.SavePreferenceOnly;
+
+		var result = await MessageBoxBase.Show(
+			owner,
+			SavePromptBody(selectedMethod),
+			SavePromptCaption,
+			MessageBoxButtons.YesNoCancel,
+			MessageBoxIcon.Warning,
+			defaultButton: selectedMethod == TokenStorageMethod.Plaintext
+				? MessageBoxDefaultButton.Button2
+				: MessageBoxDefaultButton.Button1);
+
+		return result switch
+		{
+			DialogResult.Yes => TokenStorageSaveDecision.SavePreferenceAndConvert,
+			DialogResult.No => TokenStorageSaveDecision.SavePreferenceOnly,
+			_ => TokenStorageSaveDecision.Abort
+		};
+	}
+
+	public static async Task<bool> ConfirmAndConvertAsync(object? owner, TokenStorageMethod method)
+	{
+		if (method == TokenStorageMethod.Encrypted
+			&& !IdentityTokenStorageWiring.IsOsSecretStoreAvailable(out var unavailableReason))
+		{
+			await MessageBoxBase.Show(
+				owner,
+				OsStoreUnavailableMessage(unavailableReason),
+				OsStoreUnavailableCaption,
+				MessageBoxButtons.OK,
+				MessageBoxIcon.Error);
+			return false;
+		}
+
+		var alignment = AccountTokenStorage.GetAccountsAlignment(method);
+		if (!IsConvertButtonEnabled(alignment))
+			return false;
+
+		var confirm = await MessageBoxBase.Show(
+			owner,
+			StandaloneConfirmBody(method),
+			ConvertConfirmCaption,
+			MessageBoxButtons.YesNo,
+			MessageBoxIcon.Warning,
+			defaultButton: method == TokenStorageMethod.Plaintext
+				? MessageBoxDefaultButton.Button2
+				: MessageBoxDefaultButton.Button1);
+
+		if (confirm != DialogResult.Yes)
+			return false;
+
+		return await RunConversionAsync(owner, method);
+	}
+
+	public static async Task<bool> RunConversionAsync(object? owner, TokenStorageMethod method)
+	{
+		IdentityTokenConversionResult result;
+		try
+		{
+			result = AccountTokenStorage.ConvertAllAccounts(method);
+		}
+		catch (System.Exception ex)
+		{
+			Serilog.Log.Logger.Warning(ex, "Token conversion failed");
+			await MessageBoxBase.Show(
+				owner,
+				"Token conversion failed. The original AccountsSettings.json file was left unchanged.",
+				ConversionFailedCaption,
+				MessageBoxButtons.OK,
+				MessageBoxIcon.Error);
+			return false;
+		}
+
+		if (!result.Succeeded)
+		{
+			await MessageBoxBase.Show(
+				owner,
+				FormatConversionError(result),
+				ConversionFailedCaption,
+				MessageBoxButtons.OK,
+				MessageBoxIcon.Error);
+			return false;
+		}
+
+		if (result.Changed)
+		{
+			await MessageBoxBase.Show(
+				owner,
+				ConversionSucceededMessage,
+				ConversionSucceededCaption,
+				MessageBoxButtons.OK,
+				MessageBoxIcon.Information);
+		}
+
+		return true;
+	}
+}
+
+public enum TokenStorageSaveDecision
+{
+	Abort,
+	SavePreferenceOnly,
+	SavePreferenceAndConvert
+}

--- a/Source/LibationWinForms/Dialogs/SettingsDialog.Designer.cs
+++ b/Source/LibationWinForms/Dialogs/SettingsDialog.Designer.cs
@@ -58,6 +58,11 @@
 			gridScaleFactorTbar = new System.Windows.Forms.TrackBar();
 			gridFontScaleFactorLbl = new System.Windows.Forms.Label();
 			gridFontScaleFactorTbar = new System.Windows.Forms.TrackBar();
+			tokenStorageGb = new System.Windows.Forms.GroupBox();
+			encryptTokensCbox = new System.Windows.Forms.CheckBox();
+			plaintextTokenWarningLbl = new System.Windows.Forms.Label();
+			osSecretStoreUnavailableLbl = new System.Windows.Forms.Label();
+			updateExistingTokensBtn = new System.Windows.Forms.Button();
 			booksGb = new System.Windows.Forms.GroupBox();
 			booksSelectControl = new DirectoryOrCustomSelectControl();
 			lastWriteTimeCb = new System.Windows.Forms.ComboBox();
@@ -148,6 +153,7 @@
 			groupBox1.SuspendLayout();
 			((System.ComponentModel.ISupportInitialize)gridScaleFactorTbar).BeginInit();
 			((System.ComponentModel.ISupportInitialize)gridFontScaleFactorTbar).BeginInit();
+			tokenStorageGb.SuspendLayout();
 			booksGb.SuspendLayout();
 			tab2ImportLibrary.SuspendLayout();
 			tab3DownloadDecrypt.SuspendLayout();
@@ -349,7 +355,7 @@
 			// 
 			// logsBtn
 			// 
-			logsBtn.Location = new System.Drawing.Point(256, 424);
+			logsBtn.Location = new System.Drawing.Point(256, 534);
 			logsBtn.Name = "logsBtn";
 			logsBtn.Size = new System.Drawing.Size(132, 23);
 			logsBtn.TabIndex = 5;
@@ -360,7 +366,7 @@
 			// loggingLevelLbl
 			// 
 			loggingLevelLbl.AutoSize = true;
-			loggingLevelLbl.Location = new System.Drawing.Point(6, 427);
+			loggingLevelLbl.Location = new System.Drawing.Point(6, 537);
 			loggingLevelLbl.Name = "loggingLevelLbl";
 			loggingLevelLbl.Size = new System.Drawing.Size(78, 15);
 			loggingLevelLbl.TabIndex = 3;
@@ -370,7 +376,7 @@
 			// 
 			loggingLevelCb.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
 			loggingLevelCb.FormattingEnabled = true;
-			loggingLevelCb.Location = new System.Drawing.Point(90, 424);
+			loggingLevelCb.Location = new System.Drawing.Point(90, 534);
 			loggingLevelCb.Name = "loggingLevelCb";
 			loggingLevelCb.Size = new System.Drawing.Size(129, 23);
 			loggingLevelCb.TabIndex = 4;
@@ -396,6 +402,7 @@
 			tab1ImportantSettings.Controls.Add(themeCb);
 			tab1ImportantSettings.Controls.Add(label22);
 			tab1ImportantSettings.Controls.Add(groupBox1);
+			tab1ImportantSettings.Controls.Add(tokenStorageGb);
 			tab1ImportantSettings.Controls.Add(booksGb);
 			tab1ImportantSettings.Controls.Add(logsBtn);
 			tab1ImportantSettings.Controls.Add(loggingLevelCb);
@@ -410,7 +417,7 @@
 			// themeLbl
 			// 
 			themeLbl.AutoSize = true;
-			themeLbl.Location = new System.Drawing.Point(190, 393);
+			themeLbl.Location = new System.Drawing.Point(190, 503);
 			themeLbl.Name = "themeLbl";
 			themeLbl.Size = new System.Drawing.Size(296, 15);
 			themeLbl.TabIndex = 12;
@@ -420,7 +427,7 @@
 			// 
 			themeCb.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
 			themeCb.FormattingEnabled = true;
-			themeCb.Location = new System.Drawing.Point(63, 390);
+			themeCb.Location = new System.Drawing.Point(63, 500);
 			themeCb.Name = "themeCb";
 			themeCb.Size = new System.Drawing.Size(121, 23);
 			themeCb.TabIndex = 11;
@@ -429,7 +436,7 @@
 			// label22
 			// 
 			label22.AutoSize = true;
-			label22.Location = new System.Drawing.Point(4, 393);
+			label22.Location = new System.Drawing.Point(4, 503);
 			label22.Name = "label22";
 			label22.Size = new System.Drawing.Size(44, 15);
 			label22.TabIndex = 10;
@@ -443,7 +450,7 @@
 			groupBox1.Controls.Add(gridScaleFactorTbar);
 			groupBox1.Controls.Add(gridFontScaleFactorLbl);
 			groupBox1.Controls.Add(gridFontScaleFactorTbar);
-			groupBox1.Location = new System.Drawing.Point(6, 277);
+			groupBox1.Location = new System.Drawing.Point(6, 387);
 			groupBox1.Name = "groupBox1";
 			groupBox1.Size = new System.Drawing.Size(844, 83);
 			groupBox1.TabIndex = 9;
@@ -502,6 +509,63 @@
 			gridFontScaleFactorTbar.Size = new System.Drawing.Size(160, 20);
 			gridFontScaleFactorTbar.TabIndex = 7;
 			gridFontScaleFactorTbar.TickFrequency = 25;
+			// 
+			// tokenStorageGb
+			// 
+			tokenStorageGb.Anchor = System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right;
+			tokenStorageGb.Controls.Add(updateExistingTokensBtn);
+			tokenStorageGb.Controls.Add(osSecretStoreUnavailableLbl);
+			tokenStorageGb.Controls.Add(plaintextTokenWarningLbl);
+			tokenStorageGb.Controls.Add(encryptTokensCbox);
+			tokenStorageGb.Location = new System.Drawing.Point(6, 277);
+			tokenStorageGb.Name = "tokenStorageGb";
+			tokenStorageGb.Size = new System.Drawing.Size(844, 104);
+			tokenStorageGb.TabIndex = 8;
+			tokenStorageGb.TabStop = false;
+			tokenStorageGb.Text = "Authentication tokens";
+			// 
+			// encryptTokensCbox
+			// 
+			encryptTokensCbox.AutoSize = true;
+			encryptTokensCbox.Location = new System.Drawing.Point(8, 22);
+			encryptTokensCbox.Name = "encryptTokensCbox";
+			encryptTokensCbox.Size = new System.Drawing.Size(520, 19);
+			encryptTokensCbox.TabIndex = 0;
+			encryptTokensCbox.Text = "Store authentication tokens encrypted. Unchecking this option stores tokens in plaintext.";
+			encryptTokensCbox.UseVisualStyleBackColor = true;
+			encryptTokensCbox.CheckedChanged += encryptTokensCbox_CheckedChanged;
+			// 
+			// plaintextTokenWarningLbl
+			// 
+			plaintextTokenWarningLbl.AutoSize = true;
+			plaintextTokenWarningLbl.ForeColor = System.Drawing.Color.DarkRed;
+			plaintextTokenWarningLbl.Location = new System.Drawing.Point(27, 44);
+			plaintextTokenWarningLbl.Name = "plaintextTokenWarningLbl";
+			plaintextTokenWarningLbl.Size = new System.Drawing.Size(480, 15);
+			plaintextTokenWarningLbl.TabIndex = 1;
+			plaintextTokenWarningLbl.Text = "Authentication tokens will be stored as readable plaintext in AccountsSettings.json.";
+			// 
+			// osSecretStoreUnavailableLbl
+			// 
+			osSecretStoreUnavailableLbl.AutoSize = true;
+			osSecretStoreUnavailableLbl.ForeColor = System.Drawing.Color.DarkRed;
+			osSecretStoreUnavailableLbl.Location = new System.Drawing.Point(27, 44);
+			osSecretStoreUnavailableLbl.Name = "osSecretStoreUnavailableLbl";
+			osSecretStoreUnavailableLbl.Size = new System.Drawing.Size(250, 15);
+			osSecretStoreUnavailableLbl.TabIndex = 2;
+			osSecretStoreUnavailableLbl.Text = "[OS secret store unavailable]";
+			osSecretStoreUnavailableLbl.Visible = false;
+			// 
+			// updateExistingTokensBtn
+			// 
+			updateExistingTokensBtn.Anchor = System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right;
+			updateExistingTokensBtn.Location = new System.Drawing.Point(628, 68);
+			updateExistingTokensBtn.Name = "updateExistingTokensBtn";
+			updateExistingTokensBtn.Size = new System.Drawing.Size(200, 27);
+			updateExistingTokensBtn.TabIndex = 3;
+			updateExistingTokensBtn.Text = "Update existing stored tokens";
+			updateExistingTokensBtn.UseVisualStyleBackColor = true;
+			updateExistingTokensBtn.Click += updateExistingTokensBtn_Click;
 			// 
 			// booksGb
 			// 
@@ -1493,6 +1557,8 @@
 			groupBox1.PerformLayout();
 			((System.ComponentModel.ISupportInitialize)gridScaleFactorTbar).EndInit();
 			((System.ComponentModel.ISupportInitialize)gridFontScaleFactorTbar).EndInit();
+			tokenStorageGb.ResumeLayout(false);
+			tokenStorageGb.PerformLayout();
 			booksGb.ResumeLayout(false);
 			booksGb.PerformLayout();
 			tab2ImportLibrary.ResumeLayout(false);
@@ -1544,6 +1610,11 @@
 		private System.Windows.Forms.CheckBox splitFilesByChapterCbox;
 		public System.Windows.Forms.TabControl tabControl;
 		private System.Windows.Forms.TabPage tab1ImportantSettings;
+		private System.Windows.Forms.GroupBox tokenStorageGb;
+		private System.Windows.Forms.CheckBox encryptTokensCbox;
+		private System.Windows.Forms.Label plaintextTokenWarningLbl;
+		private System.Windows.Forms.Label osSecretStoreUnavailableLbl;
+		private System.Windows.Forms.Button updateExistingTokensBtn;
 		private System.Windows.Forms.GroupBox booksGb;
 		private System.Windows.Forms.TabPage tab2ImportLibrary;
 		private System.Windows.Forms.TabPage tab3DownloadDecrypt;

--- a/Source/LibationWinForms/Dialogs/SettingsDialog.Important.cs
+++ b/Source/LibationWinForms/Dialogs/SettingsDialog.Important.cs
@@ -1,10 +1,13 @@
-﻿using Dinah.Core;
+﻿using AudibleApi.Authorization;
+using AudibleUtilities;
+using Dinah.Core;
 using FileManager;
 using LibationFileManager;
 using LibationUiBase;
 using System;
 using System.IO;
 using System.Linq;
+using System.Threading.Tasks;
 using System.Windows.Forms;
 
 namespace LibationWinForms.Dialogs;
@@ -20,6 +23,8 @@ public partial class SettingsDialog
 	}
 	private Configuration.Theme themeVariant;
 	private Configuration.Theme initialThemeVariant;
+	private TokenStorageMethod initialTokenStorageMethod;
+	private bool osSecretStoreAvailable;
 
 	private void Load_Important(Configuration config)
 	{
@@ -67,9 +72,60 @@ public partial class SettingsDialog
 		overwriteExistingCbox.Checked = config.OverwriteExisting;
 		gridScaleFactorTbar.Value = scaleFactorToLinearRange(config.GridScaleFactor);
 		gridFontScaleFactorTbar.Value = scaleFactorToLinearRange(config.GridFontScaleFactor);
+
+		Load_TokenStorage(config);
 	}
 
-	private bool Save_Important(Configuration config)
+	private void Load_TokenStorage(Configuration config)
+	{
+		initialTokenStorageMethod = config.TokenStorageMethod;
+		osSecretStoreAvailable = IdentityTokenStorageWiring.IsOsSecretStoreAvailable(out var unavailableReason);
+
+		encryptTokensCbox.Text = TokenStorageSettingsUi.CheckboxText;
+		plaintextTokenWarningLbl.Text = TokenStorageSettingsUi.PlaintextWarningText;
+		updateExistingTokensBtn.Text = TokenStorageSettingsUi.ConvertButtonText;
+		toolTip.SetToolTip(updateExistingTokensBtn, TokenStorageSettingsUi.ConvertButtonToolTip);
+
+		if (!osSecretStoreAvailable)
+		{
+			osSecretStoreUnavailableLbl.Text = TokenStorageSettingsUi.OsStoreUnavailableMessage(unavailableReason);
+			osSecretStoreUnavailableLbl.Visible = true;
+			encryptTokensCbox.Checked = false;
+			encryptTokensCbox.Enabled = false;
+		}
+		else
+		{
+			osSecretStoreUnavailableLbl.Visible = false;
+			encryptTokensCbox.Enabled = true;
+			encryptTokensCbox.Checked = TokenStorageSettingsUi.CheckboxFromMethod(config.TokenStorageMethod);
+		}
+
+		RefreshTokenStorageUiState();
+	}
+
+	private TokenStorageMethod SelectedTokenStorageMethod
+		=> TokenStorageSettingsUi.MethodFromCheckbox(encryptTokensCbox.Checked);
+
+	private void RefreshTokenStorageUiState()
+	{
+		var method = SelectedTokenStorageMethod;
+		plaintextTokenWarningLbl.Visible = osSecretStoreAvailable && method == TokenStorageMethod.Plaintext;
+
+		var alignment = AccountTokenStorage.GetAccountsAlignment(method);
+		updateExistingTokensBtn.Enabled = TokenStorageSettingsUi.IsConvertButtonEnabled(alignment);
+	}
+
+	private void encryptTokensCbox_CheckedChanged(object? sender, EventArgs e)
+		=> RefreshTokenStorageUiState();
+
+	private async void updateExistingTokensBtn_Click(object? sender, EventArgs e)
+	{
+		var converted = await TokenStorageSettingsUi.ConfirmAndConvertAsync(this, SelectedTokenStorageMethod);
+		if (converted)
+			RefreshTokenStorageUiState();
+	}
+
+	private async Task<bool> Save_Important(Configuration config)
 	{
 		var newBooks = booksSelectControl.SelectedDirectory;
 
@@ -96,6 +152,10 @@ public partial class SettingsDialog
 		}
 		#endregion
 
+		var selectedTokenMethod = SelectedTokenStorageMethod;
+		var tokenDecision = await TokenStorageSettingsUi.PromptOnPreferenceSaveAsync(this, initialTokenStorageMethod, selectedTokenMethod);
+		if (tokenDecision == TokenStorageSaveDecision.Abort)
+			return false;
 
 		config.Books = newBooks;
 
@@ -116,6 +176,17 @@ public partial class SettingsDialog
 		config.CreationTime = (creationTimeCb.SelectedItem as EnumDisplay<Configuration.DateTimeSource>)?.Value ?? Configuration.DateTimeSource.File;
 		config.LastWriteTime = (lastWriteTimeCb.SelectedItem as EnumDisplay<Configuration.DateTimeSource>)?.Value ?? Configuration.DateTimeSource.File;
 		config.ThemeVariant = (themeCb.SelectedItem as EnumDisplay<Configuration.Theme>)?.Value ?? Configuration.Theme.System;
+		config.TokenStorageMethod = selectedTokenMethod;
+
+		if (tokenDecision == TokenStorageSaveDecision.SavePreferenceAndConvert)
+		{
+			var converted = await TokenStorageSettingsUi.RunConversionAsync(this, selectedTokenMethod);
+			if (!converted)
+				return false;
+		}
+
+		initialTokenStorageMethod = selectedTokenMethod;
+		RefreshTokenStorageUiState();
 		return true;
 	}
 

--- a/Source/LibationWinForms/Dialogs/SettingsDialog.cs
+++ b/Source/LibationWinForms/Dialogs/SettingsDialog.cs
@@ -1,6 +1,7 @@
 ﻿using LibationFileManager;
 using LibationFileManager.Templates;
 using System;
+using System.Threading.Tasks;
 using System.Windows.Forms;
 
 namespace LibationWinForms.Dialogs;
@@ -40,9 +41,9 @@ public partial class SettingsDialog : Form
 			textBox.Text = template.EditingTemplate.TemplateText;
 	}
 
-	private void saveBtn_Click(object sender, EventArgs e)
+	private async void saveBtn_Click(object sender, EventArgs e)
 	{
-		if (!Save_Important(config)) return;
+		if (!await Save_Important(config)) return;
 		Save_ImportLibrary(config);
 		Save_DownloadDecrypt(config);
 		Save_AudioSettings(config);

--- a/Source/LibationWinForms/Dialogs/SetupDialog.Designer.cs
+++ b/Source/LibationWinForms/Dialogs/SetupDialog.Designer.cs
@@ -77,7 +77,10 @@
 			Controls.Add(returningUserBtn);
 			Controls.Add(newUserBtn);
 			Controls.Add(welcomeLbl);
-			FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedToolWindow;
+			FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedDialog;
+			MaximizeBox = false;
+			MinimizeBox = true;
+			ShowInTaskbar = true;
 			Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
 			Name = "SetupDialog";
 			StartPosition = System.Windows.Forms.FormStartPosition.CenterScreen;

--- a/Source/LibationWinForms/LibationWinForms.csproj
+++ b/Source/LibationWinForms/LibationWinForms.csproj
@@ -41,7 +41,7 @@
 
 
 	<ItemGroup>
-		<PackageReference Include="Dinah.Core.WindowsDesktop" Version="10.0.0.1" />
+		<PackageReference Include="Dinah.Core.WindowsDesktop" Version="10.1.0.1" />
 		<PackageReference Include="Microsoft.Web.WebView2" Version="1.0.3912.50" />
 	</ItemGroup>
 

--- a/Source/LibationWinForms/LibationWinForms.csproj
+++ b/Source/LibationWinForms/LibationWinForms.csproj
@@ -41,7 +41,7 @@
 
 
 	<ItemGroup>
-		<PackageReference Include="Dinah.Core.WindowsDesktop" Version="10.1.0.1" />
+		<PackageReference Include="Dinah.Core.WindowsDesktop" Version="10.2.0.1" />
 		<PackageReference Include="Microsoft.Web.WebView2" Version="1.0.3912.50" />
 	</ItemGroup>
 

--- a/Source/_Demos/LoadByOS/CrossPlatformClientExe/CrossPlatformClientExe.csproj
+++ b/Source/_Demos/LoadByOS/CrossPlatformClientExe/CrossPlatformClientExe.csproj
@@ -19,7 +19,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Dinah.Core" Version="10.0.0.1" />
+    <PackageReference Include="Dinah.Core" Version="10.1.0.1" />
   </ItemGroup>
 
 </Project>

--- a/Source/_Demos/LoadByOS/CrossPlatformClientExe/CrossPlatformClientExe.csproj
+++ b/Source/_Demos/LoadByOS/CrossPlatformClientExe/CrossPlatformClientExe.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
@@ -19,7 +19,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Dinah.Core" Version="10.1.0.1" />
+    <PackageReference Include="Dinah.Core" Version="10.2.0.1" />
   </ItemGroup>
 
 </Project>

--- a/Source/_Tests/AudibleUtilities.Tests/AccountTests.cs
+++ b/Source/_Tests/AudibleUtilities.Tests/AccountTests.cs
@@ -1,11 +1,15 @@
 ﻿using AssertionHelper;
 using AudibleApi;
 using AudibleApi.Authorization;
+using AudibleApi.Cryptography;
 using AudibleUtilities;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
 using System;
+using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 
 [assembly: Parallelize]
 
@@ -602,6 +606,150 @@ public class transactions : AccountsTestBase
 			File.ReadAllText(TestFile).Should().Be(EMPTY_FILE);
 			p.IsInTransaction.Should().BeTrue();
 		}
+	}
+}
+
+/// <summary>
+/// Characterization: AccountsSettings.json currently persists Identity tokens as plaintext
+/// with no IsEncrypted metadata. Baseline before token-storage encryption work.
+/// </summary>
+[TestClass]
+public class LegacyPlaintextIdentityTokens : AccountsTestBase
+{
+	const string SampleAccessToken = "Atna|_CHAR_ACCESS_";
+	const string SampleRefreshToken = "Atnr|_CHAR_REFRESH_";
+	const string SampleAdpToken = "{enc:abcdefg}{key:1234}{iv:56789}{name:QURQVG9rZW5FbmNyeXB0aW9uS2V5}{serial:Mg==}";
+	const string SampleStoreAuthCookie = "store-auth-cookie-value";
+	static readonly DateTime SampleExpires = new(2200, 1, 1, 12, 0, 0, DateTimeKind.Utc);
+
+	const string SamplePrivateKey = @"
+-----BEGIN RSA PRIVATE KEY-----
+MIIEpgIBAAKCAQEA5nPbGSVDmlEH2tJa6kz/P2HI8IeirhfPHdmi+X/nsb9i3WNf
+tmEdZxfK26IValQDXvBH17a1gr0HD6pYse1XsV2w0HxiW1RW+ZnjL8/fzPdkSOb+
+4xKlqRopCueBSdDGgAF06spZ3IeHLfEFOJX4dO1Y73pFBUkA0k53LT12L2Tjay/r
+buZHJqIzxmwja7/nkiWL0Xo7UySHtQACYsKEatu6yHBS+cPTlGR/qeUpeJTHwDLP
+7ZQ7kWzJGY1mfInYekjlZLsMsWswso3pg1vPyHgxzM2BWhY8m6mlXQ9G/USxBTib
+MNuMtpR73XsgamneFCc+Uv1cxw7ofZ41YOOAbQIDAQABAoIBAQDIre8HkKm0Aggj
+B7df/TjxCsgenR6PF/Cmf9UqC7XJ1W3UeCrq+NrP4aonZJfdhdeBnyAQuuyJMu6p
+N6ARISuSKpJEm2xTN7idluJ9yjmLlYtg6LbhKmXUQhGniz3M999DrQERTLDAF80h
+tpbjVcWMnPsrX4AnQBFVEjs5zCHU1hD+X463EmUHBWyT975jbZ8Fy7/fTzkdzLnn
+qE5lROALr2MCAAwQRFbRE6dd52vnXaBrVcAtRzjATts3WG3+SNi2Fm/OrYqQcY9e
+lBexNviT8VcldOAMrO10E2u0d+tvxFzwB3ABMvaVamrEZky4XSfB6aLzpD0JJj1s
+UHnIiVwJAoGBAPl8nLll/J9rud/N2HiAX2YkP0MC0HW4yM3KxLtXKyXrP5qBpaci
+wTDUmSWEEE3GUJMM1Z4d9tl9Lz2MhU2KqkEvLI3kQ7aUu33PYUBGMVcUzhFQ49lU
+Nzz8YB183iqo31o/DKk2Cr5gI7SykQZ0gn/urZkEJeErLzlhPXcyeY5jAoGBAOx4
+CGucVdv5MbdXZP8jVzxuvUlSp7BIQJ2phQXDFBNApFKnZn7yBYBx7dqzleymGm+R
+INZAurg3SNw4nvbQc3Z2dJ8I+n5ErjFCKp1IedVxx1eMEfecTwrQZuUwLISIyjqF
+czSJNwcNqzCx67z397/Cg5K/0pu6uIe0r7xozcbvAoGBAOOvZ9CDVPOg+rdXQvFm
+Jqou9lUPonNtOkUlgjl+qfAnK5q0KxvHSgxoWYO1bLOuAybQlbuBmSCPcKd5MMa9
+f/eRN9YetfVQ83Mz6YshBDJ22EFRUz+p7eeIY6dFp/PCvmO8Gq/qlA996dglBtmf
+RuG+T0vQT0mZgbWaGuBHfkwFAoGBAMOLg1MRxgKRMKavk6pU3EfyP3+J5XemWCDI
+1WLtbgV5uClNmzmxBBGypQHs7jbzKPtHpULn5kB+HzdVb0clG8ZDsK7u6s5OF0pO
+sBS+oVl7rF/eSeFcFhUYP26ZhsbWo3z/bERuj926VO2AxDPRTsP5o3pQPGZhY0V9
+irGgbUJrAoGBAOseS3J4BqYM4R3Hr7cRAhvzSjIkeTcDF1zTOa4FZDHBxZ6g2PNq
+8ekhtfn1zPczsPTF1vNuqEISKLxaPkVPiw0mtaZQjVwpF/IOxMNjWVLp6oJf8Mm2
+BxlXqPnQ4mG66oqSFQgDEmFdMhRb2of6xL1gYYL62C80G2T7QtmPfSab
+-----END RSA PRIVATE KEY-----
+";
+
+	static Identity CreateRegisteredIdentity()
+	{
+		var identity = new Identity(Localization.Get("us"));
+		identity.Update(
+			new PrivateKey(SamplePrivateKey),
+			new AdpToken(SampleAdpToken),
+			new AccessToken(SampleAccessToken, SampleExpires),
+			new RefreshToken(SampleRefreshToken),
+			new List<KeyValuePair<string, string?>> { new("session-id", "cookie-secret-value") },
+			deviceSerialNumber: "device-serial",
+			deviceType: "device-type",
+			amazonAccountId: "amzn-account",
+			deviceName: "device-name",
+			storeAuthenticationCookie: SampleStoreAuthCookie);
+		return identity;
+	}
+
+	[TestMethod]
+	public void toJson_registered_account_has_no_IsEncrypted_and_plaintext_secrets()
+	{
+		var settings = new AccountsSettings();
+		settings.Add(new Account("user@example.com")
+		{
+			AccountName = "Main",
+			IdentityTokens = CreateRegisteredIdentity()
+		});
+
+		var json = settings.ToJson();
+		var jo = JObject.Parse(json);
+
+		jo.SelectTokens("$..IsEncrypted").Should().HaveCount(0);
+		var tokens = jo["Accounts"]![0]!["IdentityTokens"]!;
+		tokens["ExistingAccessToken"]!["TokenValue"]!.Value<string>().Should().Be(SampleAccessToken);
+		tokens["RefreshToken"]!["Value"]!.Value<string>().Should().Be(SampleRefreshToken);
+		tokens["AdpToken"]!["Value"]!.Value<string>().Should().Be(SampleAdpToken);
+		tokens["PrivateKey"]!["Value"]!.Value<string>().Should().Be(SamplePrivateKey);
+		tokens["StoreAuthenticationCookie"]!.Value<string>().Should().Be(SampleStoreAuthCookie);
+		tokens["Cookies"]![0]!["Value"]!.Value<string>().Should().Be("cookie-secret-value");
+	}
+
+	[TestMethod]
+	public void fromJson_legacy_file_loads_usable_plaintext_tokens()
+	{
+		var settings = new AccountsSettings();
+		settings.Add(new Account("user@example.com")
+		{
+			AccountName = "Main",
+			DecryptKey = "activation-bytes-ok-as-plaintext",
+			IdentityTokens = CreateRegisteredIdentity()
+		});
+		var legacyJson = settings.ToJson();
+		JObject.Parse(legacyJson).SelectTokens("$..IsEncrypted").Should().HaveCount(0);
+
+		var loaded = AccountsSettings.FromJson(legacyJson);
+		loaded.BeNotNull();
+		loaded.Accounts.Count.Should().Be(1);
+
+		var account = loaded.Accounts[0];
+		account.AccountId.Should().Be("user@example.com");
+		account.DecryptKey.Should().Be("activation-bytes-ok-as-plaintext");
+		account.IdentityTokens.BeNotNull();
+		account.IdentityTokens.IsValid.Should().BeTrue();
+		account.IdentityTokens.ExistingAccessToken.TokenValue.Should().Be(SampleAccessToken);
+		account.IdentityTokens.RefreshToken.BeNotNull();
+		account.IdentityTokens.RefreshToken.Value.Should().Be(SampleRefreshToken);
+		account.IdentityTokens.AdpToken.BeNotNull();
+		account.IdentityTokens.AdpToken.Value.Should().Be(SampleAdpToken);
+		account.IdentityTokens.PrivateKey.BeNotNull();
+		account.IdentityTokens.PrivateKey.Value.Should().Be(SamplePrivateKey);
+		account.IdentityTokens.StoreAuthenticationCookie.Should().Be(SampleStoreAuthCookie);
+		account.IdentityTokens.Cookies.Single().Value.Should().Be("cookie-secret-value");
+	}
+
+	[TestMethod]
+	public void persister_roundtrip_keeps_plaintext_tokens_without_IsEncrypted()
+	{
+		using (var p = new AccountsSettingsPersister(new AccountsSettings(), TestFile))
+		{
+			p.AccountsSettings.Add(new Account("user@example.com")
+			{
+				AccountName = "Main",
+				IdentityTokens = CreateRegisteredIdentity()
+			});
+		}
+
+		var onDisk = File.ReadAllText(TestFile);
+		var jo = JObject.Parse(onDisk);
+		jo.SelectTokens("$..IsEncrypted").Should().HaveCount(0);
+		jo["Accounts"]![0]!["IdentityTokens"]!["RefreshToken"]!["Value"]!.Value<string>()
+			.Should().Be(SampleRefreshToken);
+
+		using var loaded = new AccountsSettingsPersister(TestFile);
+		var tokens = loaded.AccountsSettings.Accounts[0].IdentityTokens;
+		tokens.BeNotNull();
+		tokens.IsValid.Should().BeTrue();
+		tokens.ExistingAccessToken.TokenValue.Should().Be(SampleAccessToken);
+		tokens.RefreshToken.BeNotNull();
+		tokens.RefreshToken.Value.Should().Be(SampleRefreshToken);
 	}
 }
 #pragma warning restore CS8981

--- a/Source/_Tests/AudibleUtilities.Tests/IdentityTokenStorageWiringTests.cs
+++ b/Source/_Tests/AudibleUtilities.Tests/IdentityTokenStorageWiringTests.cs
@@ -1,0 +1,204 @@
+using AssertionHelper;
+using AudibleApi;
+using AudibleApi.Authorization;
+using AudibleApi.Cryptography;
+using AudibleUtilities;
+using Dinah.Core.Security;
+using LibationFileManager;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using System;
+using System.Collections.Generic;
+using System.IO;
+
+namespace IdentityTokenStorageWiringTests;
+
+[TestClass]
+[DoNotParallelize]
+public class IdentityTokenStorageWiringTests
+{
+	// Fixture material only (same shape as AudibleApi characterization tests).
+	private const string SampleAccessToken = "Atna|_CHAR_ACCESS_";
+	private const string SampleRefreshToken = "Atnr|_CHAR_REFRESH_";
+	private const string SampleAdpToken = "{enc:abcdefg}{key:1234}{iv:56789}{name:QURQVG9rZW5FbmNyeXB0aW9uS2V5}{serial:Mg==}";
+	private const string SampleStoreAuthCookie = "store-auth-cookie-value";
+	private const string SampleCookieName = "session-id";
+	private const string SampleCookieValue = "cookie-secret-value";
+	private static readonly DateTime SampleExpires = new(2200, 1, 1, 12, 0, 0, DateTimeKind.Utc);
+	private const string SamplePrivateKey = @"
+-----BEGIN RSA PRIVATE KEY-----
+MIIEpgIBAAKCAQEA5nPbGSVDmlEH2tJa6kz/P2HI8IeirhfPHdmi+X/nsb9i3WNf
+tmEdZxfK26IValQDXvBH17a1gr0HD6pYse1XsV2w0HxiW1RW+ZnjL8/fzPdkSOb+
+4xKlqRopCueBSdDGgAF06spZ3IeHLfEFOJX4dO1Y73pFBUkA0k53LT12L2Tjay/r
+buZHJqIzxmwja7/nkiWL0Xo7UySHtQACYsKEatu6yHBS+cPTlGR/qeUpeJTHwDLP
+7ZQ7kWzJGY1mfInYekjlZLsMsWswso3pg1vPyHgxzM2BWhY8m6mlXQ9G/USxBTib
+MNuMtpR73XsgamneFCc+Uv1cxw7ofZ41YOOAbQIDAQABAoIBAQDIre8HkKm0Aggj
+B7df/TjxCsgenR6PF/Cmf9UqC7XJ1W3UeCrq+NrP4aonZJfdhdeBnyAQuuyJMu6p
+N6ARISuSKpJEm2xTN7idluJ9yjmLlYtg6LbhKmXUQhGniz3M999DrQERTLDAF80h
+tpbjVcWMnPsrX4AnQBFVEjs5zCHU1hD+X463EmUHBWyT975jbZ8Fy7/fTzkdzLnn
+qE5lROALr2MCAAwQRFbRE6dd52vnXaBrVcAtRzjATts3WG3+SNi2Fm/OrYqQcY9e
+lBexNviT8VcldOAMrO10E2u0d+tvxFzwB3ABMvaVamrEZky4XSfB6aLzpD0JJj1s
+UHnIiVwJAoGBAPl8nLll/J9rud/N2HiAX2YkP0MC0HW4yM3KxLtXKyXrP5qBpaci
+wTDUmSWEEE3GUJMM1Z4d9tl9Lz2MhU2KqkEvLI3kQ7aUu33PYUBGMVcUzhFQ49lU
+Nzz8YB183iqo31o/DKk2Cr5gI7SykQZ0gn/urZkEJeErLzlhPXcyeY5jAoGBAOx4
+CGucVdv5MbdXZP8jVzxuvUlSp7BIQJ2phQXDFBNApFKnZn7yBYBx7dqzleymGm+R
+INZAurg3SNw4nvbQc3Z2dJ8I+n5ErjFCKp1IedVxx1eMEfecTwrQZuUwLISIyjqF
+czSJNwcNqzCx67z397/Cg5K/0pu6uIe0r7xozcbvAoGBAOOvZ9CDVPOg+rdXQvFm
+Jqou9lUPonNtOkUlgjl+qfAnK5q0KxvHSgxoWYO1bLOuAybQlbuBmSCPcKd5MMa9
+f/eRN9YetfVQ83Mz6YshBDJ22EFRUz+p7eeIY6dFp/PCvmO8Gq/qlA996dglBtmf
+RuG+T0vQT0mZgbWaGuBHfkwFAoGBAMOLg1MRxgKRMKavk6pU3EfyP3+J5XemWCDI
+1WLtbgV5uClNmzmxBBGypQHs7jbzKPtHpULn5kB+HzdVb0clG8ZDsK7u6s5OF0pO
+sBS+oVl7rF/eSeFcFhUYP26ZhsbWo3z/bERuj926VO2AxDPRTsP5o3pQPGZhY0V9
+irGgbUJrAoGBAOseS3J4BqYM4R3Hr7cRAhvzSjIkeTcDF1zTOa4FZDHBxZ6g2PNq
+8ekhtfn1zPczsPTF1vNuqEISKLxaPkVPiw0mtaZQjVwpF/IOxMNjWVLp6oJf8Mm2
+BxlXqPnQ4mG66oqSFQgDEmFdMhRb2of6xL1gYYL62C80G2T7QtmPfSab
+-----END RSA PRIVATE KEY-----
+";
+
+	private string? _tempDir;
+	private string? _accountsFile;
+
+	[TestInitialize]
+	public void Init()
+	{
+		IdentityTokenStorage.Reset();
+		_tempDir = Path.Combine(Path.GetTempPath(), "LibationTokenStorageTests-" + Guid.NewGuid().ToString("N"));
+		Directory.CreateDirectory(_tempDir);
+		_accountsFile = Path.Combine(_tempDir, "AccountsSettings.json");
+	}
+
+	[TestCleanup]
+	public void Cleanup()
+	{
+		IdentityTokenStorage.Reset();
+		Configuration.RestoreSingletonInstance();
+
+		if (_tempDir is not null && Directory.Exists(_tempDir))
+		{
+			try { Directory.Delete(_tempDir, recursive: true); }
+			catch { /* best effort */ }
+		}
+	}
+
+	[TestMethod]
+	public void Apply_Encrypted_configures_write_method_and_protector_when_store_available()
+	{
+		var config = Configuration.CreateMockInstance();
+		config.TokenStorageMethod = TokenStorageMethod.Encrypted;
+
+		IdentityTokenStorageWiring.Apply(config);
+
+		Assert.AreEqual(TokenStorageMethod.Encrypted, IdentityTokenStorage.WriteMethod);
+		if (IdentityTokenStorageWiring.IsOsSecretStoreAvailable(out _))
+			Assert.IsNotNull(IdentityTokenStorage.Protector);
+	}
+
+	[TestMethod]
+	public void Apply_Plaintext_configures_plaintext_writes()
+	{
+		var config = Configuration.CreateMockInstance();
+		config.TokenStorageMethod = TokenStorageMethod.Plaintext;
+
+		IdentityTokenStorageWiring.Apply(config);
+
+		Assert.AreEqual(TokenStorageMethod.Plaintext, IdentityTokenStorage.WriteMethod);
+	}
+
+	[TestMethod]
+	public void Changing_preference_updates_write_method_without_converting_existing_tokens()
+	{
+		WriteLegacyAccountsFile(_accountsFile!);
+		var before = File.ReadAllText(_accountsFile!);
+
+		var config = Configuration.CreateMockInstance();
+		config.TokenStorageMethod = TokenStorageMethod.Plaintext;
+		IdentityTokenStorageWiring.Apply(config);
+
+		config.TokenStorageMethod = TokenStorageMethod.Encrypted;
+
+		Assert.AreEqual(TokenStorageMethod.Encrypted, IdentityTokenStorage.WriteMethod);
+		File.ReadAllText(_accountsFile!).Should().Be(before);
+		Assert.AreEqual(
+			TokenStorageAlignment.SomeMismatch,
+			AccountTokenStorage.GetAccountsAlignment(TokenStorageMethod.Encrypted, _accountsFile));
+		Assert.AreEqual(
+			TokenStorageAlignment.AllMatch,
+			AccountTokenStorage.GetAccountsAlignment(TokenStorageMethod.Plaintext, _accountsFile));
+	}
+
+	[TestMethod]
+	public void New_identity_serialize_uses_configured_write_method()
+	{
+		var store = new MemoryOsSecretStore();
+		var protector = new AesGcmSecretProtector(store, "libation-wiring-tests-master-key");
+		IdentityTokenStorage.Configure(TokenStorageMethod.Encrypted, protector);
+
+		var identity = CreateRegisteredIdentity();
+		var jo = JObject.Parse(JsonConvert.SerializeObject(identity, Identity.GetJsonSerializerSettings()));
+
+		jo.SelectTokens("$..IsEncrypted").Should().HaveCount(6);
+		jo["ExistingAccessToken"]!["IsEncrypted"]!.Value<bool>().Should().BeTrue();
+	}
+
+	[TestMethod]
+	public void ConvertAllAccounts_is_explicit_and_aligns_file()
+	{
+		WriteLegacyAccountsFile(_accountsFile!);
+
+		var store = new MemoryOsSecretStore();
+		IdentityTokenStorage.Configure(TokenStorageMethod.Encrypted, new AesGcmSecretProtector(store, "libation-convert-tests"));
+
+		var result = AccountTokenStorage.ConvertAllAccounts(TokenStorageMethod.Encrypted, _accountsFile);
+		result.Succeeded.Should().BeTrue();
+		result.Changed.Should().BeTrue();
+
+		Assert.AreEqual(
+			TokenStorageAlignment.AllMatch,
+			AccountTokenStorage.GetAccountsAlignment(TokenStorageMethod.Encrypted, _accountsFile));
+
+		var after = JObject.Parse(File.ReadAllText(_accountsFile!));
+		after.SelectTokens("$..IsEncrypted").Should().HaveCount(6);
+	}
+
+	private static void WriteLegacyAccountsFile(string path)
+	{
+		var identity = CreateRegisteredIdentity();
+		IdentityTokenStorage.Configure(TokenStorageMethod.Plaintext, protector: null);
+		var identityJson = JsonConvert.SerializeObject(identity, Identity.GetJsonSerializerSettings());
+
+		var root = new JObject
+		{
+			["Accounts"] = new JArray
+			{
+				new JObject
+				{
+					["AccountId"] = "user@example.com",
+					["AccountName"] = "Test",
+					["LibraryScan"] = true,
+					["DecryptKey"] = "",
+					["IdentityTokens"] = JObject.Parse(identityJson)
+				}
+			},
+			["Cdm"] = null
+		};
+		File.WriteAllText(path, root.ToString(Formatting.Indented));
+	}
+
+	private static Identity CreateRegisteredIdentity()
+	{
+		var identity = new Identity(Localization.Get("us"));
+		identity.Update(
+			new PrivateKey(SamplePrivateKey),
+			new AdpToken(SampleAdpToken),
+			new AccessToken(SampleAccessToken, SampleExpires),
+			new RefreshToken(SampleRefreshToken),
+			new List<KeyValuePair<string, string?>> { new(SampleCookieName, SampleCookieValue) },
+			deviceSerialNumber: "device-serial",
+			deviceType: "device-type",
+			amazonAccountId: "amzn-account",
+			deviceName: "device-name",
+			storeAuthenticationCookie: SampleStoreAuthCookie);
+		return identity;
+	}
+}

--- a/Source/_Tests/LibationFileManager.Tests/TokenStorageMethodConfigurationTests.cs
+++ b/Source/_Tests/LibationFileManager.Tests/TokenStorageMethodConfigurationTests.cs
@@ -1,0 +1,63 @@
+using AssertionHelper;
+using AudibleApi.Authorization;
+using FileManager;
+using LibationFileManager;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Newtonsoft.Json.Linq;
+
+namespace TokenStorageMethodConfigurationTests;
+
+[TestClass]
+[DoNotParallelize]
+public class TokenStorageMethodConfigurationTests
+{
+	[TestCleanup]
+	public void Cleanup()
+	{
+		Configuration.RestoreSingletonInstance();
+	}
+
+	[TestMethod]
+	public void Default_when_missing_is_Encrypted()
+	{
+		var config = Configuration.CreateMockInstance();
+
+		config.Exists(nameof(Configuration.TokenStorageMethod)).Should().BeFalse();
+		Assert.AreEqual(TokenStorageMethod.Encrypted, config.TokenStorageMethod);
+	}
+
+	[TestMethod]
+	public void Round_trips_Plaintext_and_Encrypted()
+	{
+		var config = Configuration.CreateMockInstance();
+
+		config.TokenStorageMethod = TokenStorageMethod.Plaintext;
+		Assert.AreEqual(TokenStorageMethod.Plaintext, config.TokenStorageMethod);
+		Assert.AreEqual(TokenStorageMethod.Plaintext, config.CreateEphemeralCopy().TokenStorageMethod);
+
+		config.TokenStorageMethod = TokenStorageMethod.Encrypted;
+		Assert.AreEqual(TokenStorageMethod.Encrypted, config.TokenStorageMethod);
+		Assert.AreEqual(TokenStorageMethod.Encrypted, config.CreateEphemeralCopy().TokenStorageMethod);
+	}
+
+	[TestMethod]
+	public void Unknown_enum_value_resolves_to_Encrypted_not_Plaintext()
+	{
+		// Same UpCast path used by Settings.json deserialization for enum settings.
+		var parsed = IJsonBackedDictionary.UpCast<TokenStorageMethod>(new JValue("NotARealMethod"));
+
+		Assert.AreEqual(TokenStorageMethod.Encrypted, parsed);
+		Assert.AreNotEqual(TokenStorageMethod.Plaintext, parsed);
+	}
+
+	[TestMethod]
+	public void String_enum_names_round_trip_via_UpCast()
+	{
+		Assert.AreEqual(
+			TokenStorageMethod.Plaintext,
+			IJsonBackedDictionary.UpCast<TokenStorageMethod>(new JValue("Plaintext")));
+		Assert.AreEqual(
+			TokenStorageMethod.Encrypted,
+			IJsonBackedDictionary.UpCast<TokenStorageMethod>(new JValue("Encrypted")));
+	}
+}

--- a/Source/_Tests/LibationUiBase.Tests/TokenStorageSettingsUiTests.cs
+++ b/Source/_Tests/LibationUiBase.Tests/TokenStorageSettingsUiTests.cs
@@ -1,0 +1,56 @@
+using AudibleApi.Authorization;
+using LibationUiBase;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace TokenStorageSettingsUiTests;
+
+[TestClass]
+public class TokenStorageSettingsUiTests
+{
+	[TestMethod]
+	public void Checkbox_maps_to_enum_values()
+	{
+		Assert.AreEqual(TokenStorageMethod.Encrypted, TokenStorageSettingsUi.MethodFromCheckbox(true));
+		Assert.AreEqual(TokenStorageMethod.Plaintext, TokenStorageSettingsUi.MethodFromCheckbox(false));
+		Assert.IsTrue(TokenStorageSettingsUi.CheckboxFromMethod(TokenStorageMethod.Encrypted));
+		Assert.IsFalse(TokenStorageSettingsUi.CheckboxFromMethod(TokenStorageMethod.Plaintext));
+	}
+
+	[TestMethod]
+	public void Convert_button_enabled_only_for_mismatch_or_indeterminate()
+	{
+		Assert.IsTrue(TokenStorageSettingsUi.IsConvertButtonEnabled(TokenStorageAlignment.SomeMismatch));
+		Assert.IsTrue(TokenStorageSettingsUi.IsConvertButtonEnabled(TokenStorageAlignment.Indeterminate));
+		Assert.IsFalse(TokenStorageSettingsUi.IsConvertButtonEnabled(TokenStorageAlignment.AllMatch));
+		Assert.IsFalse(TokenStorageSettingsUi.IsConvertButtonEnabled(TokenStorageAlignment.NoApplicableTokens));
+	}
+
+	[TestMethod]
+	public void Prompt_bodies_warn_clearly()
+	{
+		Assert.AreEqual(
+			TokenStorageSettingsUi.SavePromptEncrypted,
+			TokenStorageSettingsUi.SavePromptBody(TokenStorageMethod.Encrypted));
+		Assert.AreEqual(
+			TokenStorageSettingsUi.SavePromptPlaintext,
+			TokenStorageSettingsUi.SavePromptBody(TokenStorageMethod.Plaintext));
+
+		StringAssert.Contains(TokenStorageSettingsUi.SavePromptPlaintext, "readable");
+		StringAssert.Contains(TokenStorageSettingsUi.StandaloneConfirmPlaintext, "readable");
+	}
+
+	[TestMethod]
+	public void FormatConversionError_includes_categories_without_secret_values()
+	{
+		var result = IdentityTokenConversionResult.Failure(
+			TokenStorageAlignment.SomeMismatch,
+			"Conversion failed.",
+			"RefreshToken",
+			"AccessToken");
+
+		var message = TokenStorageSettingsUi.FormatConversionError(result);
+		StringAssert.Contains(message, "RefreshToken");
+		StringAssert.Contains(message, "AccessToken");
+		Assert.IsFalse(message.Contains("Atna|"));
+	}
+}


### PR DESCRIPTION
Add `TokenStorageMethod` (default encrypted), wire AudibleApi persistence at startup, and keep preference changes from silently converting existing tokens