### PR TITLE
Add single-book download to right-click context menu

### DIFF
--- a/Source/LibationAvalonia/Views/ProductsDisplay.axaml.cs
+++ b/Source/LibationAvalonia/Views/ProductsDisplay.axaml.cs
@@ -371,12 +371,14 @@ public partial class ProductsDisplay : UserControl
 		});
 
 		#endregion
-		#region Liberate All (multiple books only)
-		if (entries.OfType<LibraryBookEntry>().Count() > 1)
+		#region Download audiobook(s)
+		var selectedBookCount = entries.OfType<LibraryBookEntry>().Count();
+		if (selectedBookCount >= 1)
 		{
 			args.ContextMenuItems.Add(new MenuItem
 			{
-				Header = ctx.DownloadSelectedText,
+				Header = selectedBookCount == 1 ? ctx.DownloadSingleText : ctx.DownloadSelectedText,
+				IsEnabled = ctx.DownloadBookEnabled,
 				Command = ReactiveCommand.Create(() => LiberateClicked?.Invoke(this, ctx.LibraryBookEntries.Select(e => e.LibraryBook).ToArray(), Configuration.Instance))
 			});
 		}

--- a/Source/LibationUiBase/GridView/EntryStatus.cs
+++ b/Source/LibationUiBase/GridView/EntryStatus.cs
@@ -160,7 +160,7 @@ public class EntryStatus : ReactiveObject, IComparable
 		if (BookStatus == LiberatedStatus.NotLiberated ||
 			BookStatus == LiberatedStatus.PartialDownload ||
 			PdfStatus == LiberatedStatus.NotLiberated)
-			mouseoverText += "\r\nClick to complete";
+			mouseoverText += "\r\nClick to download";
 
 		return mouseoverText;
 	}

--- a/Source/LibationUiBase/GridView/GridContextMenu.cs
+++ b/Source/LibationUiBase/GridView/GridContextMenu.cs
@@ -27,6 +27,7 @@ public class GridContextMenu
 	public string ConvertToMp3Text => $"{Accelerator}Convert to Mp3";
 	public string DownloadAsChapters => $"Download {Accelerator}split by chapters";
 	public string ReDownloadText => "Re-download this audiobook";
+	public string DownloadSingleText => "Download this audiobook";
 	public string DownloadSelectedText => "Download selected audiobooks";
 	public string EditTemplatesText => "Edit Templates";
 	public string FolderTemplateText => "Folder Template";
@@ -39,6 +40,7 @@ public class GridContextMenu
 	public bool SetDownloadedEnabled => LibraryBookEntries.Any(ge => ge.Book?.UserDefinedItem.BookStatus != LiberatedStatus.Liberated || ge.Liberate?.IsSeries is true);
 	public bool SetNotDownloadedEnabled => LibraryBookEntries.Any(ge => ge.Book?.UserDefinedItem.BookStatus != LiberatedStatus.NotLiberated || ge.Liberate?.IsSeries is true);
 	public bool ConvertToMp3Enabled => LibraryBookEntries.Any(ge => ge.Book?.UserDefinedItem.BookStatus is LiberatedStatus.Liberated);
+	public bool DownloadBookEnabled => LibraryBookEntries.Any(ge => ge.LibraryBook.NeedsBookDownload || ge.LibraryBook.NeedsPdfDownload);
 	public bool DownloadAsChaptersEnabled => LibraryBookEntries.Any(ge => ge.Book?.UserDefinedItem.BookStatus is not LiberatedStatus.Error);
 	public bool ReDownloadEnabled => LibraryBookEntries.Any(ge => ge.Book?.UserDefinedItem.BookStatus is LiberatedStatus.Liberated);
 	public bool RemoveFromAudibleEnabled => LibraryBookEntries.Any(ge => ge.LibraryBook.IsAudiblePlus);

--- a/Source/LibationWinForms/GridView/ProductsDisplay.cs
+++ b/Source/LibationWinForms/GridView/ProductsDisplay.cs
@@ -196,12 +196,14 @@ public partial class ProductsDisplay : UserControl
 		ctxMenu.Items.Add(removeMenuItem);
 
 		#endregion
-		#region Liberate All (multiple books only)
-		if (entries.OfType<LibraryBookEntry>().Count() > 1)
+		#region Download audiobook(s)
+		var selectedBookCount = entries.OfType<LibraryBookEntry>().Count();
+		if (selectedBookCount >= 1)
 		{
 			var downloadSelectedMenuItem = new ToolStripMenuItem()
 			{
-				Text = ctx.DownloadSelectedText
+				Text = selectedBookCount == 1 ? ctx.DownloadSingleText : ctx.DownloadSelectedText,
+				Enabled = ctx.DownloadBookEnabled
 			};
 			ctxMenu.Items.Add(downloadSelectedMenuItem);
 			downloadSelectedMenuItem.Click += (s, _) =>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Addresses the recurring confusion reported in [issue #1459](https://github.com/rmcrackan/Libation/issues/1459) (reopened attention via a [new +1 comment](https://github.com/rmcrackan/Libation/issues/1459#issuecomment-5258311410)): right-clicking a single book offered no ordinary "download" action. Users could only download one book via the stoplight column, split-by-chapters, or (for already-liberated books) re-download - while selecting 2+ books showed "Download selected audiobooks". This exposes the same download action for a single selection.

## Changes

- `Source/LibationAvalonia/Views/ProductsDisplay.axaml.cs`: the download context-menu item now appears when at least one book row is selected (previously only when more than one). A single selection shows singular copy; multiple selections keep the plural copy. Series-only rows still get "Liberate All Episodes".
- `Source/LibationWinForms/GridView/ProductsDisplay.cs`: mirrors the same guard/label/enable change for parity.
- `Source/LibationUiBase/GridView/GridContextMenu.cs`: adds `DownloadSingleText` ("Download this audiobook") and a shared `DownloadBookEnabled` predicate so the item is disabled when nothing in the selection needs a book or PDF download (already-liberated books use the distinct "Re-download this audiobook" item).
- `Source/LibationUiBase/GridView/EntryStatus.cs`: the stoplight hover tip now ends with "Click to download" instead of "Click to complete" for not-downloaded / partially-downloaded / PDF-pending states (shared by both UIs).

No downloader, queue, database, or configuration changes are required; the single-book path already exists in `ProcessQueueViewModel.QueueDownloadDecryptAsync`.

## Testing

- `dotnet build Source/LibationAvalonia/LibationAvalonia.csproj` succeeds (0 errors).
- Manual GUI verification of the Avalonia context menu (single book, multiple books, series row, and already-downloaded book) and the updated tooltip.

Note: `LibationWinForms` targets Windows and cannot be built on this Linux environment; that change was reviewed for parity only.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-331d8bc0-92c5-4403-8551-734892d9d7c9?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-331d8bc0-92c5-4403-8551-734892d9d7c9&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

