### PR TITLE
Add AGENTS.md with Cursor Cloud dev environment instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,50 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+Libation is a cross-platform .NET desktop/CLI app for downloading and de-DRMing Audible
+audiobooks. The core product is the Avalonia GUI (`LibationAvalonia`, assembly name `Libation`)
+plus a headless CLI (`LibationCli`) that shares the same config and SQLite library database.
+
+### Toolchain / environment
+- Requires the **.NET 10 SDK** pinned by `global.json` (`10.0.101`). It is preinstalled at
+  `~/.dotnet`; `~/.bashrc` exports `DOTNET_ROOT` and adds `~/.dotnet` (and `~/.dotnet/tools`) to
+  `PATH`. New non-login shells may not have it — use `dotnet` after a login shell, or call
+  `~/.dotnet/dotnet` directly.
+- The startup update script runs `dotnet tool restore` (restores `dotnet-ef`) and
+  `dotnet restore Source/Libation.slnx`. No other setup is needed.
+- The solution file is the new XML format: `Source/Libation.slnx` (there is no classic `.sln`).
+
+### Building — Linux only builds the cross-platform projects
+- Do **not** build the whole solution on Linux. Several projects are Windows/OS-specific and will
+  not build here: `LibationWinForms`, `HangoverWinForms` (target `net10.0-windows7.0`) and the
+  `LoadByOS/{Windows,MacOS}ConfigApp` helpers.
+- Build the runnable cross-platform apps directly:
+  - `dotnet build Source/LibationAvalonia/LibationAvalonia.csproj`
+  - `dotnet build Source/LibationCli/LibationCli.csproj`
+- There is no dedicated lint step; the repo's `.editorconfig` is minimal and CI
+  (`.github/workflows/validate.yml`) only builds and tests. The compiler/analyzer warnings from a
+  normal build serve as the static-analysis check. (A known transitive `NU1903` SQLite
+  vulnerability warning is expected and harmless.)
+
+### Testing
+- Test projects live under `Source/_Tests/` and use MSTest on **Microsoft.Testing.Platform**
+  (configured via `global.json` `test.runner`). Because of this runner, `dotnet test` requires
+  `--project` for a single project (a positional project path is rejected):
+  `dotnet test --project Source/_Tests/FileManager.Tests/FileManager.Tests.csproj`
+- CI runs `dotnet test` from `Source/`, which builds the entire solution first and is slow;
+  prefer running the seven test projects individually on Linux.
+- `AudibleUtilities.Tests` contains a network-dependent test that is usually fast but can
+  intermittently take ~2 minutes (a socket timeout when there is no network). It still passes; do
+  not assume the suite is hung if only that project is slow.
+
+### Running the apps
+- GUI: a display is available on `DISPLAY=:1`. Run with
+  `cd Source/LibationAvalonia && dotnet run`. First launch shows a Welcome/walkthrough and creates
+  config under `~/.local/share/Libation/` (`Settings.json`, `AccountsSettings.json`,
+  `LibationContext.db`).
+- CLI: `cd Source/LibationCli && dotnet run -- <command>` (e.g. `version`, `get-setting`,
+  `list-accounts`, `scan`, `liberate`). The CLI reads the same `~/.local/share/Libation/` config
+  and database as the GUI.
+- Actually scanning/downloading a library requires signing into a real Audible account, so full
+  end-to-end liberation cannot be exercised without credentials.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,15 +34,22 @@ plus a headless CLI (`LibationCli`) that shares the same config and SQLite libra
   `dotnet test --project Source/_Tests/FileManager.Tests/FileManager.Tests.csproj`
 - CI runs `dotnet test` from `Source/`, which builds the entire solution first and is slow;
   prefer running the seven test projects individually on Linux.
-- `AudibleUtilities.Tests` contains a network-dependent test that is usually fast but can
-  intermittently take ~2 minutes (a socket timeout when there is no network). It still passes; do
-  not assume the suite is hung if only that project is slow.
+- **GNOME Keyring / OS secret store:** Libation's default `TokenStorageMethod` is `Encrypted`,
+  and the AES-GCM master key is stored via the OS secret store (`OsSecretStore` /
+  `IdentityTokenStorageWiring`). On Linux that is GNOME Keyring (Secret Service). Some tests in
+  `AudibleUtilities.Tests` exercise the real OS store when it is available. If the login keyring
+  has never been created/unlocked, those calls can **block for minutes** waiting on a desktop
+  password prompt (looks like a hung test suite). A human must set a keyring password once via
+  the Desktop pane when the prompt appears; after that, subsequent runs are fast. The keyring
+  lives at `~/.local/share/keyrings/`. Do not "kill and retry" a stalled `AudibleUtilities.Tests`
+  run until you have checked for a keyring dialog on `DISPLAY=:1`.
 
 ### Running the apps
 - GUI: a display is available on `DISPLAY=:1`. Run with
   `cd Source/LibationAvalonia && dotnet run`. First launch shows a Welcome/walkthrough and creates
   config under `~/.local/share/Libation/` (`Settings.json`, `AccountsSettings.json`,
-  `LibationContext.db`).
+  `LibationContext.db`). The same keyring note above applies when the GUI/CLI first encrypts
+  account tokens.
 - CLI: `cd Source/LibationCli && dotnet run -- <command>` (e.g. `version`, `get-setting`,
   `list-accounts`, `scan`, `liberate`). The CLI reads the same `~/.local/share/Libation/` config
   and database as the GUI.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up and documents the development environment for Libation so Cloud Agents can build, test, and run the app. Adds an `AGENTS.md` with a `## Cursor Cloud specific instructions` section capturing durable, non-obvious setup/run notes.

No application code is modified — this only adds documentation. Dependency installation (`.NET 10 SDK`) is handled by the VM snapshot + startup update script (`dotnet tool restore` + `dotnet restore Source/Libation.slnx`).

## Verification

| Area | Command | Result |
|------|---------|--------|
| Build (GUI) | `dotnet build Source/LibationAvalonia/LibationAvalonia.csproj` | 0 errors |
| Build (CLI) | `dotnet build Source/LibationCli/LibationCli.csproj` | 0 errors |
| Tests | `dotnet test --project Source/_Tests/<each>` | 997 passed, 0 failed (7 projects) |
| Run (GUI/CLI) | Avalonia first-run + CLI against shared DB | Working |

### Notes captured in AGENTS.md
- On Linux, only the cross-platform projects build (`LibationAvalonia`, `LibationCli`); WinForms/OS-specific projects won't build.
- Microsoft.Testing.Platform requires `dotnet test --project <csproj>` for single projects.
- **GNOME Keyring:** Libation's default encrypted token storage uses the OS secret store. If the login keyring has never been created/unlocked, `AudibleUtilities.Tests` (and first token-encrypting GUI/CLI use) can block for minutes on a desktop password prompt — looks like a hung suite. A human must set the keyring password once via the Desktop pane; afterward runs are fast. (Initially misdiagnosed as a network timeout; corrected after the keyring was set up mid-session.)
- GUI runs on `DISPLAY=:1`; GUI and CLI share config/DB at `~/.local/share/Libation/`.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-dabfe3f0-a6a4-477c-afef-e1b37a50f0df?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-dabfe3f0-a6a4-477c-afef-e1b37a50f0df&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

