### PR TITLE
Make encrypted account tokens portable for Docker

### DIFF
--- a/Source/AudibleUtilities/AccountSettingsDecryptFailure.cs
+++ b/Source/AudibleUtilities/AccountSettingsDecryptFailure.cs
@@ -15,8 +15,9 @@ public static class AccountSettingsDecryptFailure
 
 	private static readonly string[] ThingsToTryBullets =
 	[
-		"On the machine that created the encrypted file (usually Windows): Settings -> Important, uncheck \"Store authentication tokens encrypted\", convert existing tokens to plaintext when prompted, then copy the updated AccountsSettings.json again.",
-		"Or re-authenticate on this machine/container with LibationCli login-external or import-account (do not rely on the encrypted Windows copy).",
+		"Keep tokens encrypted: on the machine that created the file, export the master key (Settings -> Important -> Export encryption key..., or LibationCli export-master-key libation-master.key), then copy that file into the Docker/config folder next to AccountsSettings.json (or set LIBATION_MASTER_KEY_FILE / LIBATION_MASTER_KEY).",
+		"Or convert to plaintext: Settings -> Important, uncheck \"Store authentication tokens encrypted\", convert existing tokens when prompted, then copy the updated AccountsSettings.json again.",
+		"Or re-authenticate on this machine/container with LibationCli login-external or import-account.",
 		$"Details: {FaqUrl}",
 	];
 

--- a/Source/AudibleUtilities/IdentityTokenStorageWiring.cs
+++ b/Source/AudibleUtilities/IdentityTokenStorageWiring.cs
@@ -2,6 +2,7 @@ using AudibleApi.Authorization;
 using Dinah.Core.Security;
 using LibationFileManager;
 using System.ComponentModel;
+using System.Security.Cryptography;
 
 namespace AudibleUtilities;
 
@@ -12,6 +13,15 @@ namespace AudibleUtilities;
 public static class IdentityTokenStorageWiring
 {
 	public const string ApplicationName = "Libation";
+
+	/// <summary>Env var: path to a raw 32-byte master key file (from <c>export-master-key</c>).</summary>
+	public const string MasterKeyFileEnvVar = "LIBATION_MASTER_KEY_FILE";
+
+	/// <summary>Env var: Base64-encoded 32-byte master key.</summary>
+	public const string MasterKeyEnvVar = "LIBATION_MASTER_KEY";
+
+	/// <summary>Default master key file name under the Libation files directory.</summary>
+	public const string DefaultMasterKeyFileName = "libation-master.key";
 
 	private static Lock Gate { get; } = new();
 	private static Configuration? _wiredConfig;
@@ -47,13 +57,37 @@ public static class IdentityTokenStorageWiring
 		ArgumentNullException.ThrowIfNull(config);
 
 		var method = config.TokenStorageMethod;
-		var store = OsSecretStore.Create(ApplicationName);
+		var store = ResolveSecretStore(config);
 		AesGcmSecretProtector? protector = store.IsAvailable
 			? new AesGcmSecretProtector(store)
 			: null;
 
 		// Encrypted + unavailable store => protector null => fail-closed on encrypt/decrypt.
 		IdentityTokenStorage.Configure(method, protector);
+	}
+
+	/// <summary>
+	/// Resolve the secret store used for the AES-GCM master key.
+	/// Priority: <see cref="MasterKeyFileEnvVar"/> -> default <see cref="DefaultMasterKeyFileName"/> under Libation files
+	/// -> <see cref="MasterKeyEnvVar"/> -> OS-bound <see cref="OsSecretStore"/>.
+	/// </summary>
+	public static IOsSecretStore ResolveSecretStore(Configuration config)
+	{
+		ArgumentNullException.ThrowIfNull(config);
+
+		var keyFileEnv = Environment.GetEnvironmentVariable(MasterKeyFileEnvVar);
+		if (!string.IsNullOrWhiteSpace(keyFileEnv))
+			return LoadMasterKeyFileOrUnavailable(keyFileEnv.Trim());
+
+		var defaultKeyPath = Path.Combine(config.LibationFiles.Location, DefaultMasterKeyFileName);
+		if (File.Exists(defaultKeyPath))
+			return LoadMasterKeyFileOrUnavailable(defaultKeyPath);
+
+		var keyEnv = Environment.GetEnvironmentVariable(MasterKeyEnvVar);
+		if (!string.IsNullOrWhiteSpace(keyEnv))
+			return LoadMasterKeyBase64OrUnavailable(keyEnv.Trim());
+
+		return OsSecretStore.Create(ApplicationName);
 	}
 
 	/// <summary>True when the OS secret store can hold Libation's encryption master key.</summary>
@@ -64,6 +98,67 @@ public static class IdentityTokenStorageWiring
 		return store.IsAvailable;
 	}
 
+	/// <summary>True when any resolved secret store (portable or OS) can supply an encryption master key.</summary>
+	public static bool IsEncryptionKeyAvailable(Configuration config, out string? unavailableReason)
+	{
+		ArgumentNullException.ThrowIfNull(config);
+		var store = ResolveSecretStore(config);
+		unavailableReason = store.IsAvailable ? null : store.UnavailableReason;
+		return store.IsAvailable;
+	}
+
+	private static IOsSecretStore LoadMasterKeyFileOrUnavailable(string path)
+	{
+		var store = new MemoryOsSecretStore();
+		try
+		{
+			MasterKeyPortability.ImportFromFile(store, path);
+			return store;
+		}
+		catch (Exception ex)
+		{
+			return new UnavailablePortableSecretStore(
+				"Portable master key file",
+				$"Portable master key file is unusable ({path}): {SafeMessage(ex)}");
+		}
+	}
+
+	private static IOsSecretStore LoadMasterKeyBase64OrUnavailable(string base64)
+	{
+		byte[] key;
+		try
+		{
+			key = Convert.FromBase64String(base64);
+		}
+		catch (FormatException ex)
+		{
+			return new UnavailablePortableSecretStore(
+				"Portable master key env",
+				$"{MasterKeyEnvVar} is not valid Base64: {SafeMessage(ex)}");
+		}
+
+		try
+		{
+			if (key.Length != AesGcmSecretProtector.KeySizeBytes)
+			{
+				return new UnavailablePortableSecretStore(
+					"Portable master key env",
+					$"{MasterKeyEnvVar} must decode to {AesGcmSecretProtector.KeySizeBytes} bytes.");
+			}
+
+			var store = new MemoryOsSecretStore();
+			store.Set(AesGcmSecretProtector.DefaultMasterKeyName, key);
+			return store;
+		}
+		finally
+		{
+			CryptographicOperations.ZeroMemory(key);
+		}
+	}
+
+	private static string SafeMessage(Exception ex)
+		=> string.IsNullOrWhiteSpace(ex.Message) ? ex.GetType().Name : ex.Message;
+
 	private static void OnPropertyChanged(object? sender, PropertyChangedEventArgs e)
 	{
 		if (e.PropertyName != nameof(Configuration.TokenStorageMethod))
@@ -72,5 +167,27 @@ public static class IdentityTokenStorageWiring
 			return;
 
 		ConfigureFrom(config);
+	}
+
+	private sealed class UnavailablePortableSecretStore : IOsSecretStore
+	{
+		public UnavailablePortableSecretStore(string name, string reason)
+		{
+			Name = name;
+			UnavailableReason = reason;
+		}
+
+		public string Name { get; }
+		public bool IsAvailable => false;
+		public string? UnavailableReason { get; }
+
+		public void Set(string key, ReadOnlySpan<byte> value)
+			=> throw new OsSecretStoreUnavailableException(Name, UnavailableReason!);
+
+		public bool TryGet(string key, out byte[] value)
+			=> throw new OsSecretStoreUnavailableException(Name, UnavailableReason!);
+
+		public void Delete(string key)
+			=> throw new OsSecretStoreUnavailableException(Name, UnavailableReason!);
 	}
 }

--- a/Source/AudibleUtilities/MasterKeyExport.cs
+++ b/Source/AudibleUtilities/MasterKeyExport.cs
@@ -1,0 +1,39 @@
+using Dinah.Core.Security;
+
+namespace AudibleUtilities;
+
+/// <summary>
+/// Export Libation's OS-bound AES-GCM master key for portable use (e.g. Docker).
+/// Never creates a new key; the desktop OS store must already hold one.
+/// </summary>
+public static class MasterKeyExport
+{
+	/// <summary>
+	/// Write the existing Libation master key as raw bytes to <paramref name="filePath"/>.
+	/// </summary>
+	/// <exception cref="InvalidOperationException">OS secret store unavailable or master key missing.</exception>
+	public static void ExportToFile(string filePath)
+	{
+		ArgumentException.ThrowIfNullOrWhiteSpace(filePath);
+
+		if (!IdentityTokenStorageWiring.IsOsSecretStoreAvailable(out var unavailableReason))
+		{
+			throw new InvalidOperationException(
+				"Cannot export the encryption master key because the OS secret store is unavailable."
+				+ (string.IsNullOrWhiteSpace(unavailableReason) ? "" : " " + unavailableReason));
+		}
+
+		var store = OsSecretStore.Create(IdentityTokenStorageWiring.ApplicationName);
+		try
+		{
+			MasterKeyPortability.ExportToFile(store, filePath);
+		}
+		catch (SecretProtectionException ex)
+		{
+			throw new InvalidOperationException(
+				"Cannot export the encryption master key because it was not found. "
+				+ "Encrypt tokens on this machine at least once (Settings -> Important, store tokens encrypted) so a key exists, then try again.",
+				ex);
+		}
+	}
+}

--- a/Source/LibationAvalonia/Controls/Settings/Important.axaml
+++ b/Source/LibationAvalonia/Controls/Settings/Important.axaml
@@ -107,14 +107,24 @@
 					IsVisible="{Binding OsStoreUnavailableVisible}"
 					Text="{Binding OsStoreUnavailableMessage}"
 					TextWrapping="Wrap" />
-				<Button
+				<StackPanel
 					Margin="0,10,0,0"
+					Orientation="Horizontal"
 					HorizontalAlignment="Right"
-					Padding="20,0"
-					Content="{Binding ConvertButtonText}"
-					ToolTip.Tip="{Binding ConvertButtonToolTip}"
-					IsEnabled="{Binding ConvertButtonEnabled}"
-					Command="{Binding ConvertExistingTokensCommand}" />
+					Spacing="10">
+					<Button
+						Padding="20,0"
+						Content="{Binding ExportButtonText}"
+						ToolTip.Tip="{Binding ExportButtonToolTip}"
+						IsEnabled="{Binding ExportButtonEnabled}"
+						Click="ExportMasterKey_Click" />
+					<Button
+						Padding="20,0"
+						Content="{Binding ConvertButtonText}"
+						ToolTip.Tip="{Binding ConvertButtonToolTip}"
+						IsEnabled="{Binding ConvertButtonEnabled}"
+						Command="{Binding ConvertExistingTokensCommand}" />
+				</StackPanel>
 			</StackPanel>
 		</controls:GroupBox>
 

--- a/Source/LibationAvalonia/Controls/Settings/Important.axaml.cs
+++ b/Source/LibationAvalonia/Controls/Settings/Important.axaml.cs
@@ -1,8 +1,11 @@
 using Avalonia.Controls;
 using Avalonia.Controls.ApplicationLifetimes;
+using Avalonia.Platform.Storage;
+using AudibleUtilities;
 using LibationAvalonia.Dialogs;
 using LibationAvalonia.ViewModels.Settings;
 using LibationFileManager;
+using LibationUiBase;
 using System.Linq;
 
 namespace LibationAvalonia.Controls.Settings;
@@ -19,6 +22,32 @@ public partial class Important : UserControl
 		}
 
 		ThemeComboBox.SelectionChanged += ThemeComboBox_SelectionChanged;
+	}
+
+	private async void ExportMasterKey_Click(object? sender, Avalonia.Interactivity.RoutedEventArgs e)
+	{
+		var owner = this.GetParentWindow();
+		if (!await TokenStorageSettingsUi.ConfirmExportMasterKeyAsync(owner))
+			return;
+
+		var options = new FilePickerSaveOptions
+		{
+			Title = TokenStorageSettingsUi.ExportConfirmCaption,
+			SuggestedFileName = IdentityTokenStorageWiring.DefaultMasterKeyFileName,
+			DefaultExtension = "key",
+			ShowOverwritePrompt = true,
+			FileTypeChoices =
+			[
+				new("Master key (*.key)") { Patterns = ["*.key"] },
+				new("All files (*.*)") { Patterns = ["*"] }
+			]
+		};
+
+		var selectedFile = (await owner.StorageProvider.SaveFilePickerAsync(options))?.TryGetLocalPath();
+		if (selectedFile is null)
+			return;
+
+		await TokenStorageSettingsUi.ExportMasterKeyToFileAsync(owner, selectedFile);
 	}
 
 	private void EditThemeColors_Click(object sender, Avalonia.Interactivity.RoutedEventArgs e)

--- a/Source/LibationAvalonia/ViewModels/Settings/ImportantSettingsVM.cs
+++ b/Source/LibationAvalonia/ViewModels/Settings/ImportantSettingsVM.cs
@@ -49,12 +49,14 @@ public class ImportantSettingsVM : ViewModelBase
 			OsStoreUnavailableMessage = TokenStorageSettingsUi.OsStoreUnavailableMessage(unavailableReason);
 			encryptTokens = false;
 			CanEditEncryptTokens = false;
+			ExportButtonEnabled = false;
 		}
 		else
 		{
 			OsStoreUnavailableVisible = false;
 			encryptTokens = TokenStorageSettingsUi.CheckboxFromMethod(config.TokenStorageMethod);
 			CanEditEncryptTokens = true;
+			ExportButtonEnabled = true;
 		}
 
 		RefreshTokenStorageUiState();
@@ -156,7 +158,10 @@ public class ImportantSettingsVM : ViewModelBase
 	public string PlaintextWarningText { get; } = TokenStorageSettingsUi.PlaintextWarningText;
 	public string ConvertButtonText { get; } = TokenStorageSettingsUi.ConvertButtonText;
 	public string ConvertButtonToolTip { get; } = TokenStorageSettingsUi.ConvertButtonToolTip;
+	public string ExportButtonText { get; } = TokenStorageSettingsUi.ExportButtonText;
+	public string ExportButtonToolTip { get; } = TokenStorageSettingsUi.ExportButtonToolTip;
 	public bool CanEditEncryptTokens { get; }
+	public bool ExportButtonEnabled { get; }
 
 	public string BooksDirectory { get; set; }
 	public bool SavePodcastsToParentFolder { get; set; }

--- a/Source/LibationCli/Options/ExportMasterKeyOptions.cs
+++ b/Source/LibationCli/Options/ExportMasterKeyOptions.cs
@@ -1,0 +1,44 @@
+using AudibleUtilities;
+using CommandLine;
+using System;
+using System.IO;
+using System.Threading.Tasks;
+
+namespace LibationCli;
+
+[Verb("export-master-key", HelpText = "Export Libation's OS-bound encryption master key to a file for portable use (e.g. Docker). The file unlocks encrypted AccountsSettings.json.")]
+internal class ExportMasterKeyOptions : OptionsBase
+{
+	[Value(0, MetaName = "path", Required = false, HelpText = "Destination path for the raw master key file (e.g. libation-master.key).")]
+	public string? KeyFilePath { get; set; }
+
+	[Option('p', "path", HelpText = "Destination path for the raw master key file. Alternative to the positional path argument.")]
+	public string? PathOption { get; set; }
+
+	protected override Task ProcessAsync()
+	{
+		var path = (PathOption ?? KeyFilePath)?.Trim();
+		if (string.IsNullOrEmpty(path))
+		{
+			PrintVerbUsage("ERROR", "=====", "Path to the master key file is required.");
+			Environment.ExitCode = (int)ExitCode.RunTimeError;
+			return Task.CompletedTask;
+		}
+
+		try
+		{
+			MasterKeyExport.ExportToFile(path);
+		}
+		catch (Exception ex)
+		{
+			PrintVerbUsage("ERROR", "=====", ex.Message);
+			Environment.ExitCode = (int)ExitCode.RunTimeError;
+			return Task.CompletedTask;
+		}
+
+		Console.WriteLine($"Wrote master key to: {Path.GetFullPath(path)}");
+		Console.WriteLine("Treat this file like a password: anyone with it can decrypt AccountsSettings.json tokens.");
+		Console.WriteLine("For Docker, copy it next to AccountsSettings.json as libation-master.key, or set LIBATION_MASTER_KEY_FILE.");
+		return Task.CompletedTask;
+	}
+}

--- a/Source/LibationUiBase/TokenStorageSettingsUi.cs
+++ b/Source/LibationUiBase/TokenStorageSettingsUi.cs
@@ -1,6 +1,7 @@
 using AudibleApi.Authorization;
 using AudibleUtilities;
 using LibationUiBase.Forms;
+using System;
 using System.Threading.Tasks;
 
 namespace LibationUiBase;
@@ -20,6 +21,20 @@ public static class TokenStorageSettingsUi
 
 	public const string ConvertButtonToolTip
 		= "Convert existing tokens in AccountsSettings.json to match the currently selected storage method.";
+
+	public const string ExportButtonText = "Export encryption key...";
+
+	public const string ExportButtonToolTip
+		= "Export the OS-bound encryption master key to a file for Docker or another machine. Treat the file like a password.";
+
+	public const string ExportConfirmCaption = "Export encryption key";
+
+	public const string ExportConfirmBody
+		= "Export the encryption master key to a file for use in Docker or on another machine?\r\n\r\n"
+		+ "Anyone with this file can decrypt encrypted tokens in AccountsSettings.json. Treat it like a password.";
+
+	public const string ExportSucceededCaption = "Encryption key exported";
+	public const string ExportFailedCaption = "Export failed";
 
 	public const string SavePromptCaption = "Convert existing tokens?";
 	public const string ConvertConfirmCaption = "Confirm token conversion";
@@ -199,6 +214,53 @@ public static class TokenStorageSettingsUi
 		}
 
 		return true;
+	}
+
+	/// <summary>Ask the user to confirm exporting the master key. Returns true when they choose Yes.</summary>
+	public static async Task<bool> ConfirmExportMasterKeyAsync(object? owner)
+	{
+		var confirm = await MessageBoxBase.Show(
+			owner,
+			ExportConfirmBody,
+			ExportConfirmCaption,
+			MessageBoxButtons.YesNo,
+			MessageBoxIcon.Warning,
+			defaultButton: MessageBoxDefaultButton.Button2);
+
+		return confirm == DialogResult.Yes;
+	}
+
+	/// <summary>
+	/// Export the OS-bound master key to <paramref name="filePath"/> and show success/error.
+	/// Caller should confirm first and obtain <paramref name="filePath"/> via a save-file dialog.
+	/// </summary>
+	public static async Task ExportMasterKeyToFileAsync(object? owner, string filePath)
+	{
+		ArgumentException.ThrowIfNullOrWhiteSpace(filePath);
+
+		try
+		{
+			MasterKeyExport.ExportToFile(filePath);
+		}
+		catch (System.Exception ex)
+		{
+			Serilog.Log.Logger.Warning(ex, "Master key export failed");
+			await MessageBoxBase.Show(
+				owner,
+				ex.Message,
+				ExportFailedCaption,
+				MessageBoxButtons.OK,
+				MessageBoxIcon.Error);
+			return;
+		}
+
+		await MessageBoxBase.Show(
+			owner,
+			$"Wrote master key to:\r\n{filePath}\r\n\r\n"
+			+ "For Docker, copy it next to AccountsSettings.json as libation-master.key, or set LIBATION_MASTER_KEY_FILE.",
+			ExportSucceededCaption,
+			MessageBoxButtons.OK,
+			MessageBoxIcon.Information);
 	}
 }
 

--- a/Source/LibationWinForms/Dialogs/SettingsDialog.Designer.cs
+++ b/Source/LibationWinForms/Dialogs/SettingsDialog.Designer.cs
@@ -75,6 +75,7 @@
 			encryptTokensCbox = new System.Windows.Forms.CheckBox();
 			plaintextTokenWarningLbl = new System.Windows.Forms.Label();
 			osSecretStoreUnavailableLbl = new System.Windows.Forms.Label();
+			exportMasterKeyBtn = new System.Windows.Forms.Button();
 			updateExistingTokensBtn = new System.Windows.Forms.Button();
 			booksGb = new System.Windows.Forms.GroupBox();
 			booksSelectControl = new DirectoryOrCustomSelectControl();
@@ -529,6 +530,7 @@
 			// 
 			tokenStorageGb.Anchor = System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right;
 			tokenStorageGb.Controls.Add(updateExistingTokensBtn);
+			tokenStorageGb.Controls.Add(exportMasterKeyBtn);
 			tokenStorageGb.Controls.Add(osSecretStoreUnavailableLbl);
 			tokenStorageGb.Controls.Add(plaintextTokenWarningLbl);
 			tokenStorageGb.Controls.Add(encryptTokensCbox);
@@ -571,13 +573,24 @@
 			osSecretStoreUnavailableLbl.Text = "[OS secret store unavailable]";
 			osSecretStoreUnavailableLbl.Visible = false;
 			// 
+			// exportMasterKeyBtn
+			// 
+			exportMasterKeyBtn.Anchor = System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right;
+			exportMasterKeyBtn.Location = new System.Drawing.Point(422, 68);
+			exportMasterKeyBtn.Name = "exportMasterKeyBtn";
+			exportMasterKeyBtn.Size = new System.Drawing.Size(200, 27);
+			exportMasterKeyBtn.TabIndex = 3;
+			exportMasterKeyBtn.Text = "Export encryption key...";
+			exportMasterKeyBtn.UseVisualStyleBackColor = true;
+			exportMasterKeyBtn.Click += exportMasterKeyBtn_Click;
+			// 
 			// updateExistingTokensBtn
 			// 
 			updateExistingTokensBtn.Anchor = System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right;
 			updateExistingTokensBtn.Location = new System.Drawing.Point(628, 68);
 			updateExistingTokensBtn.Name = "updateExistingTokensBtn";
 			updateExistingTokensBtn.Size = new System.Drawing.Size(200, 27);
-			updateExistingTokensBtn.TabIndex = 3;
+			updateExistingTokensBtn.TabIndex = 4;
 			updateExistingTokensBtn.Text = "Update existing stored tokens";
 			updateExistingTokensBtn.UseVisualStyleBackColor = true;
 			updateExistingTokensBtn.Click += updateExistingTokensBtn_Click;
@@ -1768,6 +1781,7 @@
 		private System.Windows.Forms.CheckBox encryptTokensCbox;
 		private System.Windows.Forms.Label plaintextTokenWarningLbl;
 		private System.Windows.Forms.Label osSecretStoreUnavailableLbl;
+		private System.Windows.Forms.Button exportMasterKeyBtn;
 		private System.Windows.Forms.Button updateExistingTokensBtn;
 		private System.Windows.Forms.GroupBox booksGb;
 		private System.Windows.Forms.TabPage tab2ImportLibrary;

--- a/Source/LibationWinForms/Dialogs/SettingsDialog.Important.cs
+++ b/Source/LibationWinForms/Dialogs/SettingsDialog.Important.cs
@@ -83,7 +83,9 @@ public partial class SettingsDialog
 
 		encryptTokensCbox.Text = TokenStorageSettingsUi.CheckboxText;
 		plaintextTokenWarningLbl.Text = TokenStorageSettingsUi.PlaintextWarningText;
+		exportMasterKeyBtn.Text = TokenStorageSettingsUi.ExportButtonText;
 		updateExistingTokensBtn.Text = TokenStorageSettingsUi.ConvertButtonText;
+		toolTip.SetToolTip(exportMasterKeyBtn, TokenStorageSettingsUi.ExportButtonToolTip);
 		toolTip.SetToolTip(updateExistingTokensBtn, TokenStorageSettingsUi.ConvertButtonToolTip);
 
 		if (!osSecretStoreAvailable)
@@ -92,11 +94,13 @@ public partial class SettingsDialog
 			osSecretStoreUnavailableLbl.Visible = true;
 			encryptTokensCbox.Checked = false;
 			encryptTokensCbox.Enabled = false;
+			exportMasterKeyBtn.Enabled = false;
 		}
 		else
 		{
 			osSecretStoreUnavailableLbl.Visible = false;
 			encryptTokensCbox.Enabled = true;
+			exportMasterKeyBtn.Enabled = true;
 			encryptTokensCbox.Checked = TokenStorageSettingsUi.CheckboxFromMethod(config.TokenStorageMethod);
 		}
 
@@ -117,6 +121,25 @@ public partial class SettingsDialog
 
 	private void encryptTokensCbox_CheckedChanged(object? sender, EventArgs e)
 		=> RefreshTokenStorageUiState();
+
+	private async void exportMasterKeyBtn_Click(object? sender, EventArgs e)
+	{
+		if (!await TokenStorageSettingsUi.ConfirmExportMasterKeyAsync(this))
+			return;
+
+		using var dialog = new SaveFileDialog
+		{
+			Title = TokenStorageSettingsUi.ExportConfirmCaption,
+			FileName = IdentityTokenStorageWiring.DefaultMasterKeyFileName,
+			Filter = "Master key (*.key)|*.key|All files (*.*)|*.*",
+			OverwritePrompt = true
+		};
+
+		if (dialog.ShowDialog(this) != DialogResult.OK)
+			return;
+
+		await TokenStorageSettingsUi.ExportMasterKeyToFileAsync(this, dialog.FileName);
+	}
 
 	private async void updateExistingTokensBtn_Click(object? sender, EventArgs e)
 	{

--- a/Source/_Tests/AudibleUtilities.Tests/AccountSettingsDecryptFailureTests.cs
+++ b/Source/_Tests/AudibleUtilities.Tests/AccountSettingsDecryptFailureTests.cs
@@ -46,12 +46,15 @@ public class AccountSettingsDecryptFailureTests
 	}
 
 	[TestMethod]
-	public void Explainer_mentions_plaintext_convert_cli_and_faq()
+	public void Explainer_mentions_portable_key_plaintext_cli_and_faq()
 	{
 		var ex = CreateDecryptException("ExistingAccessToken");
 		var body = AccountSettingsDecryptFailure.GetExplainerBody(ex);
 
 		StringAssert.Contains(body, "could not be decrypted");
+		StringAssert.Contains(body, "export-master-key");
+		StringAssert.Contains(body, "libation-master.key");
+		StringAssert.Contains(body, "LIBATION_MASTER_KEY_FILE");
 		StringAssert.Contains(body, "Store authentication tokens encrypted");
 		StringAssert.Contains(body, "login-external");
 		StringAssert.Contains(body, "import-account");

--- a/Source/_Tests/AudibleUtilities.Tests/IdentityTokenStorageWiringTests.cs
+++ b/Source/_Tests/AudibleUtilities.Tests/IdentityTokenStorageWiringTests.cs
@@ -287,6 +287,33 @@ BxlXqPnQ4mG66oqSFQgDEmFdMhRb2of6xL1gYYL62C80G2T7QtmPfSab
 		return identity;
 	}
 
+	[TestMethod]
+	public void MasterKeyExport_writes_key_file_when_os_store_has_key()
+	{
+		if (!IdentityTokenStorageWiring.IsOsSecretStoreAvailable(out var reason))
+			Assert.Inconclusive("OS secret store unavailable: " + reason);
+
+		Environment.SetEnvironmentVariable(LibationFiles.LIBATION_FILES_DIR, _tempDir);
+		var config = Configuration.CreateMockInstance();
+		config.TokenStorageMethod = TokenStorageMethod.Encrypted;
+		IdentityTokenStorageWiring.ConfigureFrom(config);
+
+		Assert.IsNotNull(IdentityTokenStorage.Protector);
+		_ = IdentityTokenStorage.Protector!.Protect("seed-master-key");
+
+		var exportPath = Path.Combine(_tempDir!, "libation-master.key");
+		MasterKeyExport.ExportToFile(exportPath);
+
+		File.Exists(exportPath).Should().BeTrue();
+		File.ReadAllBytes(exportPath).Length.Should().Be(AesGcmSecretProtector.KeySizeBytes);
+
+		// Portable load of the exported file can decrypt ciphertext from the OS-backed protector.
+		var payload = IdentityTokenStorage.Protector.Protect("roundtrip-secret", "aad");
+		Environment.SetEnvironmentVariable(IdentityTokenStorageWiring.MasterKeyFileEnvVar, exportPath);
+		IdentityTokenStorageWiring.ConfigureFrom(config);
+		IdentityTokenStorage.Protector!.Unprotect(payload, "aad").Should().Be("roundtrip-secret");
+	}
+
 	private string WriteTempMasterKeyFile()
 	{
 		var path = Path.Combine(_tempDir!, "exported-master.key");

--- a/Source/_Tests/AudibleUtilities.Tests/IdentityTokenStorageWiringTests.cs
+++ b/Source/_Tests/AudibleUtilities.Tests/IdentityTokenStorageWiringTests.cs
@@ -11,6 +11,7 @@ using Newtonsoft.Json.Linq;
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Security.Cryptography;
 
 namespace IdentityTokenStorageWiringTests;
 
@@ -73,6 +74,9 @@ BxlXqPnQ4mG66oqSFQgDEmFdMhRb2of6xL1gYYL62C80G2T7QtmPfSab
 	{
 		IdentityTokenStorage.Reset();
 		Configuration.RestoreSingletonInstance();
+		Environment.SetEnvironmentVariable(IdentityTokenStorageWiring.MasterKeyFileEnvVar, null);
+		Environment.SetEnvironmentVariable(IdentityTokenStorageWiring.MasterKeyEnvVar, null);
+		Environment.SetEnvironmentVariable(LibationFiles.LIBATION_FILES_DIR, null);
 
 		if (_tempDir is not null && Directory.Exists(_tempDir))
 		{
@@ -92,6 +96,87 @@ BxlXqPnQ4mG66oqSFQgDEmFdMhRb2of6xL1gYYL62C80G2T7QtmPfSab
 		Assert.AreEqual(TokenStorageMethod.Encrypted, IdentityTokenStorage.WriteMethod);
 		if (IdentityTokenStorageWiring.IsOsSecretStoreAvailable(out _))
 			Assert.IsNotNull(IdentityTokenStorage.Protector);
+	}
+
+	[TestMethod]
+	public void ResolveSecretStore_uses_master_key_file_env_before_os_store()
+	{
+		var keyPath = WriteTempMasterKeyFile();
+		Environment.SetEnvironmentVariable(IdentityTokenStorageWiring.MasterKeyFileEnvVar, keyPath);
+		Environment.SetEnvironmentVariable(LibationFiles.LIBATION_FILES_DIR, _tempDir);
+
+		var config = Configuration.CreateMockInstance();
+		var store = IdentityTokenStorageWiring.ResolveSecretStore(config);
+
+		store.Name.Should().Be("Memory");
+		store.TryGet(AesGcmSecretProtector.DefaultMasterKeyName, out var key).Should().BeTrue();
+		key.Length.Should().Be(AesGcmSecretProtector.KeySizeBytes);
+
+		IdentityTokenStorageWiring.ConfigureFrom(config);
+		Assert.IsNotNull(IdentityTokenStorage.Protector);
+		var payload = IdentityTokenStorage.Protector!.Protect("portable-secret", "aad");
+		IdentityTokenStorage.Protector.Unprotect(payload, "aad").Should().Be("portable-secret");
+	}
+
+	[TestMethod]
+	public void ResolveSecretStore_uses_default_libation_master_key_file()
+	{
+		Environment.SetEnvironmentVariable(LibationFiles.LIBATION_FILES_DIR, _tempDir);
+		var config = Configuration.CreateMockInstance();
+		var defaultPath = Path.Combine(config.LibationFiles.Location, IdentityTokenStorageWiring.DefaultMasterKeyFileName);
+		WriteMasterKeyFile(defaultPath);
+
+		var store = IdentityTokenStorageWiring.ResolveSecretStore(config);
+		store.Name.Should().Be("Memory");
+		store.TryGet(AesGcmSecretProtector.DefaultMasterKeyName, out _).Should().BeTrue();
+	}
+
+	[TestMethod]
+	public void ResolveSecretStore_uses_master_key_env_base64()
+	{
+		var key = new byte[AesGcmSecretProtector.KeySizeBytes];
+		RandomNumberGenerator.Fill(key);
+		Environment.SetEnvironmentVariable(IdentityTokenStorageWiring.MasterKeyEnvVar, Convert.ToBase64String(key));
+		Environment.SetEnvironmentVariable(LibationFiles.LIBATION_FILES_DIR, _tempDir);
+
+		var config = Configuration.CreateMockInstance();
+		var store = IdentityTokenStorageWiring.ResolveSecretStore(config);
+
+		store.Name.Should().Be("Memory");
+		store.TryGet(AesGcmSecretProtector.DefaultMasterKeyName, out var loaded).Should().BeTrue();
+		CollectionAssert.AreEqual(key, loaded);
+	}
+
+	[TestMethod]
+	public void ResolveSecretStore_invalid_master_key_env_fails_closed_without_falling_through()
+	{
+		Environment.SetEnvironmentVariable(IdentityTokenStorageWiring.MasterKeyEnvVar, "not-valid-base64!!!");
+		Environment.SetEnvironmentVariable(LibationFiles.LIBATION_FILES_DIR, _tempDir);
+
+		var config = Configuration.CreateMockInstance();
+		var store = IdentityTokenStorageWiring.ResolveSecretStore(config);
+
+		store.IsAvailable.Should().BeFalse();
+		store.Name.Should().Be("Portable master key env");
+
+		config.TokenStorageMethod = TokenStorageMethod.Encrypted;
+		IdentityTokenStorageWiring.ConfigureFrom(config);
+		Assert.IsNull(IdentityTokenStorage.Protector);
+	}
+
+	[TestMethod]
+	public void ResolveSecretStore_missing_master_key_file_env_fails_closed()
+	{
+		var missing = Path.Combine(_tempDir!, "missing-master.key");
+		Environment.SetEnvironmentVariable(IdentityTokenStorageWiring.MasterKeyFileEnvVar, missing);
+		Environment.SetEnvironmentVariable(LibationFiles.LIBATION_FILES_DIR, _tempDir);
+
+		var config = Configuration.CreateMockInstance();
+		var store = IdentityTokenStorageWiring.ResolveSecretStore(config);
+
+		store.IsAvailable.Should().BeFalse();
+		IdentityTokenStorageWiring.IsEncryptionKeyAvailable(config, out var reason).Should().BeFalse();
+		StringAssert.Contains(reason, "unusable");
 	}
 
 	[TestMethod]
@@ -200,5 +285,20 @@ BxlXqPnQ4mG66oqSFQgDEmFdMhRb2of6xL1gYYL62C80G2T7QtmPfSab
 			deviceName: "device-name",
 			storeAuthenticationCookie: SampleStoreAuthCookie);
 		return identity;
+	}
+
+	private string WriteTempMasterKeyFile()
+	{
+		var path = Path.Combine(_tempDir!, "exported-master.key");
+		WriteMasterKeyFile(path);
+		return path;
+	}
+
+	private static void WriteMasterKeyFile(string path)
+	{
+		var key = new byte[AesGcmSecretProtector.KeySizeBytes];
+		RandomNumberGenerator.Fill(key);
+		Directory.CreateDirectory(Path.GetDirectoryName(path)!);
+		File.WriteAllBytes(path, key);
 	}
 }

--- a/Source/_Tests/LibationUiBase.Tests/TokenStorageSettingsUiTests.cs
+++ b/Source/_Tests/LibationUiBase.Tests/TokenStorageSettingsUiTests.cs
@@ -53,4 +53,12 @@ public class TokenStorageSettingsUiTests
 		StringAssert.Contains(message, "AccessToken");
 		Assert.IsFalse(message.Contains("Atna|"));
 	}
+
+	[TestMethod]
+	public void Export_copy_warns_about_secret_file()
+	{
+		StringAssert.Contains(TokenStorageSettingsUi.ExportConfirmBody, "password");
+		StringAssert.Contains(TokenStorageSettingsUi.ExportButtonToolTip, "Docker");
+		Assert.AreEqual("Export encryption key...", TokenStorageSettingsUi.ExportButtonText);
+	}
 }

--- a/docs/advanced/command-line-interface.md
+++ b/docs/advanced/command-line-interface.md
@@ -72,6 +72,26 @@ libationcli import-account /home/me/Audible/account.json
 
 Use `libationcli import-account --help` for the exact options on your build.
 
+## Export the encryption master key (`export-master-key`)
+
+When authentication tokens are stored encrypted, the AES-GCM master key lives in the desktop OS secret store and does not travel with `AccountsSettings.json`. Export it to a file for Docker or another machine:
+
+```console
+libationcli export-master-key libation-master.key
+libationcli export-master-key --path "C:\path\to\libation-master.key"
+```
+
+Requirements:
+
+- The OS secret store must be available on the machine where you run the command.
+- A master key must already exist (encrypt tokens at least once on that machine).
+
+Treat the output file like a password: anyone with it can decrypt encrypted tokens in `AccountsSettings.json`. For Docker, copy `libation-master.key` into the config folder next to `AccountsSettings.json`, or set `LIBATION_MASTER_KEY_FILE` / `LIBATION_MASTER_KEY`. See [Docker - encrypted tokens](/docs/installation/docker#configuration).
+
+You can also export from the GUI: **Settings -> Important -> Export encryption key...**
+
+Use `libationcli export-master-key --help` for the exact options on your build.
+
 ## Log in with an external browser (`login-external`)
 
 For headless servers or when you prefer not to use the GUI, this verb performs the same external browser OAuth flow as Libation's alternate login: the CLI prints a sign-in URL, you complete login in your own browser, then supply the full URL shown in the browser after Audible redirects you (it is normal if that page looks broken or says the page does not exist).

--- a/docs/advanced/troubleshoot.md
+++ b/docs/advanced/troubleshoot.md
@@ -27,11 +27,18 @@ Audible returned an HTML page instead of JSON. Common causes: transient outage, 
 
 **Symptoms:** The Windows (or other desktop) app shows your full library and new titles, but Docker / Linux finds no new books after you copy `AccountsSettings.json` from that machine. Container or `Libation.log` output includes `Failed to decrypt ExistingAccessToken`.
 
-**Cause:** Recent Libation can encrypt auth tokens in `AccountsSettings.json` using a key stored in the OS secret store (on Windows: DPAPI). That key does **not** travel when you copy the file into Docker, so the container cannot decrypt the tokens and the library scan fails.
+**Cause:** Libation can encrypt auth tokens in `AccountsSettings.json` using a key stored in the OS secret store (on Windows: DPAPI). That key does **not** travel when you copy only the JSON file into Docker, so the container cannot decrypt the tokens and the library scan fails.
 
 **Quick check:** Open `AccountsSettings.json` on the Docker config volume. If you see `"IsEncrypted": true` near `ExistingAccessToken`, `RefreshToken`, or related fields, that is the problem.
 
-**Fix from Windows:** In the desktop app, open **Settings -> Important**, uncheck **Store authentication tokens encrypted**, and when prompted choose **Yes** to decrypt and re-save existing tokens as plaintext. Copy the updated `AccountsSettings.json` (and `Settings.json`) into the Docker config folder and restart the container.
+**Preferred fix (keep encryption):** On the desktop machine, export the master key:
+
+- **GUI:** Settings -> Important -> **Export encryption key...**
+- **CLI:** `LibationCli export-master-key libation-master.key`
+
+Copy `libation-master.key` into the Docker config folder next to `AccountsSettings.json` and restart. Or set `LIBATION_MASTER_KEY_FILE` / `LIBATION_MASTER_KEY` (see [Docker environment variables](/docs/installation/docker#environment-variables)). Treat the key file like a password.
+
+**Fix with plaintext tokens:** In the desktop app, open **Settings -> Important**, uncheck **Store authentication tokens encrypted**, and when prompted choose **Yes** to decrypt and re-save existing tokens as plaintext. Copy the updated `AccountsSettings.json` (and `Settings.json`) into the Docker config folder and restart the container.
 
 **Fix without copying Windows accounts:** Create or refresh credentials inside Docker with `login-external` or `import-account`. See [Docker - Adding Audible accounts without the GUI](/docs/installation/docker#adding-audible-accounts-without-the-gui).
 

--- a/docs/frequently-asked-questions.md
+++ b/docs/frequently-asked-questions.md
@@ -59,9 +59,11 @@ For reasons known only to Jeff Bezos and God, amazon and audible brazil handle l
 
 The Windows app sees your library (including new books), but Docker does not, and the log shows `Failed to decrypt ExistingAccessToken`.
 
-You likely copied an `AccountsSettings.json` that has **encrypted** tokens (`"IsEncrypted": true`). The decryption key stays on the Windows machine and is not in the file, so Docker cannot use those credentials.
+You likely copied an `AccountsSettings.json` that has **encrypted** tokens (`"IsEncrypted": true`). The decryption key normally stays on the Windows machine and is not in the JSON file, so Docker cannot use those credentials unless you also provide the exported master key.
 
-**Fix:** On Windows, **Settings -> Important**, uncheck **Store authentication tokens encrypted**, confirm converting existing tokens to plaintext, then copy the updated file into your Docker config and restart. Or re-login inside the container with `login-external` / `import-account`.
+**Preferred fix:** On Windows, export the key (**Settings -> Important -> Export encryption key...**, or `LibationCli export-master-key libation-master.key`), copy `libation-master.key` into your Docker config next to `AccountsSettings.json`, and restart.
+
+**Other fixes:** Convert tokens to plaintext in Settings -> Important, then re-copy the JSON; or re-login inside the container with `login-external` / `import-account`.
 
 Full steps: [Troubleshooting - Failed to decrypt ExistingAccessToken](/docs/advanced/troubleshoot#failed-to-decrypt-existingaccesstoken-docker-finds-no-new-books) and [Docker Troubleshooting](/docs/installation/docker#troubleshooting).
 

--- a/docs/installation/docker.md
+++ b/docs/installation/docker.md
@@ -12,11 +12,18 @@ The docker image is provided as-is. We hope it can be useful to you but it is no
 
 ## Configuration
 
-> [!WARNING] Encrypted tokens from Windows will not work in Docker
+> [!WARNING] Encrypted tokens need the master key in Docker
 >
-> If Docker logs show `Failed to decrypt ExistingAccessToken` (or your scan finds no books after copying Windows config), you copied an `AccountsSettings.json` whose auth tokens are encrypted with a key that stays on the Windows machine. Docker cannot decrypt them.
+> If Docker logs show `Failed to decrypt ExistingAccessToken` (or your scan finds no books after copying Windows config), you copied an `AccountsSettings.json` whose auth tokens are encrypted with a key that normally stays on the desktop OS secret store.
 >
-> **Fix:** On Windows, **Settings -> Important**, uncheck **Store authentication tokens encrypted**, convert existing tokens to plaintext when prompted, then re-copy `AccountsSettings.json` into the Docker config folder. Or skip copying Windows accounts and use `login-external` / `import-account` inside the container (see below).
+> **Preferred fix (keep encryption):** On the desktop machine, export the master key:
+>
+> - **GUI:** Settings -> Important -> **Export encryption key...**
+> - **CLI:** `LibationCli export-master-key libation-master.key`
+>
+> Copy `libation-master.key` into the same Docker config folder as `AccountsSettings.json` (mounted at `/config`). Libation loads it automatically. Alternatively set `LIBATION_MASTER_KEY_FILE` to the key path, or `LIBATION_MASTER_KEY` to the Base64-encoded key. Treat the key file like a password.
+>
+> **Other fixes:** On Windows, **Settings -> Important**, uncheck **Store authentication tokens encrypted**, convert existing tokens to plaintext when prompted, then re-copy `AccountsSettings.json`. Or skip copying Windows accounts and use `login-external` / `import-account` inside the container (see below).
 >
 > Details: [FAQ](/docs/frequently-asked-questions#docker-finds-no-new-books-failed-to-decrypt-existingaccesstoken) · [Troubleshooting](/docs/advanced/troubleshoot#failed-to-decrypt-existingaccesstoken-docker-finds-no-new-books)
 
@@ -26,7 +33,7 @@ The docker image is provided as-is. We hope it can be useful to you but it is no
 >
 > **Solution:** Configure custom replacement characters in `Settings.json` to replace colons with compatible characters. See [Command Line Interface - Set custom replacement characters](/docs/advanced/command-line-interface#set-custom-replacement-characters) for configuration examples.
 
-Configuration in Libation is handled by two files, `AccountsSettings.json` and `Settings.json`. These files can usually be found in the Libation folder in your user's home directory. The easiest way to configure these is to run the desktop version of Libation and then copy them into a folder, such as `/opt/libation/config`, that you'll volume mount into the image. `Settings.json` is technically optional, and, if not provided, Libation will run using the default settings. Additionally, the `Books` and `InProgress` settings in `Settings.json` will be ignored and the image will instead substitute it's own values. If tokens in that file are encrypted on Windows, see the encrypted-tokens warning above.
+Configuration in Libation is handled by two files, `AccountsSettings.json` and `Settings.json`. These files can usually be found in the Libation folder in your user's home directory. The easiest way to configure these is to run the desktop version of Libation and then copy them into a folder, such as `/opt/libation/config`, that you'll volume mount into the image. `Settings.json` is technically optional, and, if not provided, Libation will run using the default settings. Additionally, the `Books` and `InProgress` settings in `Settings.json` will be ignored and the image will instead substitute it's own values. If tokens in that file are encrypted on the desktop, also copy the exported `libation-master.key` (see the encrypted-tokens warning above).
 
 ### Adding Audible accounts without the GUI
 
@@ -80,6 +87,8 @@ sudo docker run -d \
 | LIBATION_DB_FILE           |         | Name of database file to load. By default it will look for all `.db` files and load one if there is only one present. |
 | LIBATION_CREATE_DB         | true    | Whether or not the image should create a database file if none are found.                                             |
 | LIBATION_CONNECTION_STRING |         | Connection string for Postgresql. If not present, Libation uses the default sqlite.                                   |
+| LIBATION_MASTER_KEY_FILE   |         | Path to a raw 32-byte master key file (from `export-master-key`). If unset, Libation also looks for `libation-master.key` under the Libation files / config directory. |
+| LIBATION_MASTER_KEY        |         | Base64-encoded 32-byte master key (alternative to a key file).                                                        |
 
 ## User
 


### PR DESCRIPTION
* Resolve the AES-GCM master key from a portable source before the OS store: `LIBATION_MASTER_KEY_FILE`, default `libation-master.key` next to Libation files, `LIBATION_MASTER_KEY` (Base64), then OS-bound store
* Add desktop export via Settings -> Important -> Export encryption key... and `LibationCli export-master-key`
* Document the Docker workflow (mount key file / env vars) and update FAQ, troubleshoot, CLI docs, and decrypt-failure explainer text.

Desktop daily use stays OS-bound and passwordless. Docker users can keep encrypted `AccountsSettings.json` by exporting and mounting the master key