### PR TITLE
Harden startup against library-load crashes (#1931)

### DIFF
--- a/Source/AppScaffolding/LibationScaffolding.cs
+++ b/Source/AppScaffolding/LibationScaffolding.cs
@@ -134,25 +134,13 @@ public static class LibationScaffolding
 			if (WalHoldsUnrecoveredTransactions(walFile))
 				Log.Logger.Information("Leaving SQLite WAL in place so SQLite can recover it on open: {WalFile}", walFile);
 			else
-				trySaferDelete(walFile, "WAL");
+				FileManager.FileUtility.TrySaferDelete(walFile);
 		}
 
 		// The SHM (shared-memory index) is rebuilt from the WAL/database, so it is safe to remove once
 		// no other process holds the database.
 		if (File.Exists(shmFile))
-			trySaferDelete(shmFile, "SHM");
-
-		static void trySaferDelete(string file, string label)
-		{
-			try
-			{
-				FileManager.FileUtility.SaferDelete(file);
-			}
-			catch (Exception ex)
-			{
-				Log.Logger.Warning(ex, "Could not delete SQLite {Label} file: {File}", label, file);
-			}
-		}
+			FileManager.FileUtility.TrySaferDelete(shmFile);
 	}
 
 	/// <summary>True if <paramref name="path"/> exists and cannot be opened exclusively, i.e. another process holds it.</summary>

--- a/Source/AppScaffolding/LibationScaffolding.cs
+++ b/Source/AppScaffolding/LibationScaffolding.cs
@@ -113,29 +113,86 @@ public static class LibationScaffolding
 	/// </summary>
 	private static void DeleteOpenSqliteFiles(Configuration config)
 	{
-		var walFile = SqliteStorage.DatabasePath + "-wal";
-		var shmFile = SqliteStorage.DatabasePath + "-shm";
+		var dbFile = SqliteStorage.DatabasePath;
+		var walFile = dbFile + "-wal";
+		var shmFile = dbFile + "-shm";
+
+		// If another Libation process currently has the database open, its WAL/SHM are live state.
+		// Deleting them would corrupt that process's database (and ours), so leave everything alone.
+		// See issue #1931.
+		if (IsFileLockedByAnotherProcess(dbFile))
+		{
+			Log.Logger.Information("Skipping SQLite WAL/SHM cleanup: the database appears to be open in another process.");
+			return;
+		}
+
+		// A non-empty WAL from a previous run that ended abruptly can hold committed-but-uncheckpointed
+		// transactions. Deleting it would silently discard that data; instead, leave it in place and let
+		// SQLite recover it when the database is next opened. Only remove an already-checkpointed WAL.
 		if (File.Exists(walFile))
 		{
-			try
-			{
-				FileManager.FileUtility.SaferDelete(walFile);
-			}
-			catch (Exception ex)
-			{
-				Log.Logger.Warning(ex, "Could not delete SQLite WAL file: {WalFile}", walFile);
-			}
+			if (WalHoldsUnrecoveredTransactions(walFile))
+				Log.Logger.Information("Leaving SQLite WAL in place so SQLite can recover it on open: {WalFile}", walFile);
+			else
+				trySaferDelete(walFile, "WAL");
 		}
+
+		// The SHM (shared-memory index) is rebuilt from the WAL/database, so it is safe to remove once
+		// no other process holds the database.
 		if (File.Exists(shmFile))
+			trySaferDelete(shmFile, "SHM");
+
+		static void trySaferDelete(string file, string label)
 		{
 			try
 			{
-				FileManager.FileUtility.SaferDelete(shmFile);
+				FileManager.FileUtility.SaferDelete(file);
 			}
 			catch (Exception ex)
 			{
-				Log.Logger.Warning(ex, "Could not delete SQLite SHM file: {ShmFile}", shmFile);
+				Log.Logger.Warning(ex, "Could not delete SQLite {Label} file: {File}", label, file);
 			}
+		}
+	}
+
+	/// <summary>True if <paramref name="path"/> exists and cannot be opened exclusively, i.e. another process holds it.</summary>
+	private static bool IsFileLockedByAnotherProcess(string path)
+	{
+		if (!File.Exists(path))
+			return false;
+
+		try
+		{
+			using var _ = new FileStream(path, FileMode.Open, FileAccess.ReadWrite, FileShare.None);
+			return false;
+		}
+		catch (IOException)
+		{
+			return true;
+		}
+		catch (UnauthorizedAccessException)
+		{
+			// Can't prove another process holds it, but we also can't safely touch it. Be conservative.
+			return true;
+		}
+	}
+
+	/// <summary>
+	/// True if the WAL may contain committed transactions SQLite still needs to recover. A WAL longer
+	/// than its 32-byte header may hold frames; treat any such file as unrecovered so it is preserved.
+	/// </summary>
+	private static bool WalHoldsUnrecoveredTransactions(string walFile)
+	{
+		const long walHeaderSize = 32;
+		try
+		{
+			return new FileInfo(walFile).Length > walHeaderSize;
+		}
+		catch (Exception ex)
+		{
+			// If we can't measure it, assume it matters and keep it rather than risk data loss.
+			Log.Logger.Warning(ex, "Could not inspect SQLite WAL file; leaving it in place: {WalFile}", walFile);
+			return true;
 		}
 	}
 	static bool migrationsRun = false;

--- a/Source/AudibleUtilities/AccountsSettings.cs
+++ b/Source/AudibleUtilities/AccountsSettings.cs
@@ -117,7 +117,7 @@ public class AccountsSettings : IUpdatable
 		// only by letter case (e.g. a stored id capitalized differently than settings), which caused
 		// spurious "No account found" failures that blocked every affected book. See issue #1931.
 		return Accounts.SingleOrDefault(a =>
-			string.Equals(a.AccountId, accountId, StringComparison.OrdinalIgnoreCase)
+			a.AccountId.EqualsInsensitive(accountId)
 			&& a.Locale?.Name == locale);
 	}
 

--- a/Source/AudibleUtilities/AccountsSettings.cs
+++ b/Source/AudibleUtilities/AccountsSettings.cs
@@ -113,7 +113,12 @@ public class AccountsSettings : IUpdatable
 		if (locale is null)
 			return null;
 
-		return Accounts.SingleOrDefault(a => a.AccountId == accountId && a.Locale?.Name == locale);
+		// AccountId is compared case-insensitively: Audible/library data has been observed to differ
+		// only by letter case (e.g. a stored id capitalized differently than settings), which caused
+		// spurious "No account found" failures that blocked every affected book. See issue #1931.
+		return Accounts.SingleOrDefault(a =>
+			string.Equals(a.AccountId, accountId, StringComparison.OrdinalIgnoreCase)
+			&& a.Locale?.Name == locale);
 	}
 
 	public bool Delete(string accountId, string locale)

--- a/Source/FileManager/FileSystemTest.cs
+++ b/Source/FileManager/FileSystemTest.cs
@@ -57,15 +57,8 @@ public static class FileSystemTest
 			Serilog.Log.Logger.Debug("Testing ability to write filename: {filename}", filename);
 			File.WriteAllBytes(filename, []);
 			Serilog.Log.Logger.Debug("Deleting test file after successful write: {filename}", filename);
-			try
-			{
-				FileUtility.SaferDelete(filename);
-			}
-			catch (Exception ex)
-			{
-				//An error deleting the file doesn't constitute a write failure.
-				Serilog.Log.Logger.Debug(ex, "Error deleting test file: {filename}", filename);
-			}
+			// An error deleting the file doesn't constitute a write failure.
+			FileUtility.TrySaferDelete(filename);
 			return true;
 		}
 		catch (Exception ex)

--- a/Source/FileManager/FileUtility.cs
+++ b/Source/FileManager/FileUtility.cs
@@ -181,26 +181,49 @@ public static class FileUtility
 
 	/// <summary>Delete file. No error when source does not exist. Retry up to 3 times before throwing exception.</summary>
 	public static void SaferDelete(LongPath source)
-		=> retryPolicy.Execute(() =>
-		{
-			try
-			{
-				if (!File.Exists(source))
-				{
-					Serilog.Log.Logger.Debug("No file to delete: {@DebugText}", new { source });
-					return;
-				}
+		=> retryPolicy.Execute(() => deleteFile(source, logAttemptFailure: true));
 
-				Serilog.Log.Logger.Debug("Attempt to delete file: {@DebugText}", new { source });
-				File.Delete(source);
-				Serilog.Log.Logger.Information("File successfully deleted: {@DebugText}", new { source });
-			}
-			catch (Exception e)
+	/// <summary>
+	/// Delete file, best-effort. No error when source does not exist. Retries up to 3 times and
+	/// returns false instead of throwing when the file cannot be deleted.
+	/// </summary>
+	public static bool TrySaferDelete(LongPath source)
+	{
+		try
+		{
+			retryPolicy.Execute(() => deleteFile(source, logAttemptFailure: false));
+			return true;
+		}
+		catch (Exception ex)
+		{
+			// Unlike SaferDelete, log only once after retries are exhausted. Best-effort cleanup
+			// callers should not produce an error entry for every retry or need their own wrapper.
+			Serilog.Log.Logger.Warning(ex, "Unable to delete file after retries: {@DebugText}", new { source });
+			return false;
+		}
+	}
+
+	private static void deleteFile(LongPath source, bool logAttemptFailure)
+	{
+		try
+		{
+			if (!File.Exists(source))
 			{
-				Serilog.Log.Logger.Error(e, "Failed to delete file: {@DebugText}", new { source });
-				throw;
+				Serilog.Log.Logger.Debug("No file to delete: {@DebugText}", new { source });
+				return;
 			}
-		});
+
+			Serilog.Log.Logger.Debug("Attempt to delete file: {@DebugText}", new { source });
+			File.Delete(source);
+			Serilog.Log.Logger.Information("File successfully deleted: {@DebugText}", new { source });
+		}
+		catch (Exception ex)
+		{
+			if (logAttemptFailure)
+				Serilog.Log.Logger.Error(ex, "Failed to delete file: {@DebugText}", new { source });
+			throw;
+		}
+	}
 
 	/// <summary>Move file. No error when source does not exist. Retry up to 3 times before throwing exception.</summary>
 	public static void SaferMove(LongPath source, LongPath destination)

--- a/Source/LibationAvalonia/App.axaml.cs
+++ b/Source/LibationAvalonia/App.axaml.cs
@@ -26,6 +26,9 @@ namespace LibationAvalonia;
 public class App : Application
 {
 	public static Task<List<DataLayer.LibraryBook>>? LibraryTask { get; set; }
+
+	/// <summary>Set by <see cref="Program"/> when another Libation instance already holds this folder's lock.</summary>
+	public static bool IsAnotherInstanceRunning { get; set; }
 	public static ChardonnayTheme? DefaultThemeColors { get; private set; }
 	public static MainWindow? MainWindow { get; private set; }
 	public static Uri AssetUriBase { get; } = new("avares://Libation/Assets/");
@@ -47,6 +50,15 @@ public class App : Application
 			MessageBoxBase.ShowAsyncImpl = (owner, message, caption, buttons, icon, defaultButton, saveAndRestorePosition) =>
 				MessageBox.Show(owner as Window, message, caption, buttons, icon, defaultButton, saveAndRestorePosition);
 
+			// Another instance already owns this folder. No database work has been done in this process,
+			// so just tell the user and shut down instead of racing on shared files. See issue #1931.
+			if (IsAnotherInstanceRunning)
+			{
+				_ = ShowAlreadyRunningThenShutdownAsync(desktop);
+				base.OnFrameworkInitializationCompleted();
+				return;
+			}
+
 			if (InstallUpgradeManager.TakeStartupRecoveryAlert() is { } recovery)
 				_ = MessageBox.Show(null, recovery.Body, recovery.Title, MessageBoxButtons.OK, MessageBoxIcon.Warning);
 
@@ -66,6 +78,28 @@ public class App : Application
 		}
 
 		base.OnFrameworkInitializationCompleted();
+	}
+
+	private static async Task ShowAlreadyRunningThenShutdownAsync(IClassicDesktopStyleApplicationLifetime desktop)
+	{
+		try
+		{
+			await MessageBox.Show(
+				"Libation is already running.\r\n\r\n"
+					+ "Please use the Libation window that is already open. Running more than one copy of "
+					+ "Libation against the same folder at the same time can corrupt your library.",
+				"Libation is already running",
+				MessageBoxButtons.OK,
+				MessageBoxIcon.Warning);
+		}
+		catch (Exception ex)
+		{
+			Serilog.Log.Logger.Error(ex, "Failed to show the 'already running' message");
+		}
+		finally
+		{
+			desktop.Shutdown();
+		}
 	}
 
 	private static async void RunSetupIfNeededAsync(IClassicDesktopStyleApplicationLifetime desktop, Configuration config)

--- a/Source/LibationAvalonia/App.axaml.cs
+++ b/Source/LibationAvalonia/App.axaml.cs
@@ -147,24 +147,55 @@ public class App : Application
 
 	private static async void MainWindow_Loaded(object? sender, Avalonia.Interactivity.RoutedEventArgs e)
 	{
-		if (LibraryTask is not null && MainWindow is not null)
+		// This is an async void handler: any exception that escapes it becomes an unhandled
+		// exception and crashes Libation. Every path below is caught so that a failure to load
+		// or bind the library degrades to an empty, still-usable grid instead. See issue #1931.
+		if (LibraryTask is null || MainWindow is not { } mainWindow)
+			return;
+
+		try
+		{
+			List<DataLayer.LibraryBook> library = await LibraryTask;
+			await Dispatcher.UIThread.InvokeAsync(() => mainWindow.OnLibraryLoadedAsync(library));
+		}
+		catch (Exception ex) when (StartupAssemblyBootstrap.IsInstallFolderAssemblyLoadFailure(ex))
+		{
+			Serilog.Log.Logger.Error(ex, "Failed to load library at startup");
+			FatalStartupMessage failure = StartupAssemblyBootstrap.GetStartupFailureMessage(ex)!;
+			await MessageBox.Show(
+				mainWindow,
+				failure.Body,
+				failure.Title,
+				MessageBoxButtons.OK,
+				MessageBoxIcon.Error);
+			await showEmptyLibraryAsync();
+		}
+		catch (Exception ex)
+		{
+			// Any other failure loading or binding the library must not take down the whole app.
+			// Log it, tell the user, and continue with an empty grid so Settings, re-scan, etc.
+			// remain reachable.
+			Serilog.Log.Logger.Error(ex, "Failed to load library at startup");
+			await MessageBox.Show(
+				mainWindow,
+				"Libation could not load your library, so the library view will be empty for this session. "
+					+ "Restarting Libation may resolve it. If this keeps happening, your library database or your "
+					+ "computer's memory or disk may be corrupted.",
+				"Error loading library",
+				MessageBoxButtons.OK,
+				MessageBoxIcon.Error);
+			await showEmptyLibraryAsync();
+		}
+
+		async Task showEmptyLibraryAsync()
 		{
 			try
 			{
-				List<DataLayer.LibraryBook> library = await LibraryTask;
-				await Dispatcher.UIThread.InvokeAsync(() => MainWindow.OnLibraryLoadedAsync(library));
+				await Dispatcher.UIThread.InvokeAsync(() => mainWindow.OnLibraryLoadedAsync([]));
 			}
-			catch (Exception ex) when (StartupAssemblyBootstrap.IsInstallFolderAssemblyLoadFailure(ex))
+			catch (Exception ex)
 			{
-				Serilog.Log.Logger.Error(ex, "Failed to load library at startup");
-				FatalStartupMessage failure = StartupAssemblyBootstrap.GetStartupFailureMessage(ex)!;
-				await MessageBox.Show(
-					MainWindow,
-					failure.Body,
-					failure.Title,
-					MessageBoxButtons.OK,
-					MessageBoxIcon.Error);
-				await Dispatcher.UIThread.InvokeAsync(() => MainWindow.OnLibraryLoadedAsync([]));
+				Serilog.Log.Logger.Error(ex, "Failed to show empty library after a library load failure");
 			}
 		}
 	}

--- a/Source/LibationAvalonia/Program.cs
+++ b/Source/LibationAvalonia/Program.cs
@@ -19,6 +19,9 @@ namespace LibationAvalonia;
 static class Program
 {
 	private static System.Threading.Lock SetupLock { get; } = new();
+
+	/// <summary>Held for the lifetime of the process to enforce a single instance per LibationFiles folder.</summary>
+	private static SingleInstance? SingleInstanceLock { get; set; }
 	[STAThread]
 	static void Main(string[] args)
 	{
@@ -54,7 +57,14 @@ static class Program
 		{
 			var config = LibationScaffolding.RunPreConfigMigrations();
 			StartupAssemblyBootstrap.RecoverFromIncompleteUpgradeIfNeeded();
-			if (config.LibationFiles.SettingsAreValid)
+
+			// Prevent a second instance from racing on the same database, search index, and log file.
+			// Hold the lock for the whole process; skip all database access when we are not the first
+			// instance so the running copy's state is never touched. See issue #1931.
+			SingleInstanceLock = SingleInstance.TryAcquire(config.LibationFiles.Location);
+			App.IsAnotherInstanceRunning = !SingleInstanceLock.IsFirstInstance;
+
+			if (SingleInstanceLock.IsFirstInstance && config.LibationFiles.SettingsAreValid)
 			{
 				App.RunMigrations(config);
 				StartupAssemblyBootstrap.PrepareForBackgroundDataAccess();

--- a/Source/LibationAvalonia/ViewModels/MainVM.BackupCounts.cs
+++ b/Source/LibationAvalonia/ViewModels/MainVM.BackupCounts.cs
@@ -72,6 +72,16 @@ partial class MainVM
 
 	private async void UpdateCountsBw_CompletedAsync(object? sender, System.ComponentModel.RunWorkerCompletedEventArgs e)
 	{
+		// Reading e.Result rethrows any exception from UpdateCountsBw_DoWork. Because this is an
+		// async void handler with no SynchronizationContext, that would become an unhandled
+		// exception and crash the app. Check e.Error/e.Cancelled first and degrade gracefully.
+		if (e.Cancelled)
+			return;
+		if (e.Error is not null)
+		{
+			Serilog.Log.Logger.Error(e.Error, "Failed to update backup counts");
+			return;
+		}
 		if (e.Result is not LibraryCommands.LibraryStats stats)
 			return;
 		LibraryStats = stats;

--- a/Source/LibationAvalonia/ViewModels/ProductsDisplayViewModel.cs
+++ b/Source/LibationAvalonia/ViewModels/ProductsDisplayViewModel.cs
@@ -150,7 +150,17 @@ public class ProductsDisplayViewModel : ViewModelBase
 		ArgumentNullException.ThrowIfNull(dbBooks, nameof(dbBooks));
 
 		if (GridEntries == null)
-			throw new InvalidOperationException($"Must call {nameof(BindToGridAsync)} before calling {nameof(UpdateGridAsync)}");
+		{
+			// The initial bind never completed (e.g. a failed library load left GridEntries null).
+			// Rebuild the grid from scratch instead of throwing. Throwing here previously wedged the
+			// grid for the rest of the session and produced a "Library Size Change Error" dialog on
+			// every subsequent auto-scan. See issue #1931. SOURCE is cleared first in case a prior
+			// bind partially populated it; no CollectionChanged handler is attached while GridEntries
+			// is null, so clearing is safe.
+			SOURCE.Clear();
+			await BindToGridAsync(dbBooks);
+			return;
+		}
 
 		//CollectionChanged fires for every book added, and the handler invokes
 		//VisibleCountChanged which triggers Libation to re-count all books.

--- a/Source/LibationCli/Setup.cs
+++ b/Source/LibationCli/Setup.cs
@@ -38,6 +38,17 @@ public static class Setup
 #else
 		LibationScaffolding.RunPostMigrationScaffolding(Variety.Chardonnay, config);
 #endif
+
+		// The CLI remains intentionally unrestricted for scripting and parallel use. However, if a
+		// GUI owns this LibationFiles folder's single-instance lock, record an advisory warning so
+		// concurrent access is visible when diagnosing database/search-index issues.
+		using var guiInstanceCheck = SingleInstance.TryAcquire(config.LibationFiles.Location);
+		if (!guiInstanceCheck.IsFirstInstance)
+		{
+			Serilog.Log.Logger.Warning(
+				"Another Libation GUI instance is running against this LibationFiles folder. "
+				+ "The CLI command will continue, but concurrent writes may conflict.");
+		}
 	}
 
 	static void PrintLibationFilestipAndExit()

--- a/Source/LibationFileManager/AudibleFileStorage.cs
+++ b/Source/LibationFileManager/AudibleFileStorage.cs
@@ -79,7 +79,7 @@ public abstract class AudibleFileStorage
 			if (DecryptInProgressDirectory is not LongPath decryptDir)
 				return;
 			foreach (var tempFile in FileUtility.SaferEnumerateFiles(decryptDir))
-				FileUtility.SaferDelete(tempFile);
+				FileUtility.TrySaferDelete(tempFile);
 		}
 		catch (Exception ex)
 		{

--- a/Source/LibationFileManager/SingleInstance.cs
+++ b/Source/LibationFileManager/SingleInstance.cs
@@ -1,0 +1,87 @@
+using System;
+using System.Security.Cryptography;
+using System.Text;
+using System.Threading;
+
+namespace LibationFileManager;
+
+/// <summary>
+/// Process-wide guard that prevents more than one Libation instance from running against the same
+/// LibationFiles folder at the same time. Concurrent instances race on the SQLite database, the
+/// Lucene search index, and the log file, which can corrupt state (see issue #1931).
+/// <para/>
+/// The lock is keyed on the LibationFiles location, so separate portable installs that use different
+/// folders may still run simultaneously. The returned instance must be kept alive for the lifetime of
+/// the process and disposed at exit. The guard fails open: any error acquiring it is treated as "first
+/// instance" so it can never block startup on its own.
+/// </summary>
+public sealed class SingleInstance : IDisposable
+{
+	private readonly Mutex? _mutex;
+	private readonly bool _hasHandle;
+
+	/// <summary>True if this process acquired the lock (no other instance is running for this folder).</summary>
+	public bool IsFirstInstance => _hasHandle;
+
+	private SingleInstance(Mutex? mutex, bool hasHandle)
+	{
+		_mutex = mutex;
+		_hasHandle = hasHandle;
+	}
+
+	/// <summary>
+	/// Attempts to acquire the single-instance lock for <paramref name="libationFilesLocation"/>.
+	/// </summary>
+	public static SingleInstance TryAcquire(string libationFilesLocation)
+	{
+		Mutex? mutex = null;
+		try
+		{
+			mutex = new Mutex(initiallyOwned: false, buildMutexName(libationFilesLocation));
+
+			bool hasHandle;
+			try
+			{
+				hasHandle = mutex.WaitOne(TimeSpan.Zero, exitContext: false);
+			}
+			catch (AbandonedMutexException)
+			{
+				// The previous owner exited without releasing (e.g. it crashed). Ownership transfers to us.
+				hasHandle = true;
+			}
+
+			return new SingleInstance(mutex, hasHandle);
+		}
+		catch (Exception ex)
+		{
+			// Never let the guard itself prevent startup. Fail open by treating this as the first instance.
+			Serilog.Log.Logger.Warning(ex, "Could not evaluate the single-instance lock; continuing without it.");
+			mutex?.Dispose();
+			return new SingleInstance(null, true);
+		}
+	}
+
+	private static string buildMutexName(string libationFilesLocation)
+	{
+		var normalized = (libationFilesLocation ?? string.Empty).Trim().TrimEnd('/', '\\').ToUpperInvariant();
+		var hash = Convert.ToHexString(SHA256.HashData(Encoding.UTF8.GetBytes(normalized)));
+		// Local (per-session) scope is sufficient: two OS users cannot safely share one files folder,
+		// and each user gets their own default folder. The name must be filesystem-safe and unique per folder.
+		return $"Libation-SingleInstance-{hash}";
+	}
+
+	public void Dispose()
+	{
+		try
+		{
+			if (_hasHandle)
+				_mutex?.ReleaseMutex();
+		}
+		catch
+		{
+			// best effort; the OS releases the handle on process exit regardless
+		}
+
+		_mutex?.Dispose();
+	}
+}

--- a/Source/LibationSearchEngine/SearchEngine.cs
+++ b/Source/LibationSearchEngine/SearchEngine.cs
@@ -134,7 +134,7 @@ public class SearchEngine
 			return;
 
 		foreach (var file in System.IO.Directory.GetFiles(searchEngineDirectory, "*", SearchOption.AllDirectories))
-			FileUtility.SaferDelete(file);
+			FileUtility.TrySaferDelete(file);
 
 		foreach (var dir in System.IO.Directory.GetDirectories(searchEngineDirectory, "*", SearchOption.AllDirectories).OrderByDescending(d => d.Length))
 		{

--- a/Source/LibationWinForms/Form1.BackupCounts.cs
+++ b/Source/LibationWinForms/Form1.BackupCounts.cs
@@ -21,10 +21,28 @@ public partial class Form1
 			=> setBackupCounts(null, null);
 
 		updateCountsBw.DoWork += UpdateCountsBw_DoWork;
+		// Register the error logger first so a failed count is logged exactly once, before the
+		// display handlers below run and (safely) treat the stats as unavailable.
+		updateCountsBw.RunWorkerCompleted += logBackupCountsError;
 		updateCountsBw.RunWorkerCompleted += exportMenuEnable;
 		updateCountsBw.RunWorkerCompleted += updateBottomStats;
 		updateCountsBw.RunWorkerCompleted += update_BeginBookBackups_menuItem;
 		updateCountsBw.RunWorkerCompleted += udpate_BeginPdfOnlyBackups_menuItem;
+	}
+
+	/// <summary>
+	/// Safely extract the completed <see cref="LibraryCommands.LibraryStats"/>. Returns null when the
+	/// background count was cancelled or faulted. Reading <see cref="System.ComponentModel.RunWorkerCompletedEventArgs.Result"/>
+	/// directly rethrows any <see cref="System.ComponentModel.RunWorkerCompletedEventArgs.Error"/>, which would otherwise
+	/// crash the app; callers must degrade gracefully on null.
+	/// </summary>
+	private static LibraryCommands.LibraryStats? getLibraryStats(System.ComponentModel.RunWorkerCompletedEventArgs e)
+		=> e.Cancelled || e.Error is not null ? null : e.Result as LibraryCommands.LibraryStats;
+
+	private static void logBackupCountsError(object? _, System.ComponentModel.RunWorkerCompletedEventArgs e)
+	{
+		if (e.Error is not null)
+			Serilog.Log.Logger.Error(e.Error, "Failed to update backup counts");
 	}
 
 	private bool runBackupCountsAgain;
@@ -48,20 +66,20 @@ public partial class Form1
 
 	private void exportMenuEnable(object? _, System.ComponentModel.RunWorkerCompletedEventArgs e)
 	{
-		var libraryStats = e.Result as LibraryCommands.LibraryStats;
+		var libraryStats = getLibraryStats(e);
 		Invoke(() => exportLibraryToolStripMenuItem.Enabled = libraryStats?.HasBookResults is true);
 	}
 
 	private void updateBottomStats(object? _, System.ComponentModel.RunWorkerCompletedEventArgs e)
 	{
-		var libraryStats = e.Result as LibraryCommands.LibraryStats;
+		var libraryStats = getLibraryStats(e);
 		statusStrip1.UIThreadAsync(() => backupsCountsLbl.Text = libraryStats?.StatusString ?? "ERROR GETTING STATUS");
 	}
 
 	// update 'begin book and pdf backups' menu item
 	private void update_BeginBookBackups_menuItem(object? _, System.ComponentModel.RunWorkerCompletedEventArgs e)
 	{
-		var libraryStats = e.Result as LibraryCommands.LibraryStats;
+		var libraryStats = getLibraryStats(e);
 
 		var menuItemText
 			= libraryStats?.HasPendingBooks is true
@@ -77,7 +95,7 @@ public partial class Form1
 	// update 'begin pdf only backups' menu item
 	private void udpate_BeginPdfOnlyBackups_menuItem(object? _, System.ComponentModel.RunWorkerCompletedEventArgs e)
 	{
-		var libraryStats = e.Result as LibraryCommands.LibraryStats;
+		var libraryStats = getLibraryStats(e);
 
 		var menuItemText
 			= libraryStats?.pdfsNotDownloaded > 0

--- a/Source/LibationWinForms/Form1._NonUI.cs
+++ b/Source/LibationWinForms/Form1._NonUI.cs
@@ -32,7 +32,12 @@ public partial class Form1
 
 	private void tryAutoDownloadAfterCounts(System.ComponentModel.RunWorkerCompletedEventArgs e)
 	{
-		if (!Configuration.Instance.AutoDownloadEpisodes || e.Result is not LibraryCommands.LibraryStats libraryStats)
+		// Guard e.Cancelled/e.Error before reading e.Result: e.Result rethrows a faulted count,
+		// which here (a RunWorkerCompleted handler) would become an unhandled exception.
+		if (!Configuration.Instance.AutoDownloadEpisodes || e.Cancelled || e.Error is not null)
+			return;
+
+		if (e.Result is not LibraryCommands.LibraryStats libraryStats)
 			return;
 
 		if (libraryStats.PendingBooks + libraryStats.pdfsNotDownloaded <= 0)

--- a/Source/LibationWinForms/Program.cs
+++ b/Source/LibationWinForms/Program.cs
@@ -21,6 +21,9 @@ static class Program
 
 	private static Form1? form1;
 
+	/// <summary>Held for the lifetime of the process to enforce a single instance per LibationFiles folder.</summary>
+	private static SingleInstance? singleInstanceLock;
+
 	[STAThread]
 	static void Main()
 	{
@@ -48,6 +51,22 @@ static class Program
 			// Migrations which must occur before configuration is loaded for the first time. Usually ones which alter the Configuration
 			var config = AppScaffolding.LibationScaffolding.RunPreConfigMigrations();
 			StartupAssemblyBootstrap.RecoverFromIncompleteUpgradeIfNeeded();
+
+			// Prevent a second instance from racing on the same database, search index, and log file.
+			// Bail out before any database access when we are not the first instance. See issue #1931.
+			singleInstanceLock = SingleInstance.TryAcquire(config.LibationFiles.Location);
+			if (!singleInstanceLock.IsFirstInstance)
+			{
+				MessageBox.Show(
+					"Libation is already running.\r\n\r\n"
+						+ "Please use the Libation window that is already open. Running more than one copy of "
+						+ "Libation against the same folder at the same time can corrupt your library.",
+					"Libation is already running",
+					MessageBoxButtons.OK,
+					MessageBoxIcon.Warning);
+				return;
+			}
+
 			LibationUiBase.Forms.MessageBoxBase.ShowAsyncImpl = ShowMessageBox;
 			BadBookActionDialogBase.ShowAsyncImpl = ShowBadBookActionDialog;
 

--- a/Source/_Tests/AudibleUtilities.Tests/AccountTests.cs
+++ b/Source/_Tests/AudibleUtilities.Tests/AccountTests.cs
@@ -412,6 +412,21 @@ public class retrieve : AccountsTestBase
 		acct.BeNotNull();
 		acct.AccountName.Should().Be("bar");
 	}
+
+	[TestMethod]
+	public void get_account_id_is_case_insensitive()
+	{
+		var id = new Identity(usLocale);
+		var acct = new Account("HopefulRN2016@Gmail.com") { IdentityTokens = id, AccountName = "foo" };
+
+		var accountsSettings = new AccountsSettings();
+		accountsSettings.Add(acct);
+
+		// stored id differs only by letter case; lookup must still succeed (issue #1931)
+		var found = accountsSettings.GetAccount("hopefulrn2016@gmail.com", "us");
+		found.BeNotNull();
+		found.AccountName.Should().Be("foo");
+	}
 }
 
 [TestClass]

--- a/Source/_Tests/FileManager.Tests/FileUtilityTests.cs
+++ b/Source/_Tests/FileManager.Tests/FileUtilityTests.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.IO;
 using AssertionHelper;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
@@ -243,4 +244,25 @@ public class RemoveLastCharacter
 	[DataRow("123", "12")]
 	public void Tests(string input, string? expected)
 		=> FileUtility.RemoveLastCharacter(input).Should().Be(expected);
+}
+
+[TestClass]
+public class TrySaferDelete
+{
+	[TestMethod]
+	public void deletes_existing_file()
+	{
+		var path = Path.GetTempFileName();
+
+		FileUtility.TrySaferDelete(path).Should().BeTrue();
+		File.Exists(path).Should().BeFalse();
+	}
+
+	[TestMethod]
+	public void missing_file_is_success()
+	{
+		var path = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString("N"));
+
+		FileUtility.TrySaferDelete(path).Should().BeTrue();
+	}
 }

--- a/Source/_Tests/LibationFileManager.Tests/SingleInstanceTests.cs
+++ b/Source/_Tests/LibationFileManager.Tests/SingleInstanceTests.cs
@@ -1,0 +1,109 @@
+using LibationFileManager;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.IO;
+using System.Threading;
+
+namespace LibationFileManager.Tests;
+
+[TestClass]
+public class SingleInstanceTests
+{
+	private static string UniqueLocation() => Path.Combine(Path.GetTempPath(), "Libation-SI-" + Guid.NewGuid().ToString("N"));
+
+	/// <summary>
+	/// Acquire and hold the lock on a dedicated background thread. A named mutex is owned per-thread and
+	/// is reentrant on its owning thread, so a "different instance" must be simulated from another thread
+	/// (which mirrors the real cross-process case). The returned action releases the lock and joins.
+	/// </summary>
+	private static (bool isFirstInstance, Action release) HoldOnBackgroundThread(string location)
+	{
+		var acquired = new ManualResetEventSlim();
+		var release = new ManualResetEventSlim();
+		var isFirst = false;
+
+		var thread = new Thread(() =>
+		{
+			using var instance = SingleInstance.TryAcquire(location);
+			isFirst = instance.IsFirstInstance;
+			acquired.Set();
+			release.Wait();
+		})
+		{ IsBackground = true };
+
+		thread.Start();
+		acquired.Wait();
+
+		return (isFirst, () => { release.Set(); thread.Join(); });
+	}
+
+	[TestMethod]
+	public void first_acquire_is_first_instance()
+	{
+		using var first = SingleInstance.TryAcquire(UniqueLocation());
+		Assert.IsTrue(first.IsFirstInstance);
+	}
+
+	[TestMethod]
+	public void second_acquire_same_location_is_not_first_instance()
+	{
+		var location = UniqueLocation();
+
+		var (heldIsFirst, release) = HoldOnBackgroundThread(location);
+		try
+		{
+			Assert.IsTrue(heldIsFirst);
+
+			using var second = SingleInstance.TryAcquire(location);
+			Assert.IsFalse(second.IsFirstInstance);
+		}
+		finally
+		{
+			release();
+		}
+	}
+
+	[TestMethod]
+	public void different_locations_both_get_first_instance()
+	{
+		using var a = SingleInstance.TryAcquire(UniqueLocation());
+		using var b = SingleInstance.TryAcquire(UniqueLocation());
+
+		Assert.IsTrue(a.IsFirstInstance);
+		Assert.IsTrue(b.IsFirstInstance);
+	}
+
+	[TestMethod]
+	public void releasing_allows_a_new_first_instance()
+	{
+		var location = UniqueLocation();
+
+		var (heldIsFirst, release) = HoldOnBackgroundThread(location);
+		Assert.IsTrue(heldIsFirst);
+		// release the first owner, then a fresh acquire should succeed
+		release();
+
+		using var next = SingleInstance.TryAcquire(location);
+		Assert.IsTrue(next.IsFirstInstance);
+	}
+
+	[TestMethod]
+	public void location_matching_ignores_trailing_separator_and_case()
+	{
+		var baseDir = UniqueLocation();
+
+		var (heldIsFirst, release) = HoldOnBackgroundThread(baseDir);
+		try
+		{
+			Assert.IsTrue(heldIsFirst);
+
+			// same folder expressed with a trailing separator and different case must map to the same lock
+			using var second = SingleInstance.TryAcquire(baseDir.ToUpperInvariant() + Path.DirectorySeparatorChar);
+			Assert.IsFalse(second.IsFirstInstance);
+		}
+		finally
+		{
+			release();
+		}
+	}
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Diagnosis and hardening for [#1931](https://github.com/rmcrackan/Libation/issues/1931) ("Crashing Libation").

The reporter's ~30 crashes all happen at the same spot: loading the library at startup. The underlying exceptions are CLR-level impossibilities that vary run to run (e.g. `BadImageFormatException`, `EntryPointNotFoundException`, casts between unrelated EF types, a null EF identity-map dictionary, a CNG decryption failure), which points at memory/disk corruption on that machine rather than a Libation logic bug. That root cause is not fixable in code, but Libation was converting every such failure into a hard crash instead of degrading. This PR fixes the parts Libation controls so a bad library load leaves the app usable, and addresses several secondary issues surfaced by the logs.

## Changes

- **BackgroundWorker result guard.** `RunWorkerCompletedEventArgs.Result` rethrows any exception from the count `DoWork`. In the Avalonia `async void` completion handler that became an unhandled exception and crashed the app. Now `e.Cancelled`/`e.Error` are checked first (Avalonia and the five WinForms handlers), logging once and degrading to empty stats.
- **Recoverable startup.** `App.MainWindow_Loaded` is `async void` and previously only caught install-folder assembly failures; anything else escaped and killed the app. Added a general fallback catch that logs, shows a non-fatal message, and continues with an empty grid. The empty-library fallback is itself wrapped so it can never throw.
- **Grid no longer wedges.** When an initial bind fails, `GridEntries` stayed null and every later auto-scan threw `Must call BindToGridAsync before calling UpdateGridAsync`, producing repeated "Library Size Change Error" dialogs. `UpdateGridAsync` now rebuilds the grid instead of throwing.
- **Single-instance guard.** New `SingleInstance` (named mutex keyed on the LibationFiles folder), wired into Avalonia and WinForms startup. A second GUI launch shows a message and exits before any database access, instead of racing on the SQLite DB, Lucene index, and log file (all observed in the logs). Separate portable folders may still run concurrently. CLI commands remain unrestricted; when a CLI detects a GUI holding the same lock it records an advisory warning and continues.
- **Data-safe SQLite WAL/SHM cleanup.** `DeleteOpenSqliteFiles` previously deleted `LibationContext.db-wal`/`-shm` unconditionally, discarding committed-but-uncheckpointed transactions after an abrupt exit. It now skips cleanup when the DB is held by another process and preserves a non-empty WAL so SQLite can recover it on open.
- **Central best-effort deletion.** Added `FileUtility.TrySaferDelete`, which retries without throwing, logs one warning only after retries are exhausted, and returns success/failure. SQLite cleanup now uses it instead of a local wrapper. Existing non-fatal cleanup in filesystem capability tests, partial-decrypt startup cleanup, and search-index rebuilding also use it, so one locked file no longer aborts cleanup of the remaining files.
- **Case-insensitive account lookup.** `AccountsSettings.GetAccount` compared `AccountId` case-sensitively; the reporter's stored id differed only by letter case, causing ~1,200 spurious `No account found` errors. It now uses Dinah.Core's `EqualsInsensitive` extension.

## Testing

All seven cross-platform test projects pass on Linux (.NET 10):

- `LibationFileManager.Tests`: 616 passed / 21 skipped (Windows-only), including 5 new `SingleInstanceTests`.
- `AudibleUtilities.Tests`: 73 passed / 2 skipped, including a new case-insensitive `GetAccount` test.
- `FileManager.Tests`: 204 passed, including 2 new `TrySaferDelete` tests.
- `ApplicationServices` (46), `FileLiberator` (8), `LibationSearchEngine` (40), `LibationUiBase` (32): all passed.

`LibationAvalonia` and `LibationCli` build cleanly. `LibationWinForms` targets `net10.0-windows` and cannot be built on Linux; its edits mirror the compiled Avalonia changes.

## Notes

- The crashes' root cause (machine memory/disk corruption) is not addressed by code; the issue reply asks the reporter for `LibationCrash.log` and Event Viewer `.NET Runtime`/`Application Error` entries and recommends Windows Memory Diagnostic and `chkdsk`.
- GUI single-instance handling shows a message and exits rather than focusing the existing window (cross-process window activation was out of scope); the key goal is preventing the shared-file race.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ade49b14-dba7-44c1-a480-95089699b47d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ade49b14-dba7-44c1-a480-95089699b47d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

