### PR TITLE
docs: fix missing `->` in the `<has series#->` example

### DIFF
--- a/Source/_Tests/LibationFileManager.Tests/TemplatesTests.cs
+++ b/Source/_Tests/LibationFileManager.Tests/TemplatesTests.cs
@@ -783,6 +783,32 @@ namespace TemplatesTests
 		}
 
 		[TestMethod]
+		// a book can be in a series but have no series number. <has series#-> nested inside
+		// <if series-> is the way to keep the number's punctuation out of the name in that case.
+		[DataRow("<if series-><first series>|<has series#-><series#>. <-has><-if series><title short>", "1", "Series A|1. A Study in Scarlet")]
+		[DataRow("<if series-><first series>|<has series#-><series#>. <-has><-if series><title short>", "", "Series A|A Study in Scarlet")]
+		[DataRow("<if series-><first series>|<has series#-><series#>. <-has><-if series><title short>", null, "A Study in Scarlet")]
+		// without the conditional, a missing number leaves its trailing punctuation behind
+		[DataRow("<if series-><first series>|<series#>. <-if series><title short>", "", "Series A|. A Study in Scarlet")]
+		// and a missing number between two spaces leaves a double space, which is then collapsed
+		[DataRow("<if series-><first series><has series#-> <series#><-has> - <-if series><title short>", "1", "Series A 1 - A Study in Scarlet")]
+		[DataRow("<if series-><first series><has series#-> <series#><-has> - <-if series><title short>", "", "Series A - A Study in Scarlet")]
+		[DataRow("<if series-><first series[{N}{ {#}}]> - <-if series><title short>", "1", "Series A 1 - A Study in Scarlet")]
+		[DataRow("<if series-><first series[{N}{ {#}}]> - <-if series><title short>", "", "Series A - A Study in Scarlet")]
+		public void HasSeriesNumber_nested_in_IfSeries(string template, string? seriesOrder, string expected)
+		{
+			var bookDto = GetLibraryBook(seriesOrder is null ? null : [new SeriesDto("Series A", seriesOrder, "B1")]);
+
+			Templates.TryGetTemplate<Templates.FileTemplate>(template, out var fileTemplate).Should().BeTrue();
+			fileTemplate.Errors.Should().HaveCount(0);
+			fileTemplate.Warnings.Should().HaveCount(0);
+			fileTemplate
+				.GetFilename(bookDto, "", "", culture: CultureInfo.InvariantCulture, replacements: Replacements)
+				.PathWithoutPrefix
+				.Should().Be(expected);
+		}
+
+		[TestMethod]
 		[DataRow(@"C:\a\b", @"C:\a\b\foobar.ext", PlatformID.Win32NT)]
 		[DataRow(@"/a/b", @"/a/b/foobar.ext", PlatformID.Unix)]
 		public void IfSeries_empty(string directory, string expected, PlatformID platformId)

--- a/Source/_Tests/LibationFileManager.Tests/TemplatesTests.cs
+++ b/Source/_Tests/LibationFileManager.Tests/TemplatesTests.cs
@@ -785,11 +785,11 @@ namespace TemplatesTests
 		[TestMethod]
 		// a book can be in a series but have no series number. <has series#-> nested inside
 		// <if series-> is the way to keep the number's punctuation out of the name in that case.
-		[DataRow("<if series-><first series>|<has series#-><series#>. <-has><-if series><title short>", "1", "Series A|1. A Study in Scarlet")]
-		[DataRow("<if series-><first series>|<has series#-><series#>. <-has><-if series><title short>", "", "Series A|A Study in Scarlet")]
-		[DataRow("<if series-><first series>|<has series#-><series#>. <-has><-if series><title short>", null, "A Study in Scarlet")]
+		[DataRow("<if series-><first series> - <has series#-><series#>. <-has><-if series><title short>", "1", "Series A - 1. A Study in Scarlet")]
+		[DataRow("<if series-><first series> - <has series#-><series#>. <-has><-if series><title short>", "", "Series A - A Study in Scarlet")]
+		[DataRow("<if series-><first series> - <has series#-><series#>. <-has><-if series><title short>", null, "A Study in Scarlet")]
 		// without the conditional, a missing number leaves its trailing punctuation behind
-		[DataRow("<if series-><first series>|<series#>. <-if series><title short>", "", "Series A|. A Study in Scarlet")]
+		[DataRow("<if series-><first series> - <series#>. <-if series><title short>", "", "Series A - . A Study in Scarlet")]
 		// and a missing number between two spaces leaves a double space, which is then collapsed
 		[DataRow("<if series-><first series><has series#-> <series#><-has> - <-if series><title short>", "1", "Series A 1 - A Study in Scarlet")]
 		[DataRow("<if series-><first series><has series#-> <series#><-has> - <-if series><title short>", "", "Series A - A Study in Scarlet")]

--- a/docs/features/naming-templates.md
+++ b/docs/features/naming-templates.md
@@ -102,7 +102,11 @@ As an example, this folder template will place all Liberated podcasts into a "Po
 
 This example will add a number if the `<series#>` tag has a value:
 
-`<has series#><series#><-has>`
+`<has series#-><series#><-has>`
+
+Conditionals may be nested. This folder template puts every book under its series, and prefixes the book folder with the series number only for the books that have one, so that books without a number don't end up in a folder starting with `.`:
+
+`<if series-><first series>/<has series#-><series#>. <-has><-if series><title short>`
 
 This example will put non-series books in a "Standalones" folder:
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

The `<has>` example in `docs/features/naming-templates.md` is missing the `->` delimiter on the opening tag:

```
<has series#><series#><-has>
```

The reference table one section earlier documents the correct form (`<has PROPERTY->...<-has>`), and the subtitle example further down is also correct (`<has audible subtitle->`), so this single line is the outlier.

Because `<has series#>` is not recognized as a conditional open tag, the parser treats it as literal text plus a `<series#>` property tag. The later `<-has>` then has nothing to close, so it closes the enclosing conditional instead. A user who copies this example into a template like the one below gets a confusing warning about a completely different tag:

```
<if series-><first series>/<has series#><series#>. <-has><-if series><title short>
```

produces `Missing <-if series> closing conditional.` and leaks the literal text `<has series#>` into the folder name. This came up on [r/audiobooks](https://old.reddit.com/r/audiobooks/comments/1vlyc3b/libation_folder_template_question/), where the reporter concluded that nesting conditionals was unsupported, when in fact only the `->` was missing.

## Changes

- Fix the example to `<has series#-><series#><-has>`.
- Add a nested-conditional example. The reference table shows each conditional in isolation, and nothing else in the doc demonstrates that they compose. The added example is the common real-world case: put a book under its series and prefix the folder with the series number only when the book has one, so books without a number do not land in a folder starting with `.`.
- Add regression tests in `TemplatesTests` for `<has series#->` nested inside `<if series->` covering a numbered series entry, a series entry with an empty number, and a standalone book. Also cover the trailing-punctuation and double-space artifacts that appear without the conditional, and the equivalent `<first series[{N}{ {#}}]>` format-template spelling.

## Verification

`dotnet test --project Source/_Tests/LibationFileManager.Tests/LibationFileManager.Tests.csproj` passes with the 8 new cases:

```
Test run summary: Passed!
  total: 632
  failed: 0
  succeeded: 611
  skipped: 21
```

`npx vitepress build` completes, and the rendered page shows the corrected example.

Behavior confirmed against the real template engine before and after the fix:

```
##### <has series#> WITHOUT ->
  warnings: [Missing <-if series> closing conditional. | Missing <-if series> closing conditional.]
  numbered  : Sherlock Holmes/<has series#>1
  no number : Sherlock Holmes/<has series#>

##### <has series#-> WITH -> (nested inside <if series->)
  warnings: []
  numbered  : Sherlock Holmes/1. A Study in Scarlet
  no number : Sherlock Holmes/A Study in Scarlet
```

No engine behavior changes; this is a documentation correction plus test coverage.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-422f5b07-e04f-4242-af02-f6f5175a4221?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-422f5b07-e04f-4242-af02-f6f5175a4221&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

