### PR TITLE
bugfix #1925: stop library scans from silently dropping titles

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,14 +35,19 @@ plus a headless CLI (`LibationCli`) that shares the same config and SQLite libra
 - CI runs `dotnet test` from `Source/`, which builds the entire solution first and is slow;
   prefer running the seven test projects individually on Linux.
 - **GNOME Keyring / OS secret store:** Libation's default `TokenStorageMethod` is `Encrypted`,
-  and the AES-GCM master key is stored via the OS secret store (`OsSecretStore` /
-  `IdentityTokenStorageWiring`). On Linux that is GNOME Keyring (Secret Service). Some tests in
-  `AudibleUtilities.Tests` exercise the real OS store when it is available. If the login keyring
-  has never been created/unlocked, those calls can **block for minutes** waiting on a desktop
-  password prompt (looks like a hung test suite). A human must set a keyring password once via
-  the Desktop pane when the prompt appears; after that, subsequent runs are fast. The keyring
-  lives at `~/.local/share/keyrings/`. Do not "kill and retry" a stalled `AudibleUtilities.Tests`
-  run until you have checked for a keyring dialog on `DISPLAY=:1`.
+ and the AES-GCM master key is stored via the OS secret store (`OsSecretStore` /
+ `IdentityTokenStorageWiring`). On Linux that is GNOME Keyring (Secret Service), which **blocks
+ indefinitely** here: the login keyring is locked with a password nobody has, and the D-Bus call
+ hangs even with no prompt on screen. Probing availability does not help - the probe is the
+ blocking call.
+ Every test project should finish in about a second. If one runs for minutes, assume something
+ reached the OS secret store; do not sit through it and do not re-run it hoping for a different
+ result. `ResolveSecretStore` short-circuits on `LIBATION_MASTER_KEY_FILE`, an existing
+ `libation-master.key` under the Libation files dir, or `LIBATION_MASTER_KEY`, so setting one of
+ those keeps a test off the OS store entirely.
+ The tests that deliberately exercise the real store are opt-in via
+ `LIBATION_TEST_OS_SECRET_STORE=1` and are skipped otherwise. Leave them skipped on Linux; they
+ will hang if enabled. Always run tests under `timeout` so a regression here cannot stall a session.
 
 ### Running the apps
 - GUI: a display is available on `DISPLAY=:1`. Run with

--- a/Source/AppScaffolding/LibationScaffolding.cs
+++ b/Source/AppScaffolding/LibationScaffolding.cs
@@ -269,6 +269,10 @@ public static class LibationScaffolding
 			LogLevel_Fatal_Enabled = Log.Logger.IsFatalEnabled(),
 
 			config.AutoScan,
+			// These silently exclude titles from every scan, so a log without them can't explain a missing book
+			config.ImportEpisodes,
+			config.ImportPlusTitles,
+			config.DownloadEpisodes,
 			config.BetaOptIn,
 			config.UseCoverAsFolderIcon,
 			config.LibationFiles,

--- a/Source/AudibleUtilities/ApiExtended.cs
+++ b/Source/AudibleUtilities/ApiExtended.cs
@@ -143,8 +143,10 @@ public class ApiExtended
 		var importEpisodes = Configuration.Instance.ImportEpisodes;
 		var importPlusTitles = Configuration.Instance.ImportPlusTitles;
 
-		List<Item> items = new();
-		int libraryItemCount = 0, episodeItemsExcluded = 0, plusTitlesExcluded = 0;
+		var items = new List<Item>();
+		var libraryItemCount = 0;
+		var episodeItemsExcluded = 0;
+		var plusTitlesExcluded = 0;
 		var sw = Stopwatch.StartNew();
 		var totalTime = TimeSpan.Zero;
 		using var semaphore = new SemaphoreSlim(MaxConcurrency);
@@ -378,7 +380,7 @@ public class ApiExtended
 		var items = await fetch(asins);
 		var missing = GetMissingAsins(asins, items);
 
-		for (int attempt = 1; attempt <= maxRetries && missing.Count > 0; attempt++)
+		for (var attempt = 1; attempt <= maxRetries && missing.Count > 0; attempt++)
 		{
 			onRetry?.Invoke(attempt);
 

--- a/Source/AudibleUtilities/ApiExtended.cs
+++ b/Source/AudibleUtilities/ApiExtended.cs
@@ -215,18 +215,9 @@ public class ApiExtended
 		Serilog.Log.Logger.Debug("Begin indexing series episodes");
 		items.AddRange(allEps);
 
-		//Set the Item.Series info for episodes and parents.
-		foreach (var parent in items.Where(i => i.IsSeriesParent))
-		{
-			var children = items.Where(i => i.IsEpisodes && i.Relationships?.Any(r => r.Asin == parent.Asin) is true);
-			SetSeries(parent, children);
-		}
-
-		//An episode whose series parent never made it into this scan can't be linked to a series, so it
-		//gets dropped. Name the casualties: without them a title silently vanishes from the library and
+		//Name the casualties: an unlinked episode silently vanishes from the library, and without this
 		//there is nothing in the log to explain why.
-		var orphans = items.Where(isOrphan).Select(describe).Distinct().ToList();
-		items.RemoveAll(isOrphan);
+		var orphans = LinkEpisodesToSeries(items).Select(describe).Distinct().ToList();
 		if (orphans.Count > 0)
 			Serilog.Log.Logger.Warning(
 				"{orphansRemoved} podcast episodes were not imported because their series parent was missing from this scan. {@DebugInfo}",
@@ -256,8 +247,31 @@ public class ApiExtended
 
 		return items;
 
-		static bool isOrphan(Item item) => (item.IsEpisodes || item.IsSeriesParent) && item.Series is null;
 		static string describe(Item item) => $"[{item.Asin}] {item.Title}";
+	}
+
+	/// <summary>
+	/// Set <see cref="Item.Series"/> on every series parent in <paramref name="items"/> and on the episodes
+	/// belonging to it, then drop the episodes and parents left unlinked. An episode is left unlinked when
+	/// its parent is not among <paramref name="items"/>, which happens when Audible omits the parent from a
+	/// catalog response or when the parent is a container Libation does not treat as a series (e.g. a season).
+	/// </summary>
+	/// <returns>The unlinked items removed from <paramref name="items"/>.</returns>
+	public static List<Item> LinkEpisodesToSeries(List<Item> items)
+	{
+		ArgumentValidator.EnsureNotNull(items, nameof(items));
+
+		foreach (var parent in items.Where(i => i.IsSeriesParent))
+		{
+			var children = items.Where(i => i.IsEpisodes && i.Relationships?.Any(r => r.Asin == parent.Asin) is true);
+			SetSeries(parent, children);
+		}
+
+		var unlinked = items.Where(isUnlinked).ToList();
+		items.RemoveAll(isUnlinked);
+		return unlinked;
+
+		static bool isUnlinked(Item item) => (item.IsEpisodes || item.IsSeriesParent) && item.Series is null;
 	}
 
 	#region episodes and podcasts

--- a/Source/AudibleUtilities/ApiExtended.cs
+++ b/Source/AudibleUtilities/ApiExtended.cs
@@ -23,6 +23,10 @@ public class ApiExtended
 
 	private const int MaxConcurrency = 10;
 	private const int BatchSize = 50;
+	/// <summary>Extra attempts to re-request catalog products that Audible omitted from an otherwise successful response.</summary>
+	private const int MissingAsinRetries = 2;
+	/// <summary>Upper bound on how many dropped titles a single log entry will name.</summary>
+	private const int MaxLoggedTitles = 50;
 
 	private ApiExtended(Api api) => Api = api;
 
@@ -135,7 +139,12 @@ public class ApiExtended
 	{
 		Serilog.Log.Logger.Debug("Beginning library scan.");
 
+		//Read the import filters once so a settings change mid-scan can't produce a half-filtered library.
+		var importEpisodes = Configuration.Instance.ImportEpisodes;
+		var importPlusTitles = Configuration.Instance.ImportPlusTitles;
+
 		List<Item> items = new();
+		int libraryItemCount = 0, episodeItemsExcluded = 0, plusTitlesExcluded = 0;
 		var sw = Stopwatch.StartNew();
 		var totalTime = TimeSpan.Zero;
 		using var semaphore = new SemaphoreSlim(MaxConcurrency);
@@ -147,7 +156,9 @@ public class ApiExtended
 		//Get relationship asins from episode-type items and write them to episodeChannel where they will be batched and queried.
 		await foreach (var itemsBatch in Api.GetLibraryItemsPagesAsync(libraryOptions, BatchSize, semaphore))
 		{
-			if (Configuration.Instance.ImportEpisodes)
+			libraryItemCount += itemsBatch.Length;
+
+			if (importEpisodes)
 			{
 				var episodes = itemsBatch.Where(i => i.IsEpisodes).ToList();
 				var series = itemsBatch.Where(i => i.IsSeriesParent).ToList();
@@ -170,11 +181,18 @@ public class ApiExtended
 				items.AddRange(episodes);
 				items.AddRange(series);
 			}
+			else
+				episodeItemsExcluded += itemsBatch.Count(i => i.IsSeriesParent || i.IsEpisodes);
 
-			var booksInBatch
-				= itemsBatch
-				.Where(i => !i.IsSeriesParent && !i.IsEpisodes)
-				.Where(i => i.IsAyce is not true || Configuration.Instance.ImportPlusTitles);
+			var booksInBatch = itemsBatch.Where(i => !i.IsSeriesParent && !i.IsEpisodes).ToList();
+
+			if (!importPlusTitles)
+			{
+				var ownedInBatch = booksInBatch.Where(i => i.IsAyce is not true).ToList();
+				plusTitlesExcluded += booksInBatch.Count - ownedInBatch.Count;
+				booksInBatch = ownedInBatch;
+			}
+
 			items.AddRange(booksInBatch);
 		}
 
@@ -204,14 +222,32 @@ public class ApiExtended
 			SetSeries(parent, children);
 		}
 
-		int orphansRemoved = items.RemoveAll(i => (i.IsEpisodes || i.IsSeriesParent) && i.Series is null);
-		if (orphansRemoved > 0)
-			Serilog.Log.Debug("{orphansRemoved} podcast orphans not imported", orphansRemoved);
+		//An episode whose series parent never made it into this scan can't be linked to a series, so it
+		//gets dropped. Name the casualties: without them a title silently vanishes from the library and
+		//there is nothing in the log to explain why.
+		var orphans = items.Where(isOrphan).Select(describe).Distinct().ToList();
+		items.RemoveAll(isOrphan);
+		if (orphans.Count > 0)
+			Serilog.Log.Logger.Warning(
+				"{orphansRemoved} podcast episodes were not imported because their series parent was missing from this scan. {@DebugInfo}",
+				orphans.Count,
+				new { Orphans = orphans.Take(MaxLoggedTitles).ToList(), Truncated = orphans.Count > MaxLoggedTitles });
 
 		sw.Stop();
 		totalTime += sw.Elapsed;
 		Serilog.Log.Logger.Information("Completed indexing series episodes after {elappsed_ms} ms.", sw.ElapsedMilliseconds);
 		Serilog.Log.Logger.Information($"Completed library scan in {totalTime.TotalMilliseconds:F0} ms.");
+		Serilog.Log.Logger.Information("Library scan tally. {@DebugInfo}", new
+		{
+			LibraryItems = libraryItemCount,
+			EpisodesFetched = allEps.Count,
+			OrphanedEpisodesDropped = orphans.Count,
+			ImportEpisodes = importEpisodes,
+			EpisodeItemsExcluded = episodeItemsExcluded,
+			ImportPlusTitles = importPlusTitles,
+			PlusTitlesExcluded = plusTitlesExcluded,
+			ItemsToImport = items.Count
+		});
 
 		Array.ForEach(ISanitizer.GetAllSanitizers(), s => s.Sanitize(items));
 		var allExceptions = IValidator.GetAllValidators().SelectMany(v => v.Validate(items)).ToList();
@@ -219,6 +255,9 @@ public class ApiExtended
 			throw new ImportValidationException(items, allExceptions);
 
 		return items;
+
+		static bool isOrphan(Item item) => (item.IsEpisodes || item.IsSeriesParent) && item.Series is null;
+		static string describe(Item item) => $"[{item.Asin}] {item.Title}";
 	}
 
 	#region episodes and podcasts
@@ -260,14 +299,26 @@ public class ApiExtended
 		try
 		{
 			var sw = Stopwatch.StartNew();
-			var items = await Api.GetCatalogProductsAsync(asins, CatalogOptions.ResponseGroupOptions.Rating | CatalogOptions.ResponseGroupOptions.Media
-				| CatalogOptions.ResponseGroupOptions.Relationships | CatalogOptions.ResponseGroupOptions.ProductDesc
-				| CatalogOptions.ResponseGroupOptions.Contributors | CatalogOptions.ResponseGroupOptions.ProvidedReview
-				| CatalogOptions.ResponseGroupOptions.ProductPlans | CatalogOptions.ResponseGroupOptions.Series
-				| CatalogOptions.ResponseGroupOptions.CategoryLadders | CatalogOptions.ResponseGroupOptions.ProductExtendedAttrs);
+
+			//Audible sometimes omits products from a response that is otherwise successful. Those episodes
+			//would silently disappear from the library, so re-request them before accepting the loss.
+			var (items, missing) = await FetchRetryingMissingAsync(
+				asins,
+				getCatalogProductsAsync,
+				MissingAsinRetries,
+				attempt => Serilog.Log.Logger.Debug($"Batch {batchNum} Retry {attempt}: Re-fetching asins Audible did not return"));
+
 			sw.Stop();
 
 			Serilog.Log.Logger.Debug($"Batch {batchNum} End: Retrieved {items.Count} items in {sw.ElapsedMilliseconds} ms");
+
+			if (missing.Count > 0)
+				Serilog.Log.Logger.Warning(
+					"Audible did not return {missingCount} of the {requestedCount} catalog products requested in batch {batchNum}. Those titles are missing from this scan. {@DebugInfo}",
+					missing.Count,
+					asins.Count,
+					batchNum,
+					new { MissingAsins = missing });
 
 			return items;
 		}
@@ -277,6 +328,52 @@ public class ApiExtended
 			throw;
 		}
 		finally { semaphore.Release(); }
+	}
+
+	private Task<List<Item>> getCatalogProductsAsync(List<string> asins)
+		=> Api.GetCatalogProductsAsync(asins, CatalogOptions.ResponseGroupOptions.Rating | CatalogOptions.ResponseGroupOptions.Media
+			| CatalogOptions.ResponseGroupOptions.Relationships | CatalogOptions.ResponseGroupOptions.ProductDesc
+			| CatalogOptions.ResponseGroupOptions.Contributors | CatalogOptions.ResponseGroupOptions.ProvidedReview
+			| CatalogOptions.ResponseGroupOptions.ProductPlans | CatalogOptions.ResponseGroupOptions.Series
+			| CatalogOptions.ResponseGroupOptions.CategoryLadders | CatalogOptions.ResponseGroupOptions.ProductExtendedAttrs);
+
+	/// <summary>Requested asins for which <paramref name="received"/> holds no matching <see cref="Item"/>.</summary>
+	public static List<string> GetMissingAsins(IEnumerable<string> requested, IEnumerable<Item> received)
+	{
+		ArgumentValidator.EnsureNotNull(requested, nameof(requested));
+		ArgumentValidator.EnsureNotNull(received, nameof(received));
+
+		var found = received.Select(i => i.Asin).OfType<string>().ToHashSet(StringComparer.OrdinalIgnoreCase);
+		return requested.Where(a => !found.Contains(a)).ToList();
+	}
+
+	/// <summary>
+	/// Fetch <paramref name="asins"/>, re-requesting any that <paramref name="fetch"/> fails to return.
+	/// Audible's catalog endpoint can answer 200 while quietly omitting products.
+	/// </summary>
+	/// <returns>Everything that was returned, plus the asins still unaccounted for after the last attempt.</returns>
+	public static async Task<(List<Item> Items, List<string> Missing)> FetchRetryingMissingAsync(
+		List<string> asins,
+		Func<List<string>, Task<List<Item>>> fetch,
+		int maxRetries,
+		Action<int>? onRetry = null)
+	{
+		ArgumentValidator.EnsureNotNull(asins, nameof(asins));
+		ArgumentValidator.EnsureNotNull(fetch, nameof(fetch));
+
+		var items = await fetch(asins);
+		var missing = GetMissingAsins(asins, items);
+
+		for (int attempt = 1; attempt <= maxRetries && missing.Count > 0; attempt++)
+		{
+			onRetry?.Invoke(attempt);
+
+			var retriedItems = await fetch(missing);
+			items.AddRange(retriedItems);
+			missing = GetMissingAsins(missing, retriedItems);
+		}
+
+		return (items, missing);
 	}
 
 	public static void SetSeries(Item parent, IEnumerable<Item> children)

--- a/Source/DataLayer/QueryObjects/LibraryBookQueries.cs
+++ b/Source/DataLayer/QueryObjects/LibraryBookQueries.cs
@@ -108,6 +108,16 @@ public static class LibraryBookQueries
 					.ParentedEpisodes()
 					.Select(ge => ge.Book.AudibleProductId), ge => ge.Book.AudibleProductId);
 
+		/// <summary>
+		/// Books displayed as top-level rows: ordinary products plus episodes whose series parent
+		/// is not in the database. Showing orphaned episodes here keeps a successfully imported
+		/// title discoverable instead of silently hiding it from both grids.
+		/// </summary>
+		public IEnumerable<LibraryBook> StandaloneBooks()
+			=> libraryBooks
+				.Where(lb => lb.Book.IsProduct())
+				.Concat(libraryBooks.FindOrphanedEpisodes());
+
 		public IEnumerable<LibraryBook> FindChildren(LibraryBook parent)
 			=> libraryBooks.Where(lb => lb.Book.IsEpisodeChild() && lb.HasSeriesId(parent.Book.AudibleProductId));
 

--- a/Source/LibationAvalonia/ViewModels/ProductsDisplayViewModel.cs
+++ b/Source/LibationAvalonia/ViewModels/ProductsDisplayViewModel.cs
@@ -162,6 +162,7 @@ public class ProductsDisplayViewModel : ViewModelBase
 		var allEntries = SOURCE.BookEntries().ToDictionarySafe(b => b.AudibleProductId);
 		var seriesEntries = SOURCE.SeriesEntries().ToList();
 		var parentedEpisodes = dbBooks.ParentedEpisodes().ToHashSet();
+		var orphanedEpisodes = dbBooks.FindOrphanedEpisodes().ToHashSet();
 
 		await Dispatcher.UIThread.InvokeAsync(() =>
 		{
@@ -169,11 +170,31 @@ public class ProductsDisplayViewModel : ViewModelBase
 			{
 				var existingEntry = allEntries.TryGetValue(libraryBook.Book.AudibleProductId, out var e) ? e : null;
 
-				if (libraryBook.Book.IsProduct())
+				if (libraryBook.Book.IsProduct() || orphanedEpisodes.Contains(libraryBook))
+				{
+					// An episode can become orphaned when its parent is removed. Move it out from under
+					// the old parent and keep it visible as a standalone row.
+					if (existingEntry?.Parent is not null)
+					{
+						existingEntry.Parent.RemoveChild(existingEntry);
+						RemoveBooks([existingEntry], []);
+						existingEntry = null;
+					}
+
 					UpsertBook(libraryBook, existingEntry);
+				}
 				else if (parentedEpisodes.Contains(libraryBook))
-					//Only try to add or update is this LibraryBook is a know child of a parent
+				{
+					// If a formerly orphaned episode now has a parent, remove its standalone row
+					// before recreating it beneath that parent.
+					if (existingEntry is { Parent: null })
+					{
+						RemoveBooks([existingEntry], []);
+						existingEntry = null;
+					}
+
 					UpsertEpisode(libraryBook, existingEntry, seriesEntries, dbBooks);
+				}
 			}
 		});
 

--- a/Source/LibationUiBase/GridView/LibraryBookEntry.cs
+++ b/Source/LibationUiBase/GridView/LibraryBookEntry.cs
@@ -32,11 +32,14 @@ public class LibraryBookEntry : GridEntry
 	}
 
 	/// <summary>
-	/// Creates <see cref="LibraryBookEntry{TStatus}"/> for all non-episode books in an enumeration of <see cref="LibraryBook"/>.
+	/// Creates <see cref="LibraryBookEntry{TStatus}"/> for ordinary books and episodes whose series parent is missing.
 	/// </summary>
 	/// <remarks>Can be called from any thread, but requires the calling thread's <see cref="System.Threading.SynchronizationContext.Current"/> to be valid.</remarks>
 	public static async Task<List<GridEntry>> GetAllProductsAsync(IEnumerable<LibraryBook> libraryBooks)
-		=> await GetAllProductsAsync(libraryBooks, lb => lb.Book.IsProduct(), lb => new LibraryBookEntry(lb) as GridEntry);
+		=> await GetAllProductsAsync(
+			libraryBooks.StandaloneBooks(),
+			_ => true,
+			lb => new LibraryBookEntry(lb) as GridEntry);
 
 	protected override string? GetBookTags()
 		=> Book is null ? null : string.Join("\r\n", Book.UserDefinedItem.TagsEnumerated);

--- a/Source/LibationWinForms/GridView/ProductsGrid.cs
+++ b/Source/LibationWinForms/GridView/ProductsGrid.cs
@@ -350,6 +350,7 @@ public partial class ProductsGrid : UserControl
 		var allEntries = bindingList.AllItems().BookEntries().ToDictionarySafe(b => b.AudibleProductId);
 		var seriesEntries = bindingList.AllItems().SeriesEntries().ToList();
 		var parentedEpisodes = dbBooks.ParentedEpisodes().ToHashSet();
+		var orphanedEpisodes = dbBooks.FindOrphanedEpisodes().ToHashSet();
 
 		//Get the UI thread's synchronization context and set it on the current thread to ensure
 		//it's available for creation of new IGridEntry items during upsert
@@ -361,14 +362,30 @@ public partial class ProductsGrid : UserControl
 		{
 			var existingEntry = allEntries.TryGetValue(libraryBook.Book.AudibleProductId, out var e) ? e : null;
 
-			if (libraryBook.Book.IsProduct())
+			if (libraryBook.Book.IsProduct() || orphanedEpisodes.Contains(libraryBook))
 			{
+				// An episode can become orphaned when its parent is removed. Move it out from under
+				// the old parent and keep it visible as a standalone row.
+				if (existingEntry?.Parent is not null)
+				{
+					existingEntry.Parent.RemoveChild(existingEntry);
+					bindingList.Remove(existingEntry);
+					existingEntry = null;
+				}
+
 				AddOrUpdateBook(libraryBook, existingEntry);
 				continue;
 			}
 			if (parentedEpisodes.Contains(libraryBook))
 			{
-				//Only try to add or update is this LibraryBook is a know child of a parent
+				// If a formerly orphaned episode now has a parent, remove its standalone row
+				// before recreating it beneath that parent.
+				if (existingEntry is { Parent: null })
+				{
+					bindingList.Remove(existingEntry);
+					existingEntry = null;
+				}
+
 				AddOrUpdateEpisode(libraryBook, existingEntry, seriesEntries, dbBooks);
 			}
 		}

--- a/Source/_Tests/AudibleUtilities.Tests/ApiExtendedCatalogFetchTests.cs
+++ b/Source/_Tests/AudibleUtilities.Tests/ApiExtendedCatalogFetchTests.cs
@@ -1,0 +1,158 @@
+using AudibleApi.Common;
+using AudibleUtilities;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace ApiExtendedCatalogFetchTests;
+
+/// <summary>
+/// Audible's catalog endpoint can answer 200 while quietly omitting products. When that happened
+/// the affected podcast episodes vanished from the library with nothing in the log (issue #1925).
+/// </summary>
+[TestClass]
+public class GetMissingAsins
+{
+	private static Item item(string asin) => new() { Asin = asin };
+
+	[TestMethod]
+	public void nothing_missing_when_all_returned()
+	{
+		var missing = ApiExtended.GetMissingAsins(["A1", "A2", "A3"], [item("A1"), item("A2"), item("A3")]);
+
+		Assert.AreEqual(0, missing.Count);
+	}
+
+	[TestMethod]
+	public void reports_asins_the_response_omitted()
+	{
+		var missing = ApiExtended.GetMissingAsins(["A1", "A2", "A3"], [item("A1"), item("A3")]);
+
+		CollectionAssert.AreEqual(new[] { "A2" }, missing);
+	}
+
+	[TestMethod]
+	public void reports_every_asin_when_response_is_empty()
+	{
+		var missing = ApiExtended.GetMissingAsins(["A1", "A2"], []);
+
+		CollectionAssert.AreEqual(new[] { "A1", "A2" }, missing);
+	}
+
+	[TestMethod]
+	public void asin_comparison_ignores_case()
+	{
+		var missing = ApiExtended.GetMissingAsins(["a1"], [item("A1")]);
+
+		Assert.AreEqual(0, missing.Count);
+	}
+
+	[TestMethod]
+	public void items_without_an_asin_do_not_satisfy_a_request()
+	{
+		var missing = ApiExtended.GetMissingAsins(["A1"], [new Item()]);
+
+		CollectionAssert.AreEqual(new[] { "A1" }, missing);
+	}
+
+	[TestMethod]
+	public void extra_unrequested_items_are_ignored()
+	{
+		var missing = ApiExtended.GetMissingAsins(["A1"], [item("A1"), item("A9")]);
+
+		Assert.AreEqual(0, missing.Count);
+	}
+}
+
+[TestClass]
+public class FetchRetryingMissingAsync
+{
+	private static Item item(string asin) => new() { Asin = asin };
+
+	/// <summary>Returns the requested asins minus <paramref name="omit"/>, recording each request.</summary>
+	private static Func<List<string>, Task<List<Item>>> fetcher(List<List<string>> requests, params string[] omit)
+		=> asins =>
+		{
+			requests.Add([.. asins]);
+			return Task.FromResult(asins.Where(a => !omit.Contains(a)).Select(item).ToList());
+		};
+
+	[TestMethod]
+	public async Task complete_response_is_not_retried()
+	{
+		var requests = new List<List<string>>();
+
+		var (items, missing) = await ApiExtended.FetchRetryingMissingAsync(["A1", "A2"], fetcher(requests), maxRetries: 2);
+
+		Assert.AreEqual(1, requests.Count);
+		Assert.AreEqual(2, items.Count);
+		Assert.AreEqual(0, missing.Count);
+	}
+
+	[TestMethod]
+	public async Task omitted_asin_is_re_requested_on_its_own()
+	{
+		var requests = new List<List<string>>();
+		int call = 0;
+
+		// Audible drops A2 from the first response, then returns it when asked again.
+		Task<List<Item>> fetch(List<string> asins)
+		{
+			requests.Add([.. asins]);
+			var omit = call++ == 0 ? "A2" : null;
+			return Task.FromResult(asins.Where(a => a != omit).Select(item).ToList());
+		}
+
+		var (items, missing) = await ApiExtended.FetchRetryingMissingAsync(["A1", "A2", "A3"], fetch, maxRetries: 2);
+
+		Assert.AreEqual(2, requests.Count);
+		CollectionAssert.AreEqual(new[] { "A2" }, requests[1]);
+		CollectionAssert.AreEquivalent(new[] { "A1", "A2", "A3" }, items.Select(i => i.Asin).ToList());
+		Assert.AreEqual(0, missing.Count);
+	}
+
+	[TestMethod]
+	public async Task persistently_omitted_asin_is_reported_after_the_retries_run_out()
+	{
+		var requests = new List<List<string>>();
+
+		var (items, missing) = await ApiExtended.FetchRetryingMissingAsync(["A1", "A2"], fetcher(requests, "A2"), maxRetries: 2);
+
+		Assert.AreEqual(3, requests.Count);
+		CollectionAssert.AreEqual(new[] { "A1" }, items.Select(i => i.Asin).ToList());
+		CollectionAssert.AreEqual(new[] { "A2" }, missing);
+	}
+
+	[TestMethod]
+	public async Task retries_can_be_disabled()
+	{
+		var requests = new List<List<string>>();
+
+		var (_, missing) = await ApiExtended.FetchRetryingMissingAsync(["A1", "A2"], fetcher(requests, "A2"), maxRetries: 0);
+
+		Assert.AreEqual(1, requests.Count);
+		CollectionAssert.AreEqual(new[] { "A2" }, missing);
+	}
+
+	[TestMethod]
+	public async Task onRetry_reports_each_attempt_number()
+	{
+		var attempts = new List<int>();
+
+		await ApiExtended.FetchRetryingMissingAsync(["A1"], fetcher([], "A1"), maxRetries: 2, attempts.Add);
+
+		CollectionAssert.AreEqual(new[] { 1, 2 }, attempts);
+	}
+
+	[TestMethod]
+	public async Task onRetry_is_not_called_for_a_complete_response()
+	{
+		var attempts = new List<int>();
+
+		await ApiExtended.FetchRetryingMissingAsync(["A1"], fetcher([]), maxRetries: 2, attempts.Add);
+
+		Assert.AreEqual(0, attempts.Count);
+	}
+}

--- a/Source/_Tests/AudibleUtilities.Tests/ApiExtendedCatalogFetchTests.cs
+++ b/Source/_Tests/AudibleUtilities.Tests/ApiExtendedCatalogFetchTests.cs
@@ -95,7 +95,7 @@ public class FetchRetryingMissingAsync
 	public async Task omitted_asin_is_re_requested_on_its_own()
 	{
 		var requests = new List<List<string>>();
-		int call = 0;
+		var call = 0;
 
 		// Audible drops A2 from the first response, then returns it when asked again.
 		Task<List<Item>> fetch(List<string> asins)

--- a/Source/_Tests/AudibleUtilities.Tests/ApiExtendedLinkEpisodesTests.cs
+++ b/Source/_Tests/AudibleUtilities.Tests/ApiExtendedLinkEpisodesTests.cs
@@ -1,0 +1,180 @@
+using AudibleApi.Common;
+using AudibleUtilities;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace ApiExtendedLinkEpisodesTests;
+
+/// <summary>
+/// Episodes that can't be linked to a series parent are dropped from the scan. That is what makes a
+/// podcast episode disappear from the library with nothing in the log (issue #1925), so the drop has
+/// to be both correct and reported.
+/// </summary>
+[TestClass]
+public class LinkEpisodesToSeries
+{
+	private static Relationship rel(string asin, string toProduct, string type)
+		=> new() { Asin = asin, RelationshipToProduct = toProduct, RelationshipType = type };
+
+	/// <summary>A podcast show: has episode children, no season parent.</summary>
+	private static Item show(string asin, string title, params string[] episodeAsins)
+		=> new()
+		{
+			Asin = asin,
+			Title = title,
+			PurchaseDate = new DateTimeOffset(2026, 8, 1, 0, 0, 0, TimeSpan.Zero),
+			Relationships = episodeAsins.Select(e => rel(e, RelationshipToProduct.Child, RelationshipType.Episode)).ToArray()
+		};
+
+	/// <summary>A podcast episode pointing at its parent.</summary>
+	private static Item episode(string asin, string title, string parentAsin, long sort)
+		=> new()
+		{
+			Asin = asin,
+			Title = title,
+			Relationships = [new Relationship
+			{
+				Asin = parentAsin,
+				RelationshipToProduct = RelationshipToProduct.Parent,
+				RelationshipType = RelationshipType.Episode,
+				Sort = sort
+			}]
+		};
+
+	/// <summary>A season container: episode children, but a season parent of its own.</summary>
+	private static Item season(string asin, string showAsin, params string[] episodeAsins)
+		=> new()
+		{
+			Asin = asin,
+			Title = $"Season {asin}",
+			Relationships =
+			[
+				.. episodeAsins.Select(e => rel(e, RelationshipToProduct.Child, RelationshipType.Episode)),
+				rel(showAsin, RelationshipToProduct.Parent, RelationshipType.Season)
+			]
+		};
+
+	private static Item book(string asin) => new() { Asin = asin, Title = "A regular audiobook" };
+
+	[TestMethod]
+	public void episodes_are_linked_to_their_show_and_nothing_is_dropped()
+	{
+		var items = new List<Item>
+		{
+			show("SHOW", "My Show", "EP1", "EP2"),
+			episode("EP1", "Episode one", "SHOW", 1),
+			episode("EP2", "Episode two", "SHOW", 2)
+		};
+
+		var unlinked = ApiExtended.LinkEpisodesToSeries(items);
+
+		Assert.AreEqual(0, unlinked.Count);
+		Assert.AreEqual(3, items.Count);
+		Assert.IsTrue(items.All(i => i.Series is not null));
+		CollectionAssert.AreEquivalent(
+			new[] { "SHOW", "SHOW", "SHOW" },
+			items.Select(i => i.Series!.Single().Asin).ToList());
+	}
+
+	[TestMethod]
+	public void episode_whose_show_is_absent_is_dropped_and_returned()
+	{
+		// Audible omitted SHOW from the catalog response, so EP2's parent never made it into the scan.
+		var items = new List<Item>
+		{
+			episode("EP2", "Episode two", "SHOW", 2),
+			book("BOOK")
+		};
+
+		var unlinked = ApiExtended.LinkEpisodesToSeries(items);
+
+		CollectionAssert.AreEqual(new[] { "EP2" }, unlinked.Select(i => i.Asin).ToList());
+		CollectionAssert.AreEqual(new[] { "BOOK" }, items.Select(i => i.Asin).ToList());
+	}
+
+	[TestMethod]
+	public void only_the_episode_with_the_missing_parent_is_dropped()
+	{
+		var items = new List<Item>
+		{
+			show("SHOW", "My Show", "EP1", "EP3"),
+			episode("EP1", "Episode one", "SHOW", 1),
+			episode("EP2", "Episode two", "OTHER_SHOW", 2),
+			episode("EP3", "Episode three", "SHOW", 3)
+		};
+
+		var unlinked = ApiExtended.LinkEpisodesToSeries(items);
+
+		CollectionAssert.AreEqual(new[] { "EP2" }, unlinked.Select(i => i.Asin).ToList());
+		CollectionAssert.AreEquivalent(new[] { "SHOW", "EP1", "EP3" }, items.Select(i => i.Asin).ToList());
+	}
+
+	[TestMethod]
+	public void episode_under_a_season_container_is_dropped_because_a_season_is_not_a_series_parent()
+	{
+		var seasonItem = season("SEASON", "SHOW", "EP1");
+		Assert.IsFalse(seasonItem.IsSeriesParent, "a season has a season parent of its own, so it is not a series parent");
+
+		var items = new List<Item> { seasonItem, episode("EP1", "Episode one", "SEASON", 1) };
+
+		var unlinked = ApiExtended.LinkEpisodesToSeries(items);
+
+		// The episode has nothing to link to, so it is dropped. The season itself is left alone here;
+		// it is filtered out of the scan earlier for being neither a series parent nor an episode.
+		CollectionAssert.AreEqual(new[] { "EP1" }, unlinked.Select(i => i.Asin).ToList());
+		CollectionAssert.AreEqual(new[] { "SEASON" }, items.Select(i => i.Asin).ToList());
+		Assert.IsNull(seasonItem.Series);
+	}
+
+	[TestMethod]
+	public void regular_audiobooks_are_never_dropped()
+	{
+		var items = new List<Item> { book("BOOK1"), book("BOOK2") };
+
+		var unlinked = ApiExtended.LinkEpisodesToSeries(items);
+
+		Assert.AreEqual(0, unlinked.Count);
+		Assert.AreEqual(2, items.Count);
+	}
+
+	[TestMethod]
+	public void a_show_with_no_episodes_in_the_scan_is_still_linked_to_itself()
+	{
+		var items = new List<Item> { show("SHOW", "My Show", "EP1") };
+
+		var unlinked = ApiExtended.LinkEpisodesToSeries(items);
+
+		Assert.AreEqual(0, unlinked.Count);
+		Assert.AreEqual("SHOW", items.Single().Series!.Single().Asin);
+	}
+
+	[TestMethod]
+	public void duplicate_copies_of_an_episode_are_both_linked()
+	{
+		// An episode can arrive both from the library pages and from the catalog batch.
+		var items = new List<Item>
+		{
+			show("SHOW", "My Show", "EP1"),
+			episode("EP1", "Episode one", "SHOW", 1),
+			episode("EP1", "Episode one", "SHOW", 1)
+		};
+
+		var unlinked = ApiExtended.LinkEpisodesToSeries(items);
+
+		Assert.AreEqual(0, unlinked.Count);
+		Assert.AreEqual(3, items.Count);
+	}
+
+	[TestMethod]
+	public void empty_input_is_a_no_op()
+	{
+		var items = new List<Item>();
+
+		var unlinked = ApiExtended.LinkEpisodesToSeries(items);
+
+		Assert.AreEqual(0, unlinked.Count);
+		Assert.AreEqual(0, items.Count);
+	}
+}

--- a/Source/_Tests/AudibleUtilities.Tests/IdentityTokenStorageWiringTests.cs
+++ b/Source/_Tests/AudibleUtilities.Tests/IdentityTokenStorageWiringTests.cs
@@ -60,6 +60,33 @@ BxlXqPnQ4mG66oqSFQgDEmFdMhRb2of6xL1gYYL62C80G2T7QtmPfSab
 	private string? _tempDir;
 	private string? _accountsFile;
 
+	/// <summary>
+	/// Set to "1" to also run the tests that talk to the real OS secret store.
+	/// </summary>
+	private const string OsSecretStoreTestsEnvVar = "LIBATION_TEST_OS_SECRET_STORE";
+
+	/// <summary>
+	/// Reading the OS secret store blocks until the desktop unlock prompt is answered, which can be
+	/// forever on a headless or locked-keyring machine. Probing availability first does not help: the
+	/// probe is the blocking call. Tests that need the real store are therefore opt-in.
+	/// </summary>
+	private static void SkipUnlessOsSecretStoreTestsEnabled()
+	{
+		if (Environment.GetEnvironmentVariable(OsSecretStoreTestsEnvVar) != "1")
+			Assert.Inconclusive($"Set {OsSecretStoreTestsEnvVar}=1 to exercise the real OS secret store.");
+	}
+
+	/// <summary>
+	/// Resolve the master key from a temp key file so <see cref="IdentityTokenStorageWiring.ResolveSecretStore"/>
+	/// short-circuits before it reaches the OS secret store. Tests about which write method gets configured
+	/// have no business depending on a desktop keyring, and must not mint a key into the real Libation folder.
+	/// </summary>
+	private void UsePortableMasterKey()
+	{
+		Environment.SetEnvironmentVariable(LibationFiles.LIBATION_FILES_DIR, _tempDir);
+		Environment.SetEnvironmentVariable(IdentityTokenStorageWiring.MasterKeyFileEnvVar, WriteTempMasterKeyFile());
+	}
+
 	[TestInitialize]
 	public void Init()
 	{
@@ -86,16 +113,16 @@ BxlXqPnQ4mG66oqSFQgDEmFdMhRb2of6xL1gYYL62C80G2T7QtmPfSab
 	}
 
 	[TestMethod]
-	public void Apply_Encrypted_configures_write_method_and_protector_when_store_available()
+	public void Apply_Encrypted_configures_write_method_and_protector()
 	{
+		UsePortableMasterKey();
 		var config = Configuration.CreateMockInstance();
 		config.TokenStorageMethod = TokenStorageMethod.Encrypted;
 
 		IdentityTokenStorageWiring.Apply(config);
 
 		Assert.AreEqual(TokenStorageMethod.Encrypted, IdentityTokenStorage.WriteMethod);
-		if (IdentityTokenStorageWiring.IsOsSecretStoreAvailable(out _))
-			Assert.IsNotNull(IdentityTokenStorage.Protector);
+		Assert.IsNotNull(IdentityTokenStorage.Protector);
 	}
 
 	[TestMethod]
@@ -182,6 +209,7 @@ BxlXqPnQ4mG66oqSFQgDEmFdMhRb2of6xL1gYYL62C80G2T7QtmPfSab
 	[TestMethod]
 	public void Apply_Plaintext_configures_plaintext_writes()
 	{
+		UsePortableMasterKey();
 		var config = Configuration.CreateMockInstance();
 		config.TokenStorageMethod = TokenStorageMethod.Plaintext;
 
@@ -193,6 +221,7 @@ BxlXqPnQ4mG66oqSFQgDEmFdMhRb2of6xL1gYYL62C80G2T7QtmPfSab
 	[TestMethod]
 	public void Changing_preference_updates_write_method_without_converting_existing_tokens()
 	{
+		UsePortableMasterKey();
 		WriteLegacyAccountsFile(_accountsFile!);
 		var before = File.ReadAllText(_accountsFile!);
 
@@ -290,6 +319,7 @@ BxlXqPnQ4mG66oqSFQgDEmFdMhRb2of6xL1gYYL62C80G2T7QtmPfSab
 	[TestMethod]
 	public void ResolveSecretStore_uses_os_store_when_available_without_last_resort_key_file()
 	{
+		SkipUnlessOsSecretStoreTestsEnabled();
 		if (!IdentityTokenStorageWiring.IsOsSecretStoreAvailable(out var reason))
 			Assert.Inconclusive("OS secret store unavailable: " + reason);
 
@@ -357,6 +387,7 @@ BxlXqPnQ4mG66oqSFQgDEmFdMhRb2of6xL1gYYL62C80G2T7QtmPfSab
 	[TestMethod]
 	public void MasterKeyExport_writes_key_file_when_os_store_has_key()
 	{
+		SkipUnlessOsSecretStoreTestsEnabled();
 		if (!IdentityTokenStorageWiring.IsOsSecretStoreAvailable(out var reason))
 			Assert.Inconclusive("OS secret store unavailable: " + reason);
 

--- a/Source/_Tests/LibationUiBase.Tests/StandaloneBooksTests.cs
+++ b/Source/_Tests/LibationUiBase.Tests/StandaloneBooksTests.cs
@@ -1,0 +1,73 @@
+using DataLayer;
+
+namespace LibationUiBase.Tests;
+
+[TestClass]
+public class StandaloneBooksTests
+{
+	private static LibraryBook libraryBook(string asin, ContentType contentType, string? seriesAsin = null)
+	{
+		var contributor = Contributor.GetEmpty();
+		var book = new Book(
+			new AudibleProductId(asin),
+			asin,
+			null,
+			null,
+			1,
+			contentType,
+			[contributor],
+			[contributor],
+			"us");
+
+		if (seriesAsin is not null)
+			book.UpsertSeries(new Series(new AudibleSeriesId(seriesAsin), $"Series {seriesAsin}"), "1");
+
+		return new LibraryBook(book, new DateTime(2026, 8, 10), "account");
+	}
+
+	[TestMethod]
+	public void ordinary_books_are_standalone()
+	{
+		var product = libraryBook("BOOK", ContentType.Product);
+
+		var standalone = new[] { product }.StandaloneBooks().ToList();
+
+		CollectionAssert.AreEqual(new[] { "BOOK" }, standalone.Select(lb => lb.Book.AudibleProductId).ToList());
+	}
+
+	[TestMethod]
+	public void episode_without_its_parent_is_standalone()
+	{
+		var orphan = libraryBook("EPISODE", ContentType.Episode, "SHOW");
+
+		var standalone = new[] { orphan }.StandaloneBooks().ToList();
+
+		CollectionAssert.AreEqual(new[] { "EPISODE" }, standalone.Select(lb => lb.Book.AudibleProductId).ToList());
+	}
+
+	[TestMethod]
+	public void episode_with_its_parent_is_not_standalone()
+	{
+		var parent = libraryBook("SHOW", ContentType.Parent, "SHOW");
+		var episode = libraryBook("EPISODE", ContentType.Episode, "SHOW");
+
+		var standalone = new[] { parent, episode }.StandaloneBooks().ToList();
+
+		Assert.AreEqual(0, standalone.Count);
+	}
+
+	[TestMethod]
+	public void products_and_orphans_are_returned_but_parents_and_parented_episodes_are_not()
+	{
+		var product = libraryBook("BOOK", ContentType.Product);
+		var parent = libraryBook("SHOW", ContentType.Parent, "SHOW");
+		var child = libraryBook("CHILD", ContentType.Episode, "SHOW");
+		var orphan = libraryBook("ORPHAN", ContentType.Episode, "MISSING_SHOW");
+
+		var standalone = new[] { product, parent, child, orphan }.StandaloneBooks().ToList();
+
+		CollectionAssert.AreEquivalent(
+			new[] { "BOOK", "ORPHAN" },
+			standalone.Select(lb => lb.Book.AudibleProductId).ToList());
+	}
+}

--- a/Source/_Tests/LibationUiBase.Tests/StandaloneBooksTests.cs
+++ b/Source/_Tests/LibationUiBase.Tests/StandaloneBooksTests.cs
@@ -79,6 +79,7 @@ public class StandaloneBooksTests
 		var child = libraryBook("CHILD", ContentType.Episode, "SHOW");
 		var orphan = libraryBook("ORPHAN", ContentType.Episode, "MISSING_SHOW");
 
+		SynchronizationContext.SetSynchronizationContext(new SynchronizationContext());
 		var entries = await LibraryBookEntry.GetAllProductsAsync([parent, child, orphan]);
 
 		CollectionAssert.AreEqual(

--- a/Source/_Tests/LibationUiBase.Tests/StandaloneBooksTests.cs
+++ b/Source/_Tests/LibationUiBase.Tests/StandaloneBooksTests.cs
@@ -1,4 +1,5 @@
 using DataLayer;
+using LibationUiBase.GridView;
 
 namespace LibationUiBase.Tests;
 
@@ -69,5 +70,20 @@ public class StandaloneBooksTests
 		CollectionAssert.AreEquivalent(
 			new[] { "BOOK", "ORPHAN" },
 			standalone.Select(lb => lb.Book.AudibleProductId).ToList());
+	}
+
+	[TestMethod]
+	public async Task grid_entries_include_orphaned_episode_as_a_standalone_row()
+	{
+		var parent = libraryBook("SHOW", ContentType.Parent, "SHOW");
+		var child = libraryBook("CHILD", ContentType.Episode, "SHOW");
+		var orphan = libraryBook("ORPHAN", ContentType.Episode, "MISSING_SHOW");
+
+		var entries = await LibraryBookEntry.GetAllProductsAsync([parent, child, orphan]);
+
+		CollectionAssert.AreEqual(
+			new[] { "ORPHAN" },
+			entries.Select(entry => entry.AudibleProductId).ToList());
+		Assert.IsNull(((LibraryBookEntry)entries.Single()).Parent);
 	}
 }


### PR DESCRIPTION
Diagnoses and addresses #1925, where a title visible on Audible did not appear in Libation and left no useful trace in the log. Also fixes an unrelated test-suite bottleneck found while working on it.

## Diagnosis

The attached log contains 1140 scans. The direct library page count is stable, but podcast expansion is not:

| Library items returned by Audible | Post-expansion totals observed |
|-|-|
| 434 | 2141, 2142, 2143 |
| 438 | 2145, 2146 |
| 439 | 2147 |
| 440 | 2147, 2148, 2149, 2150, 2151 |

1117 consecutive scans read exactly 440 direct library items but produced five different expanded totals. Audible's catalog endpoint can return HTTP 200 while omitting requested products. Libation accepted that partial response, then silently removed episodes that could not be linked to a series parent. Separately, an episode already in the database whose parent was absent rendered nowhere, because neither grid treated it as a product or as a displayable series child.

The log could not explain other exclusions either: orphan pruning was Debug-only and did not name titles, and `ImportEpisodes` / `ImportPlusTitles` were not logged at all.

## Scan changes

- Compare every successful catalog response against the requested ASINs.
- Re-request omitted ASINs (2 extra attempts), then warn with any Audible still will not return.
- Warn with ASIN and title when an episode is dropped for having no series parent.
- Emit a per-scan tally: direct items, expanded episodes, dropped orphans, filter settings, filter exclusions, final import count.
- Record `ImportEpisodes`, `ImportPlusTitles`, and `DownloadEpisodes` in the startup state block.
- Read the import filters once per scan so a mid-scan settings change cannot half-filter a library.

## Grid changes

- Show database orphan episodes as standalone rows in both Avalonia and WinForms.
- Move a standalone orphan under its parent once a later scan finds it, and back to a standalone row if the parent disappears.

## How this addresses #1925

Three protections at the points where the reported title could vanish:

1. Audible omits an episode or parent from a successful catalog response -> Libation re-requests that exact ASIN instead of accepting the gap.
2. The parent stays unavailable -> the log names the excluded episode and the reason.
3. The episode is already stored but its parent is absent -> both grids show it as a standalone row, so it stays searchable and downloadable.

A non-episode title omitted from Audible's direct paged library response still cannot be recovered, since Libation never receives an ASIN for it. The new tally makes that API-side discrepancy visible and distinguishes it from local filtering.

## Test suite bottleneck (unrelated to #1925, found while testing)

`IdentityTokenStorageWiring.ConfigureFrom` always calls `ResolveSecretStore`, which falls through to `OsSecretStore.Create(...).IsAvailable` when no master key file or env var is set. That is a blocking libsecret call. On a headless machine, or one whose login keyring is locked, it waits on a desktop unlock prompt that never gets answered. Five tests reached it and one reached it twice. Guarding with an availability probe does not help, because the probe is the blocking call.

- Tests that only assert which write method gets configured now resolve the master key from a temp key file, so they short-circuit before the OS store. This also stops them minting a last-resort key file into the real Libation folder.
- The two tests that exist to exercise the real OS store are opt-in via `LIBATION_TEST_OS_SECRET_STORE=1`.
- AGENTS.md corrected: it previously said to wait for a human to set a keyring password, which does not work here.

`AudibleUtilities.Tests` went from 12m 20s to 1.8s. The test that used to fail in this environment is now a clean skip.

## Verification

Avalonia and CLI builds pass with 0 errors. All Linux-buildable test projects, each under a hard timeout:

```
AudibleUtilities       total: 74  failed: 0  succeeded: 72  skipped: 2   duration: 1s 842ms
ApplicationServices    total: 46  failed: 0  succeeded: 46               duration:    363ms
FileLiberator          total:  8  failed: 0  succeeded:  8               duration:    395ms
FileManager            total: 202 failed: 0  succeeded: 202              duration: 1s 299ms
LibationFileManager    total: 624 failed: 0  succeeded: 603              duration: 1s 304ms
LibationSearchEngine   total: 40  failed: 0  succeeded: 40               duration:    327ms
LibationUiBase         total: 32  failed: 0  succeeded: 32               duration:    412ms
```

`LibationUiBase` includes direct verification that an orphaned episode becomes a standalone `LibraryBookEntry`. Zero failures anywhere; the whole suite now runs in about 6 seconds.