### PR TITLE
Add Cursor rule: prefer ASCII-centric prose

### DIFF
--- a/.cursor/rules/prefer-ascii.mdc
+++ b/.cursor/rules/prefer-ascii.mdc
@@ -1,0 +1,16 @@
+---
+description: Prefer ASCII-centric characters in all written output
+alwaysApply: true
+---
+
+# Prefer ASCII-centric characters
+
+In all written output (chat replies, GitHub comments, commit messages, docs, PR bodies, and similar prose):
+
+- Prefer `->` instead of arrow glyphs (no `→`, `⇒`, `←`, etc.)
+- Prefer `...` instead of single-character ellipses (no `…`)
+- Prefer straight single and double quotes (`'` and `"`) instead of curly/smart quotes
+- Prefer `-` instead of long dashes (no `–`, `—`)
+- No emoji or similar decorative characters/glyphs
+
+Use plain ASCII unless a non-ASCII character is required for correctness (e.g. a code identifier, file path, or user-facing string that already contains it).


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds an always-apply Cursor rule (`.cursor/rules/prefer-ascii.mdc`) so agents prefer ASCII-centric characters in written output:

- `->` instead of arrow glyphs
- `...` instead of single-character ellipses
- straight `'` / `"` quotes
- `-` instead of long dashes
- no emoji or similar glyphs

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-dabfe3f0-a6a4-477c-afef-e1b37a50f0df?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-dabfe3f0-a6a4-477c-afef-e1b37a50f0df&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

