### PR TITLE
Update AAXClean.Codecs to 3.1.0 — fixes xHE-AAC seeking in Apple players

### DIFF
--- a/Source/AaxDecrypter/AaxDecrypter.csproj
+++ b/Source/AaxDecrypter/AaxDecrypter.csproj
@@ -14,7 +14,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-	  <PackageReference Include="AAXClean.Codecs" Version="3.0.2" />
+	  <PackageReference Include="AAXClean.Codecs" Version="3.1.0" />
 	</ItemGroup>
 
 	<ItemGroup>


### PR DESCRIPTION
## What this fixes for Libation users

Audiobooks downloaded with **Request xHE-AAC codec** enabled currently can't be seeked in Apple
Books or any iPhone/iPad/Mac app built on Apple's audio stack: resume, chapter jumps, and
scrubbing either fail outright or play audio from the wrong position, and chapter-split files
often won't even start playback without rewind-and-retry fiddling. (Sequential play works, which
is why the files seem fine at first.) ffmpeg-based players tolerate the files, which hid this
for a long time.

Root cause — confirmed by Apple engineering in response to a Feedback report — is on the
container side: USAC (xHE-AAC) requires a sync sample table (`stss`) enumerating its seekable
frames (ISO/IEC 23003-3 §H.1), and the remuxed files didn't have one, so Apple's demuxer seeks
to frames that aren't valid decode entry points. Mbucari/AAXClean#18 makes AAXClean write a
correct `stss` (derived from the USAC bitstream itself), and Mbucari/AAXClean#19 makes
chapter-split output sample-accurate via edit lists, with each split part starting on a
decodable frame. Both are merged and released in AAXClean.Codecs 3.1.0 (AAXClean 3.1.0
transitively).

## Validation

- Before/after on a real Audible xHE-AAC title (Apple decoder, 31 seek probes at every chapter
  start plus known-bad offsets): **23 failures → 0**, with the audio payload MD5-identical
  (the remux stays lossless).
- A 220-book library re-downloaded through a Libation build using these changes: 195 xHE-AAC
  files, every one verified correct (spot-checked bit-exact against the bitstream on titles
  from 8 minutes to 72 hours); 403/403 Apple seek probes passed.
- Libation's full test suite passes against the released 3.1.0 packages (966 tests, 0 failures,
  21 environment-dependent skips). The end-to-end runs above — including the complete macOS
  bundle build and a live liberation on macOS (arm64) — were done on pre-release builds of the
  same changes.
- AAC-LC output is unchanged.

Users' existing xHE-AAC files can be repaired without re-downloading — any lossless
re-conversion through the updated AAXClean adds the missing table in place.

Details, measurements, and Apple's response are in Mbucari/AAXClean#18 and #19.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
