### PR TITLE
Defer fluent theme reloads while a color picker is open

### DIFF
--- a/Source/LibationAvalonia/Controls/ColorPickerExt.cs
+++ b/Source/LibationAvalonia/Controls/ColorPickerExt.cs
@@ -1,0 +1,42 @@
+using Avalonia.Controls;
+using Avalonia.Controls.Primitives;
+using Avalonia.VisualTree;
+using System;
+using System.Linq;
+
+namespace LibationAvalonia.Controls;
+
+/// <summary> A <see cref="ColorPicker"/> which reports when its drop-down flyout opens and closes. </summary>
+public class ColorPickerExt : ColorPicker
+{
+	protected override Type StyleKeyOverride => typeof(ColorPicker);
+
+	public event EventHandler? FlyoutOpened;
+	public event EventHandler? FlyoutClosed;
+
+	private FlyoutBase? Flyout;
+
+	protected override void OnApplyTemplate(TemplateAppliedEventArgs e)
+	{
+		base.OnApplyTemplate(e);
+
+		if (Flyout is not null)
+		{
+			Flyout.Opened -= Flyout_Opened;
+			Flyout.Closed -= Flyout_Closed;
+		}
+
+		//The ColorPicker's template is a DropDownButton whose flyout hosts the editor.
+		Flyout = this.GetVisualDescendants().OfType<DropDownButton>().FirstOrDefault()?.Flyout;
+
+		if (Flyout is not null)
+		{
+			Flyout.Opened += Flyout_Opened;
+			Flyout.Closed += Flyout_Closed;
+		}
+	}
+
+	private void Flyout_Opened(object? sender, EventArgs e) => FlyoutOpened?.Invoke(this, e);
+
+	private void Flyout_Closed(object? sender, EventArgs e) => FlyoutClosed?.Invoke(this, e);
+}

--- a/Source/LibationAvalonia/Dialogs/ThemePickerDialog.axaml
+++ b/Source/LibationAvalonia/Dialogs/ThemePickerDialog.axaml
@@ -30,8 +30,10 @@
 					<DataGridTemplateColumn Width="Auto" Header="Color">
 						<DataGridTemplateColumn.CellTemplate>
 							<DataTemplate>
-								<ColorPicker
+								<controls:ColorPickerExt
 									IsHexInputVisible="True"
+									FlyoutOpened="ColorPicker_FlyoutOpened"
+									FlyoutClosed="ColorPicker_FlyoutClosed"
 									Color="{Binding ThemeColor, Mode=TwoWay}" />
 							</DataTemplate>
 						</DataGridTemplateColumn.CellTemplate>

--- a/Source/LibationAvalonia/Dialogs/ThemePickerDialog.axaml.cs
+++ b/Source/LibationAvalonia/Dialogs/ThemePickerDialog.axaml.cs
@@ -18,6 +18,9 @@ public partial class ThemePickerDialog : DialogWindow
 	private ChardonnayTheme ExistingTheme { get; } = ChardonnayTheme.GetLiveTheme();
 	private ChardonnayTheme WorkingTheme { get; set; }
 
+	/// <summary>The number of <see cref="Controls.ColorPickerExt"/> flyouts which are currently open</summary>
+	private int OpenColorPickerFlyouts;
+
 	public ThemePickerDialog()
 	{
 		InitializeComponent();
@@ -27,6 +30,7 @@ public partial class ThemePickerDialog : DialogWindow
 
 		DataContext = this;
 		Closing += ThemePickerDialog_Closing;
+		Closed += ThemePickerDialog_Closed;
 	}
 
 	private void ThemePickerDialog_Closing(object? sender, Avalonia.Controls.WindowClosingEventArgs e)
@@ -37,6 +41,10 @@ public partial class ThemePickerDialog : DialogWindow
 			e.Cancel = true;
 		}
 	}
+
+	private void ThemePickerDialog_Closed(object? sender, EventArgs e)
+		//This window's color pickers are gone, so any deferred reload is now safe to perform.
+		=> ChardonnayTheme.ReloadDeferredFluentTheme();
 
 	public async Task ImportTheme()
 	{
@@ -173,7 +181,19 @@ public partial class ThemePickerDialog : DialogWindow
 	private void ColorSetter(Color color, string colorName)
 	{
 		WorkingTheme.SetColor(ActualThemeVariant, colorName, color);
-		WorkingTheme.ApplyTheme(ActualThemeVariant);
+		WorkingTheme.ApplyTheme(ActualThemeVariant, deferFluentReload: OpenColorPickerFlyouts > 0);
+	}
+
+	private void ColorPicker_FlyoutOpened(object? sender, EventArgs e)
+		=> OpenColorPickerFlyouts++;
+
+	private void ColorPicker_FlyoutClosed(object? sender, EventArgs e)
+	{
+		if (--OpenColorPickerFlyouts <= 0)
+		{
+			OpenColorPickerFlyouts = 0;
+			ChardonnayTheme.ReloadDeferredFluentTheme();
+		}
 	}
 
 	public class ThemeItemColor : ViewModels.ViewModelBase

--- a/Source/LibationAvalonia/Themes/ChardonnayTheme.cs
+++ b/Source/LibationAvalonia/Themes/ChardonnayTheme.cs
@@ -28,6 +28,9 @@ public class ChardonnayTheme : IUpdatable, ICloneable
 	private static readonly FrozenDictionary<ThemeVariant, ColorPaletteResources> ColorPalettes
 		= FluentVariants.ToFrozenDictionary(t => t, _ => new ColorPaletteResources());
 
+	/// <summary>Whether a fluent theme reload has been deferred by <see cref="ApplyTheme(ThemeVariant, bool)"/></summary>
+	private static bool fluentReloadDeferred;
+
 	private ChardonnayTheme()
 	{
 		ThemeColors = FluentVariants.ToDictionary(t => t, _ => new Dictionary<string, Color>());
@@ -80,7 +83,12 @@ public class ChardonnayTheme : IUpdatable, ICloneable
 	public void ApplyTheme(LibationFileManager.Configuration.Theme themeVariant)
 		=> ApplyTheme(FromVariantName(themeVariant));
 
-	public void ApplyTheme(ThemeVariant themeVariant)
+	/// <param name="deferFluentReload">
+	/// Whether to postpone reloading the fluent theme until <see cref="ReloadDeferredFluentTheme"/> is called.
+	/// Reloading it while a popup is open leaves the popup's contents parented to its old
+	/// presenter, and reopening that popup then throws.
+	/// </param>
+	public void ApplyTheme(ThemeVariant themeVariant, bool deferFluentReload = false)
 	{
 		App.Current.RequestedThemeVariant = themeVariant;
 		themeVariant = App.Current.ActualThemeVariant;
@@ -112,21 +120,38 @@ public class ChardonnayTheme : IUpdatable, ICloneable
 			}
 		}
 
-		if (fluentColorChanged)
+		if (fluentColorChanged || fluentReloadDeferred)
 		{
-			var oldFluent = App.Current.Styles.OfType<FluentTheme>().Single();
-			App.Current.Styles.Remove(oldFluent);
-
-			//We must make a new fluent theme and add it to the app for
-			//the changes to the ColorPaletteResources to take effect.
-			//Changes to the Libation-specific resources are instant.
-			var newFluent = new FluentTheme();
-
-			foreach (var kvp in ColorPalettes)
-				newFluent.Palettes[kvp.Key] = kvp.Value;
-
-			App.Current.Styles.Add(newFluent);
+			if (deferFluentReload)
+				fluentReloadDeferred = true;
+			else
+				ReloadFluentTheme();
 		}
+	}
+
+	/// <summary> Perform a fluent theme reload which <see cref="ApplyTheme(ThemeVariant, bool)"/> deferred. </summary>
+	public static void ReloadDeferredFluentTheme()
+	{
+		if (fluentReloadDeferred)
+			ReloadFluentTheme();
+	}
+
+	private static void ReloadFluentTheme()
+	{
+		fluentReloadDeferred = false;
+
+		var oldFluent = App.Current.Styles.OfType<FluentTheme>().Single();
+		App.Current.Styles.Remove(oldFluent);
+
+		//We must make a new fluent theme and add it to the app for
+		//the changes to the ColorPaletteResources to take effect.
+		//Changes to the Libation-specific resources are instant.
+		var newFluent = new FluentTheme();
+
+		foreach (var kvp in ColorPalettes)
+			newFluent.Palettes[kvp.Key] = kvp.Value;
+
+		App.Current.Styles.Add(newFluent);
 	}
 
 	/// <summary> Get the currently-active theme colors. </summary>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes #1927.

## The bug

Editing a fluent palette color (`BaseHigh`, `BaseLow`, `ChromeHigh`, etc.) in the theme editor removes and re-adds the application's `FluentTheme`, which is the only way changes to `ColorPaletteResources` take effect. When that swap happens while the color picker's flyout is open, the flyout's tab content is left parented to its old presenter. Reopening that picker then throws:

```
The control Grid already has a visual parent ContentPresenter (Name = PART_SelectedContentHost)
while trying to add it as a child of ContentPresenter (Name = PART_SelectedContentHost,
Host = TabControl (Name = PART_TabControl)).
```

`PART_TabControl` and `PART_SelectedContentHost` are parts of Avalonia's own `ColorPicker` template, not Libation controls. This is the same failure mode as AvaloniaUI/Avalonia#4839, and the same class of problem the theme selector combo box already works around in `Important.axaml.cs`.

Libation's own brushes live in `ThemeDictionaries` and update in place, so only the fluent palette rows are affected.

## The fix

`ApplyTheme` gains an opt-in `deferFluentReload` flag. When set, palette colors are still written but the `FluentTheme` swap is postponed until `ReloadDeferredFluentTheme` is called. The theme editor tracks how many color picker flyouts are open and defers while any of them are, then reloads once the last one closes (or once the editor window itself closes).

Fluent colors now preview when the picker closes rather than on every intermediate value. That also coalesces the many changes produced by dragging through the spectrum into a single theme reload. Libation's own brushes still preview live.

`ColorPickerExt` is a small `ColorPicker` subclass that surfaces `FlyoutOpened`/`FlyoutClosed` from the `DropDownButton` in its template, since the base control does not expose flyout state.

## Testing

Verified manually on Linux, and all test projects under `Source/_Tests` pass.

The crash itself reproduces on Windows and I could not trigger it on Linux, so the verification below instead confirms the behavior that prevents it: no theme reload happens while the picker is open, and the change lands as soon as it closes.

Selecting red for `BaseHigh` leaves the surrounding UI untouched while the flyout is open, and applies the instant the flyout closes. The same holds for a second edit on another fluent row.

[issue_1927_deferred_theme_reload_verification.mp4](https://cursor.com/agents/bc-9dce629a-31bc-4f9a-96d6-190b95d0b900/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fissue_1927_deferred_theme_reload_verification.mp4)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9dce629a-31bc-4f9a-96d6-190b95d0b900?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9dce629a-31bc-4f9a-96d6-190b95d0b900&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

