### PR TITLE
Last-resort portable master key when OS secret store is unavailable

### DIFF
--- a/Source/AudibleUtilities/IdentityTokenStorageWiring.cs
+++ b/Source/AudibleUtilities/IdentityTokenStorageWiring.cs
@@ -1,4 +1,5 @@
 using AudibleApi.Authorization;
+using Dinah.Core.IO;
 using Dinah.Core.Security;
 using LibationFileManager;
 using System.ComponentModel;
@@ -68,8 +69,10 @@ public static class IdentityTokenStorageWiring
 
 	/// <summary>
 	/// Resolve the secret store used for the AES-GCM master key.
-	/// Priority: <see cref="MasterKeyFileEnvVar"/> -> default <see cref="DefaultMasterKeyFileName"/> under Libation files
-	/// -> <see cref="MasterKeyEnvVar"/> -> OS-bound <see cref="OsSecretStore"/>.
+	/// Supported priority: <see cref="MasterKeyFileEnvVar"/> -> existing default <see cref="DefaultMasterKeyFileName"/>
+	/// under Libation files -> <see cref="MasterKeyEnvVar"/> -> OS-bound <see cref="OsSecretStore"/>.
+	/// If the OS store is unavailable, falls through to
+	/// <see cref="TryCreateLastResortPortableMasterKeyStore"/> (headless compatibility path; not the preferred setup).
 	/// </summary>
 	public static IOsSecretStore ResolveSecretStore(Configuration config)
 	{
@@ -87,7 +90,11 @@ public static class IdentityTokenStorageWiring
 		if (!string.IsNullOrWhiteSpace(keyEnv))
 			return LoadMasterKeyBase64OrUnavailable(keyEnv.Trim());
 
-		return OsSecretStore.Create(ApplicationName);
+		var osStore = OsSecretStore.Create(ApplicationName);
+		if (osStore.IsAvailable)
+			return osStore;
+
+		return TryCreateLastResortPortableMasterKeyStore(config);
 	}
 
 	/// <summary>True when the OS secret store can hold Libation's encryption master key.</summary>
@@ -105,6 +112,52 @@ public static class IdentityTokenStorageWiring
 		var store = ResolveSecretStore(config);
 		unavailableReason = store.IsAvailable ? null : store.UnavailableReason;
 		return store.IsAvailable;
+	}
+
+	/// <summary>
+	/// Headless / Docker compatibility path when encryption is enabled but there is no OS secret store
+	/// and the user did not supply a master key.
+	/// Prefer setting <see cref="Configuration.TokenStorageMethod"/> to plaintext, or supplying an exported
+	/// <see cref="DefaultMasterKeyFileName"/> / env key, instead of relying on this path.
+	/// Creates <see cref="DefaultMasterKeyFileName"/> under Libation files if missing, then loads it.
+	/// </summary>
+	internal static IOsSecretStore TryCreateLastResortPortableMasterKeyStore(Configuration config)
+	{
+		ArgumentNullException.ThrowIfNull(config);
+
+		var keyPath = Path.Combine(config.LibationFiles.Location, DefaultMasterKeyFileName);
+		try
+		{
+			if (!File.Exists(keyPath))
+				MintRawMasterKeyFile(keyPath);
+
+			return LoadMasterKeyFileOrUnavailable(keyPath);
+		}
+		catch (Exception ex)
+		{
+			return new UnavailablePortableSecretStore(
+				"Last-resort portable master key",
+				$"Could not create or load last-resort portable master key ({keyPath}): {SafeMessage(ex)}");
+		}
+	}
+
+	/// <summary>Write a new raw 32-byte master key file (same format as <c>export-master-key</c>).</summary>
+	private static void MintRawMasterKeyFile(string keyPath)
+	{
+		var key = new byte[AesGcmSecretProtector.KeySizeBytes];
+		RandomNumberGenerator.Fill(key);
+		try
+		{
+			var directory = Path.GetDirectoryName(Path.GetFullPath(keyPath));
+			if (!string.IsNullOrEmpty(directory))
+				Directory.CreateDirectory(directory);
+
+			AtomicFileWriter.WriteAllBytes(keyPath, key);
+		}
+		finally
+		{
+			CryptographicOperations.ZeroMemory(key);
+		}
 	}
 
 	private static IOsSecretStore LoadMasterKeyFileOrUnavailable(string path)

--- a/Source/AudibleUtilities/IdentityTokenStorageWiring.cs
+++ b/Source/AudibleUtilities/IdentityTokenStorageWiring.cs
@@ -114,6 +114,9 @@ public static class IdentityTokenStorageWiring
 		return store.IsAvailable;
 	}
 
+	/// <summary>Sidecar notice written beside an auto-minted last-resort master key.</summary>
+	public const string LastResortMasterKeyNoticeFileName = "libation-master.key.NOTICE.txt";
+
 	/// <summary>
 	/// Headless / Docker compatibility path when encryption is enabled but there is no OS secret store
 	/// and the user did not supply a master key.
@@ -129,7 +132,10 @@ public static class IdentityTokenStorageWiring
 		try
 		{
 			if (!File.Exists(keyPath))
+			{
 				MintRawMasterKeyFile(keyPath);
+				AnnounceLastResortPortableMasterKey(keyPath);
+			}
 
 			return LoadMasterKeyFileOrUnavailable(keyPath);
 		}
@@ -139,6 +145,40 @@ public static class IdentityTokenStorageWiring
 				"Last-resort portable master key",
 				$"Could not create or load last-resort portable master key ({keyPath}): {SafeMessage(ex)}");
 		}
+	}
+
+	/// <summary>
+	/// Warn that a last-resort portable master key was auto-created. Not the recommended setup.
+	/// </summary>
+	internal static void AnnounceLastResortPortableMasterKey(string keyPath)
+	{
+		ArgumentException.ThrowIfNullOrWhiteSpace(keyPath);
+
+		var fullKeyPath = Path.GetFullPath(keyPath);
+		var noticePath = Path.Combine(
+			Path.GetDirectoryName(fullKeyPath) ?? ".",
+			LastResortMasterKeyNoticeFileName);
+
+		var message =
+			"LAST-RESORT: Token encryption is enabled, but no OS secret store is available and no master key was supplied. "
+			+ $"Libation created a portable master key at '{fullKeyPath}'. "
+			+ "This is a compatibility fallback, not the recommended setup. "
+			+ "Prefer: set TokenStorageMethod to Plaintext in Settings, "
+			+ $"OR supply your own key (export from desktop and place '{DefaultMasterKeyFileName}' next to AccountsSettings.json, "
+			+ $"or set {MasterKeyFileEnvVar} / {MasterKeyEnvVar}). "
+			+ "Treat the key file like a password. It will not decrypt tokens encrypted under a different machine's key.";
+
+		try
+		{
+			AtomicFileWriter.WriteAllText(noticePath, message + Environment.NewLine);
+		}
+		catch (Exception ex)
+		{
+			Serilog.Log.Logger.Warning(ex, "Could not write last-resort master key notice file at {NoticePath}", noticePath);
+		}
+
+		Serilog.Log.Logger.Warning(message);
+		Console.Error.WriteLine(message);
 	}
 
 	/// <summary>Write a new raw 32-byte master key file (same format as <c>export-master-key</c>).</summary>

--- a/Source/_Tests/AudibleUtilities.Tests/IdentityTokenStorageWiringTests.cs
+++ b/Source/_Tests/AudibleUtilities.Tests/IdentityTokenStorageWiringTests.cs
@@ -317,6 +317,12 @@ BxlXqPnQ4mG66oqSFQgDEmFdMhRb2of6xL1gYYL62C80G2T7QtmPfSab
 		store.Name.Should().Be("Memory");
 		File.Exists(defaultPath).Should().BeTrue();
 		File.ReadAllBytes(defaultPath).Length.Should().Be(AesGcmSecretProtector.KeySizeBytes);
+		var noticePath = Path.Combine(config.LibationFiles.Location, IdentityTokenStorageWiring.LastResortMasterKeyNoticeFileName);
+		File.Exists(noticePath).Should().BeTrue();
+		var notice = File.ReadAllText(noticePath);
+		StringAssert.Contains(notice, "LAST-RESORT");
+		StringAssert.Contains(notice, "Plaintext");
+		StringAssert.Contains(notice, IdentityTokenStorageWiring.MasterKeyFileEnvVar);
 		store.TryGet(AesGcmSecretProtector.DefaultMasterKeyName, out var key).Should().BeTrue();
 		key.Length.Should().Be(AesGcmSecretProtector.KeySizeBytes);
 
@@ -330,6 +336,22 @@ BxlXqPnQ4mG66oqSFQgDEmFdMhRb2of6xL1gYYL62C80G2T7QtmPfSab
 		Assert.IsNotNull(IdentityTokenStorage.Protector);
 		var payload = IdentityTokenStorage.Protector!.Protect("last-resort-secret", "aad");
 		IdentityTokenStorage.Protector.Unprotect(payload, "aad").Should().Be("last-resort-secret");
+	}
+
+	[TestMethod]
+	public void AnnounceLastResortPortableMasterKey_writes_notice_beside_key()
+	{
+		var keyPath = Path.Combine(_tempDir!, IdentityTokenStorageWiring.DefaultMasterKeyFileName);
+		File.WriteAllBytes(keyPath, new byte[AesGcmSecretProtector.KeySizeBytes]);
+
+		IdentityTokenStorageWiring.AnnounceLastResortPortableMasterKey(keyPath);
+
+		var noticePath = Path.Combine(_tempDir!, IdentityTokenStorageWiring.LastResortMasterKeyNoticeFileName);
+		File.Exists(noticePath).Should().BeTrue();
+		var notice = File.ReadAllText(noticePath);
+		StringAssert.Contains(notice, "LAST-RESORT");
+		StringAssert.Contains(notice, keyPath);
+		StringAssert.Contains(notice, "compatibility fallback");
 	}
 
 	[TestMethod]

--- a/Source/_Tests/AudibleUtilities.Tests/IdentityTokenStorageWiringTests.cs
+++ b/Source/_Tests/AudibleUtilities.Tests/IdentityTokenStorageWiringTests.cs
@@ -288,6 +288,51 @@ BxlXqPnQ4mG66oqSFQgDEmFdMhRb2of6xL1gYYL62C80G2T7QtmPfSab
 	}
 
 	[TestMethod]
+	public void ResolveSecretStore_uses_os_store_when_available_without_last_resort_key_file()
+	{
+		if (!IdentityTokenStorageWiring.IsOsSecretStoreAvailable(out var reason))
+			Assert.Inconclusive("OS secret store unavailable: " + reason);
+
+		Environment.SetEnvironmentVariable(LibationFiles.LIBATION_FILES_DIR, _tempDir);
+		var config = Configuration.CreateMockInstance();
+		var defaultPath = Path.Combine(config.LibationFiles.Location, IdentityTokenStorageWiring.DefaultMasterKeyFileName);
+
+		var store = IdentityTokenStorageWiring.ResolveSecretStore(config);
+
+		store.IsAvailable.Should().BeTrue();
+		Assert.IsFalse(File.Exists(defaultPath), "OS store available => must not mint last-resort key file");
+	}
+
+	[TestMethod]
+	public void TryCreateLastResortPortableMasterKeyStore_mints_default_key_file_and_loads_protector()
+	{
+		Environment.SetEnvironmentVariable(LibationFiles.LIBATION_FILES_DIR, _tempDir);
+		var config = Configuration.CreateMockInstance();
+		var defaultPath = Path.Combine(config.LibationFiles.Location, IdentityTokenStorageWiring.DefaultMasterKeyFileName);
+		File.Exists(defaultPath).Should().BeFalse();
+
+		var store = IdentityTokenStorageWiring.TryCreateLastResortPortableMasterKeyStore(config);
+
+		store.IsAvailable.Should().BeTrue();
+		store.Name.Should().Be("Memory");
+		File.Exists(defaultPath).Should().BeTrue();
+		File.ReadAllBytes(defaultPath).Length.Should().Be(AesGcmSecretProtector.KeySizeBytes);
+		store.TryGet(AesGcmSecretProtector.DefaultMasterKeyName, out var key).Should().BeTrue();
+		key.Length.Should().Be(AesGcmSecretProtector.KeySizeBytes);
+
+		// Second call must reuse the file, not mint a different key.
+		var store2 = IdentityTokenStorageWiring.TryCreateLastResortPortableMasterKeyStore(config);
+		store2.TryGet(AesGcmSecretProtector.DefaultMasterKeyName, out var key2).Should().BeTrue();
+		CollectionAssert.AreEqual(key, key2);
+
+		config.TokenStorageMethod = TokenStorageMethod.Encrypted;
+		IdentityTokenStorageWiring.ConfigureFrom(config);
+		Assert.IsNotNull(IdentityTokenStorage.Protector);
+		var payload = IdentityTokenStorage.Protector!.Protect("last-resort-secret", "aad");
+		IdentityTokenStorage.Protector.Unprotect(payload, "aad").Should().Be("last-resort-secret");
+	}
+
+	[TestMethod]
 	public void MasterKeyExport_writes_key_file_when_os_store_has_key()
 	{
 		if (!IdentityTokenStorageWiring.IsOsSecretStoreAvailable(out var reason))

--- a/docs/installation/docker.md
+++ b/docs/installation/docker.md
@@ -25,6 +25,8 @@ The docker image is provided as-is. We hope it can be useful to you but it is no
 >
 > **Other fixes:** On Windows, **Settings -> Important**, uncheck **Store authentication tokens encrypted**, convert existing tokens to plaintext when prompted, then re-copy `AccountsSettings.json`. Or skip copying Windows accounts and use `login-external` / `import-account` inside the container (see below).
 >
+> **Last resort (not recommended):** If encryption stays on and you never supply a key, Libation may auto-create `libation-master.key` under the Libation files directory and warn loudly (console, log, and `libation-master.key.NOTICE.txt`). That key only unlocks tokens encrypted with it afterward - it will not decrypt tokens from another machine. Prefer the steps above. When creating accounts in Docker, use `--libationFiles /config` so any key file persists on the host mount.
+>
 > Details: [FAQ](/docs/frequently-asked-questions#docker-finds-no-new-books-failed-to-decrypt-existingaccesstoken) · [Troubleshooting](/docs/advanced/troubleshoot#failed-to-decrypt-existingaccesstoken-docker-finds-no-new-books)
 
 > [!WARNING] NTFS filesystem limitations


### PR DESCRIPTION
When token encryption is on but there is no OS secret store and no user-supplied master key, mint/load `{LibationFiles}/libation-master.key` via a segregated last-resort helper (not the preferred Docker path).

Warning users is difficult on docker, but we'll try like hell. On auto-create: Serilog Warning, stderr/console, and `libation-master.key.NOTICE.txt` explaining Plaintext or supplying an exported key.