### PR TITLE
Draft: remove legacy abs-upload CLI alias

### DIFF
--- a/Source/FileLiberator/UploadToAudiobookshelf.cs
+++ b/Source/FileLiberator/UploadToAudiobookshelf.cs
@@ -15,6 +15,27 @@ public class UploadToAudiobookshelf : Processable, IProcessable<UploadToAudioboo
 {
 	public override string Name => "Upload to Audiobookshelf";
 
+	public enum UploadOutcome { Uploaded, AlreadyExists, NoFilesFound, Failed }
+
+	public sealed class UploadOutcomeEventArgs(UploadOutcome outcome, string message) : EventArgs
+	{
+		public UploadOutcome Outcome { get; } = outcome;
+		public string Message { get; } = message;
+	}
+
+	/// <summary>
+	/// Raised exactly once per processed book, classifying what happened and why.
+	/// <para/>
+	/// Upload failures are reported here rather than through the returned <see cref="StatusHandler"/>.
+	/// A non-success StatusHandler marks the book as a bad book: the GUI process queue breaks its step
+	/// loop and raises the Abort/Retry/Ignore dialog. Uploading is a courtesy step layered onto
+	/// liberation and must never fail the book, so <see cref="ProcessAsync"/> always reports success.
+	/// </summary>
+	public event EventHandler<UploadOutcomeEventArgs>? OutcomeDetermined;
+
+	private void OnOutcomeDetermined(UploadOutcome outcome, string message)
+		=> OutcomeDetermined?.Invoke(this, new UploadOutcomeEventArgs(outcome, message));
+
 	public override bool Validate(LibraryBook libraryBook)
 	{
 		if (!Configuration.AudiobookshelfEnabled)
@@ -26,7 +47,9 @@ public class UploadToAudiobookshelf : Processable, IProcessable<UploadToAudioboo
 			|| string.IsNullOrWhiteSpace(Configuration.AudiobookshelfFolderId))
 			return false;
 
-		return libraryBook.Book.AudioExists;
+		// Deliberately narrower than Book.AudioExists, which also accepts LiberatedStatus.Error.
+		// An errored liberation may have left partial files; uploading those is worse than skipping.
+		return libraryBook.Book.UserDefinedItem.BookStatus == LiberatedStatus.Liberated;
 	}
 
 	public override async Task<StatusHandler> ProcessAsync(LibraryBook libraryBook)
@@ -37,7 +60,10 @@ public class UploadToAudiobookshelf : Processable, IProcessable<UploadToAudioboo
 			var files = GetFilesToUpload(libraryBook);
 			if (files.Count == 0)
 			{
-				OnStatusUpdate("No audio files found to upload");
+				const string message = "No audio files found on disk to upload";
+				OnStatusUpdate(message);
+				Serilog.Log.Logger.Error("No audio files found on disk to upload for {Book}", libraryBook.LogFriendly());
+				OnOutcomeDetermined(UploadOutcome.NoFilesFound, message);
 				return new StatusHandler();
 			}
 
@@ -59,20 +85,26 @@ public class UploadToAudiobookshelf : Processable, IProcessable<UploadToAudioboo
 
 			if (result == AudiobookshelfApiService.UploadResult.Success)
 			{
-				OnStatusUpdate("Upload to Audiobookshelf completed successfully");
+				const string message = "Upload to Audiobookshelf completed successfully";
+				OnStatusUpdate(message);
+				OnOutcomeDetermined(UploadOutcome.Uploaded, message);
 				return new StatusHandler();
 			}
 			else if (result == AudiobookshelfApiService.UploadResult.AlreadyExists)
 			{
-				OnStatusUpdate("Book already exists on Audiobookshelf; skipping upload");
+				const string message = "Book already exists on Audiobookshelf; skipping upload";
+				OnStatusUpdate(message);
 				Serilog.Log.Logger.Information("Book already exists on Audiobookshelf, skipping upload: {Book}", libraryBook.LogFriendly());
+				OnOutcomeDetermined(UploadOutcome.AlreadyExists, message);
 				return new StatusHandler();
 			}
 			else
 			{
-				OnStatusUpdate("Upload to Audiobookshelf failed; book remains liberated on disk");
+				const string message = "Upload to Audiobookshelf failed; book remains liberated on disk";
+				OnStatusUpdate(message);
 				Serilog.Log.Logger.Error("Audiobookshelf upload failed for {Book}, but continuing as soft-failure", libraryBook.LogFriendly());
 				// Soft-fail: log the error but do not mark the book as failed
+				OnOutcomeDetermined(UploadOutcome.Failed, message + ". See log for details.");
 				return new StatusHandler();
 			}
 		}
@@ -81,6 +113,7 @@ public class UploadToAudiobookshelf : Processable, IProcessable<UploadToAudioboo
 			Serilog.Log.Logger.Error(ex, "Error uploading {Book} to Audiobookshelf; continuing as soft-failure", libraryBook.LogFriendly());
 			OnStatusUpdate($"Audiobookshelf upload error: {ex.Message}");
 			// Soft-fail: log the error but do not mark the book as failed
+			OnOutcomeDetermined(UploadOutcome.Failed, $"Audiobookshelf upload error: {ex.Message}");
 			return new StatusHandler();
 		}
 		finally
@@ -89,38 +122,55 @@ public class UploadToAudiobookshelf : Processable, IProcessable<UploadToAudioboo
 		}
 	}
 
-	private static List<string> GetFilesToUpload(LibraryBook libraryBook)
-	{
-		var files = new List<string>();
-		var productId = libraryBook.Book.AudibleProductId;
+	/// <summary>
+	/// Resolves a book's audio files by both the path cache and a live scan of the Books directory.
+	/// <para/>
+	/// Must not use <see cref="FilePathCache"/> alone. A book can be liberated - and so pass
+	/// <see cref="Validate"/>, which reads a database status - while having no cache entry at all.
+	/// </summary>
+	internal static List<string> GetAudioFilesOnDisk(string productId)
+		=> AudibleFileStorage.Audio.GetPaths(productId)
+		.Select(p => (string)p)
+		.Where(File.Exists)
+		.ToList();
 
-		// Get audio files from cache
-		var audioFiles = FilePathCache.GetFiles(productId)
-			.Where(f => f.fileType == FileType.Audio && File.Exists(f.path))
-			.Select(f => (string)f.path)
+	/// <summary>
+	/// Composes the final upload payload: de-duplicated audio files, followed by cover art at most once.
+	/// </summary>
+	internal static List<string> BuildUploadFileList(IEnumerable<string> audioPaths, string? coverPath)
+	{
+		var files = audioPaths
+			.Where(p => !string.IsNullOrWhiteSpace(p))
 			.Distinct()
+			.Where(p => !string.Equals(p, coverPath, StringComparison.Ordinal))
 			.ToList();
 
-		files.AddRange(audioFiles);
-
-		// Use Libation's known cover art output path (same logic as DownloadDecryptBook.DownloadCoverArt)
-		if (audioFiles.FirstOrDefault() is { } firstAudioFile)
-		{
-			var dir = Path.GetDirectoryName(firstAudioFile);
-			if (dir is not null)
-			{
-				var coverPath = AudibleFileStorage.Audio.GetCustomDirFilename(
-					libraryBook,
-					dir,
-					".jpg",
-					returnFirstExisting: false);
-
-				if (File.Exists(coverPath))
-					files.Add(coverPath);
-			}
-		}
+		if (!string.IsNullOrWhiteSpace(coverPath))
+			files.Add(coverPath);
 
 		return files;
+	}
+
+	internal static List<string> GetFilesToUpload(LibraryBook libraryBook)
+	{
+		var audioFiles = GetAudioFilesOnDisk(libraryBook.Book.AudibleProductId);
+
+		return BuildUploadFileList(audioFiles, GetCoverArtPath(libraryBook, audioFiles.FirstOrDefault()));
+	}
+
+	/// <summary>Libation's known cover art output path. Same logic as DownloadDecryptBook.DownloadCoverArt.</summary>
+	private static string? GetCoverArtPath(LibraryBook libraryBook, string? firstAudioFile)
+	{
+		if (firstAudioFile is null || Path.GetDirectoryName(firstAudioFile) is not string dir)
+			return null;
+
+		var coverPath = AudibleFileStorage.Audio.GetCustomDirFilename(
+			libraryBook,
+			dir,
+			".jpg",
+			returnFirstExisting: false);
+
+		return File.Exists(coverPath) ? coverPath : null;
 	}
 
 	public static UploadToAudiobookshelf Create(Configuration config) => new() { Configuration = config };

--- a/Source/FileLiberator/UploadToAudiobookshelf.cs
+++ b/Source/FileLiberator/UploadToAudiobookshelf.cs
@@ -62,7 +62,7 @@ public class UploadToAudiobookshelf : Processable, IProcessable<UploadToAudioboo
 			{
 				const string message = "No audio files found on disk to upload";
 				OnStatusUpdate(message);
-				Serilog.Log.Logger.Error("No audio files found on disk to upload for {Book}", libraryBook.LogFriendly());
+				Serilog.Log.Logger.Warning("No audio files found on disk to upload for {Book}", libraryBook.LogFriendly());
 				OnOutcomeDetermined(UploadOutcome.NoFilesFound, message);
 				return new StatusHandler();
 			}
@@ -135,13 +135,27 @@ public class UploadToAudiobookshelf : Processable, IProcessable<UploadToAudioboo
 		.ToList();
 
 	/// <summary>
-	/// Composes the final upload payload: de-duplicated audio files, followed by cover art at most once.
+	/// Composes the final upload payload from one preferred audio format, in deterministic order,
+	/// followed by cover art at most once.
 	/// </summary>
 	internal static List<string> BuildUploadFileList(IEnumerable<string> audioPaths, string? coverPath)
 	{
-		var files = audioPaths
+		var audioFiles = audioPaths
 			.Where(p => !string.IsNullOrWhiteSpace(p))
-			.Distinct()
+			.Distinct(StringComparer.Ordinal)
+			.ToList();
+
+		var m4bFiles = audioFiles
+			.Where(p => p.EndsWith(".m4b", StringComparison.OrdinalIgnoreCase))
+			.ToList();
+		var preferredAudioFiles = m4bFiles.Count > 0
+			? m4bFiles
+			: audioFiles.Any(p => p.EndsWith(".mp3", StringComparison.OrdinalIgnoreCase))
+				? audioFiles.Where(p => p.EndsWith(".mp3", StringComparison.OrdinalIgnoreCase)).ToList()
+				: audioFiles;
+
+		var files = preferredAudioFiles
+			.OrderBy(p => p, StringComparer.Ordinal)
 			.Where(p => !string.Equals(p, coverPath, StringComparison.Ordinal))
 			.ToList();
 

--- a/Source/FileLiberator/_InternalsVisible.cs
+++ b/Source/FileLiberator/_InternalsVisible.cs
@@ -1,0 +1,1 @@
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo(nameof(FileLiberator) + ".Tests")]

--- a/Source/Libation.slnx
+++ b/Source/Libation.slnx
@@ -66,6 +66,7 @@
     <Project Path="_Tests/AudibleUtilities.Tests/AudibleUtilities.Tests.csproj" />
     <Project Path="_Tests/FileLiberator.Tests/FileLiberator.Tests.csproj" />
     <Project Path="_Tests/FileManager.Tests/FileManager.Tests.csproj" />
+    <Project Path="_Tests/LibationCli.Tests/LibationCli.Tests.csproj" />
     <Project Path="_Tests/LibationFileManager.Tests/LibationFileManager.Tests.csproj" />
     <Project Path="_Tests/LibationSearchEngine.Tests/LibationSearchEngine.Tests.csproj" />
     <Project Path="_Tests/LibationUiBase.Tests/LibationUiBase.Tests.csproj" />

--- a/Source/LibationCli/CliCommandGroups.cs
+++ b/Source/LibationCli/CliCommandGroups.cs
@@ -10,7 +10,7 @@ internal static class CliCommandGroups
 			"abs",
 			"Audiobookshelf commands.",
 			[
-				new("upload", "abs-upload", "Upload liberated audiobooks to Audiobookshelf."),
+				new("upload", "upload", "Upload liberated audiobooks to Audiobookshelf.", typeof(AbsUploadOptions)),
 			]),
 	];
 }

--- a/Source/LibationCli/CliCommandGroups.cs
+++ b/Source/LibationCli/CliCommandGroups.cs
@@ -1,0 +1,16 @@
+using System.Collections.Generic;
+
+namespace LibationCli;
+
+internal static class CliCommandGroups
+{
+	public static IReadOnlyList<CliCommandGroup> All { get; } =
+	[
+		new(
+			"abs",
+			"Audiobookshelf commands.",
+			[
+				new("upload", "abs-upload", "Upload liberated audiobooks to Audiobookshelf."),
+			]),
+	];
+}

--- a/Source/LibationCli/CliCommandRouter.cs
+++ b/Source/LibationCli/CliCommandRouter.cs
@@ -1,0 +1,42 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace LibationCli;
+
+internal enum CliRouteKind
+{
+	PassThrough,
+	GroupHelp,
+	RewrittenCommand,
+	UnknownSubcommand,
+}
+
+internal sealed record CliRoute(CliRouteKind Kind, string[] ParserArgs, CliCommandGroup? Group);
+
+internal sealed record CliSubcommand(string Name, string FlatVerb, string HelpText);
+
+internal sealed record CliCommandGroup(string Name, string HelpText, IReadOnlyList<CliSubcommand> Subcommands);
+
+internal static class CliCommandRouter
+{
+	public static CliRoute Route(string[] args, IReadOnlyList<CliCommandGroup> groups)
+	{
+		var group = groups.FirstOrDefault(group => group.Name == args.FirstOrDefault());
+		if (group is null)
+			return new(CliRouteKind.PassThrough, args, null);
+
+		if (args.Length == 1)
+			return new(CliRouteKind.GroupHelp, args, group);
+
+		var subcommand = group.Subcommands.FirstOrDefault(subcommand => subcommand.Name == args[1]);
+		if (subcommand is null)
+			return new(CliRouteKind.UnknownSubcommand, args, group);
+
+		var parserArgs = new string[args.Length - 1];
+		parserArgs[0] = subcommand.FlatVerb;
+		Array.Copy(args, 2, parserArgs, 1, parserArgs.Length - 1);
+
+		return new(CliRouteKind.RewrittenCommand, parserArgs, group);
+	}
+}

--- a/Source/LibationCli/CliCommandRouter.cs
+++ b/Source/LibationCli/CliCommandRouter.cs
@@ -22,11 +22,18 @@ internal static class CliCommandRouter
 {
 	public static CliRoute Route(string[] args, IReadOnlyList<CliCommandGroup> groups)
 	{
+		if (args.Length == 2 && args[0] == "help")
+		{
+			var helpGroup = groups.FirstOrDefault(group => group.Name == args[1]);
+			if (helpGroup is not null)
+				return new(CliRouteKind.GroupHelp, args, helpGroup);
+		}
+
 		var group = groups.FirstOrDefault(group => group.Name == args.FirstOrDefault());
 		if (group is null)
 			return new(CliRouteKind.PassThrough, args, null);
 
-		if (args.Length == 1)
+		if (args.Length == 1 || (args.Length == 2 && args[1] == "--help"))
 			return new(CliRouteKind.GroupHelp, args, group);
 
 		var subcommand = group.Subcommands.FirstOrDefault(subcommand => subcommand.Name == args[1]);

--- a/Source/LibationCli/CliCommandRouter.cs
+++ b/Source/LibationCli/CliCommandRouter.cs
@@ -12,9 +12,9 @@ internal enum CliRouteKind
 	UnknownSubcommand,
 }
 
-internal sealed record CliRoute(CliRouteKind Kind, string[] ParserArgs, CliCommandGroup? Group);
+internal sealed record CliRoute(CliRouteKind Kind, string[] ParserArgs, CliCommandGroup? Group, CliSubcommand? Subcommand = null);
 
-internal sealed record CliSubcommand(string Name, string FlatVerb, string HelpText);
+internal sealed record CliSubcommand(string Name, string ParserVerb, string HelpText, Type OptionsType);
 
 internal sealed record CliCommandGroup(string Name, string HelpText, IReadOnlyList<CliSubcommand> Subcommands);
 
@@ -27,7 +27,7 @@ internal static class CliCommandRouter
 			var nestedHelpGroup = groups.FirstOrDefault(group => group.Name == args[1]);
 			var nestedHelpSubcommand = nestedHelpGroup?.Subcommands.FirstOrDefault(subcommand => subcommand.Name == args[2]);
 			if (nestedHelpSubcommand is not null)
-				return new(CliRouteKind.RewrittenCommand, ["help", nestedHelpSubcommand.FlatVerb], nestedHelpGroup);
+				return new(CliRouteKind.RewrittenCommand, [nestedHelpSubcommand.ParserVerb, "--help"], nestedHelpGroup, nestedHelpSubcommand);
 		}
 
 		if (args.Length == 2 && args[0] == "help")
@@ -49,9 +49,9 @@ internal static class CliCommandRouter
 			return new(CliRouteKind.UnknownSubcommand, args, group);
 
 		var parserArgs = new string[args.Length - 1];
-		parserArgs[0] = subcommand.FlatVerb;
+		parserArgs[0] = subcommand.ParserVerb;
 		Array.Copy(args, 2, parserArgs, 1, parserArgs.Length - 1);
 
-		return new(CliRouteKind.RewrittenCommand, parserArgs, group);
+		return new(CliRouteKind.RewrittenCommand, parserArgs, group, subcommand);
 	}
 }

--- a/Source/LibationCli/CliCommandRouter.cs
+++ b/Source/LibationCli/CliCommandRouter.cs
@@ -22,6 +22,14 @@ internal static class CliCommandRouter
 {
 	public static CliRoute Route(string[] args, IReadOnlyList<CliCommandGroup> groups)
 	{
+		if (args.Length == 3 && args[0] == "help")
+		{
+			var nestedHelpGroup = groups.FirstOrDefault(group => group.Name == args[1]);
+			var nestedHelpSubcommand = nestedHelpGroup?.Subcommands.FirstOrDefault(subcommand => subcommand.Name == args[2]);
+			if (nestedHelpSubcommand is not null)
+				return new(CliRouteKind.RewrittenCommand, ["help", nestedHelpSubcommand.FlatVerb], nestedHelpGroup);
+		}
+
 		if (args.Length == 2 && args[0] == "help")
 		{
 			var helpGroup = groups.FirstOrDefault(group => group.Name == args[1]);

--- a/Source/LibationCli/HelpVerb.cs
+++ b/Source/LibationCli/HelpVerb.cs
@@ -26,6 +26,16 @@ internal class HelpVerb
 		MaximumDisplayWidth = 80
 	};
 
+	public static HelpText GetGroupHelpText(CliCommandGroup group)
+	{
+		var helpText = CreateHelpText();
+		helpText.AddPreOptionsLine(group.HelpText);
+		helpText.AddPreOptionsLine($"{group.Name} commands:");
+		foreach (var subcommand in group.Subcommands)
+			helpText.AddPreOptionsLine($"  {group.Name} {subcommand.Name}  {subcommand.HelpText}");
+		return helpText;
+	}
+
 	/// <summary>
 	/// Get the <see cref="HelpType"/>'s <see cref="HelpText"/>
 	/// </summary>

--- a/Source/LibationCli/Options/UploadOptions.cs
+++ b/Source/LibationCli/Options/UploadOptions.cs
@@ -8,7 +8,7 @@ using System.Threading.Tasks;
 
 namespace LibationCli;
 
-[Verb("abs-upload", HelpText = "Upload already-liberated books to Audiobookshelf. Default: all liberated titles.\n"
+[Verb("upload", HelpText = "Upload already-liberated books to Audiobookshelf. Default: all liberated titles.\n"
 	+ "Optional: specify product id(s) via --id or positional ASIN(s).\n"
 	+ "Books are never re-downloaded and local files are never deleted.")]
 public class AbsUploadOptions : ProcessableOptionsBase

--- a/Source/LibationCli/Options/UploadOptions.cs
+++ b/Source/LibationCli/Options/UploadOptions.cs
@@ -1,0 +1,96 @@
+using CommandLine;
+using FileLiberator;
+using LibationFileManager;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace LibationCli;
+
+[Verb("upload", HelpText = "Upload already-liberated books to Audiobookshelf. Default: all liberated titles whose audio is on disk.\n"
+	+ "Optional: specify product id(s) via --id or positional ASIN(s) to upload those book(s).\n"
+	+ "Books are never re-downloaded and local files are never deleted.")]
+public class UploadOptions : ProcessableOptionsBase
+{
+	protected override async Task ProcessAsync()
+	{
+		if (AudibleFileStorage.BooksDirectory is null)
+		{
+			Console.Error.WriteLine("Error: Books directory is not set. Please configure the 'Books' setting in Settings.json.");
+			return;
+		}
+
+		var configErrors = GetAudiobookshelfConfigurationErrors();
+		if (configErrors.Count > 0)
+		{
+			Console.Error.WriteLine("Audiobookshelf is not fully configured:");
+			foreach (var error in configErrors)
+				Console.Error.WriteLine("  " + error);
+			Console.Error.WriteLine();
+			Console.Error.WriteLine("Set these under Settings -> Audiobookshelf in the main Libation app, then retry.");
+			return;
+		}
+
+		var outcomes = new Dictionary<UploadToAudiobookshelf.UploadOutcome, int>();
+
+		var uploader = CreateProcessable<UploadToAudiobookshelf>();
+
+		// Failures arrive here rather than through StatusHandler: an upload problem must never mark
+		// the book as a bad book. See UploadToAudiobookshelf.OutcomeDetermined.
+		uploader.OutcomeDetermined += (_, e) =>
+		{
+			outcomes[e.Outcome] = outcomes.GetValueOrDefault(e.Outcome) + 1;
+
+			if (e.Outcome is UploadToAudiobookshelf.UploadOutcome.Failed or UploadToAudiobookshelf.UploadOutcome.NoFilesFound)
+				Console.Error.WriteLine(e.Message);
+		};
+
+		// RunAsync invokes this per candidate book, before processing. Books rejected by Validate on a
+		// targeted run never reach ProcessAsync and so raise no outcome; counting here lets the summary
+		// account for them instead of silently omitting them.
+		var candidates = 0;
+		await RunAsync(uploader, _ => candidates++);
+
+		PrintSummary(outcomes, candidates);
+	}
+
+	/// <summary>
+	/// Without this check every book fails <see cref="UploadToAudiobookshelf.Validate"/> and the
+	/// run looks like a silent no-op.
+	/// </summary>
+	private static List<string> GetAudiobookshelfConfigurationErrors()
+	{
+		var config = Configuration.Instance;
+		var errors = new List<string>();
+
+		if (!config.AudiobookshelfEnabled)
+			errors.Add("Audiobookshelf upload is turned off.");
+		if (string.IsNullOrWhiteSpace(config.AudiobookshelfServerUrl))
+			errors.Add("Server URL is not set.");
+		if (string.IsNullOrWhiteSpace(config.AudiobookshelfApiToken))
+			errors.Add("API token is not set.");
+		if (string.IsNullOrWhiteSpace(config.AudiobookshelfLibraryId))
+			errors.Add("No library is selected.");
+		if (string.IsNullOrWhiteSpace(config.AudiobookshelfFolderId))
+			errors.Add("No folder is selected.");
+
+		return errors;
+	}
+
+	private static void PrintSummary(Dictionary<UploadToAudiobookshelf.UploadOutcome, int> outcomes, int candidates)
+	{
+		int count(UploadToAudiobookshelf.UploadOutcome outcome) => outcomes.GetValueOrDefault(outcome);
+
+		// Anything counted as a candidate but never processed was rejected before ProcessAsync ran.
+		var skipped = int.Max(0, candidates - outcomes.Values.Sum());
+
+		Console.WriteLine();
+		Console.WriteLine("Audiobookshelf upload summary:");
+		Console.WriteLine($"  uploaded:          {count(UploadToAudiobookshelf.UploadOutcome.Uploaded)}");
+		Console.WriteLine($"  already on server: {count(UploadToAudiobookshelf.UploadOutcome.AlreadyExists)}");
+		Console.WriteLine($"  no files found:    {count(UploadToAudiobookshelf.UploadOutcome.NoFilesFound)}");
+		Console.WriteLine($"  failed:            {count(UploadToAudiobookshelf.UploadOutcome.Failed)}");
+		Console.WriteLine($"  skipped:           {skipped}");
+	}
+}

--- a/Source/LibationCli/Options/UploadOptions.cs
+++ b/Source/LibationCli/Options/UploadOptions.cs
@@ -8,10 +8,10 @@ using System.Threading.Tasks;
 
 namespace LibationCli;
 
-[Verb("upload", HelpText = "Upload already-liberated books to Audiobookshelf. Default: all liberated titles whose audio is on disk.\n"
-	+ "Optional: specify product id(s) via --id or positional ASIN(s) to upload those book(s).\n"
+[Verb("abs-upload", HelpText = "Upload already-liberated books to Audiobookshelf. Default: all liberated titles.\n"
+	+ "Optional: specify product id(s) via --id or positional ASIN(s).\n"
 	+ "Books are never re-downloaded and local files are never deleted.")]
-public class UploadOptions : ProcessableOptionsBase
+public class AbsUploadOptions : ProcessableOptionsBase
 {
 	protected override async Task ProcessAsync()
 	{
@@ -50,9 +50,10 @@ public class UploadOptions : ProcessableOptionsBase
 		// targeted run never reach ProcessAsync and so raise no outcome; counting here lets the summary
 		// account for them instead of silently omitting them.
 		var candidates = 0;
-		await RunAsync(uploader, _ => candidates++);
+		var notFound = 0;
+		await RunAsync(uploader, _ => candidates++, _ => notFound++);
 
-		PrintSummary(outcomes, candidates);
+		PrintSummary(outcomes, candidates, notFound);
 	}
 
 	/// <summary>
@@ -78,12 +79,12 @@ public class UploadOptions : ProcessableOptionsBase
 		return errors;
 	}
 
-	private static void PrintSummary(Dictionary<UploadToAudiobookshelf.UploadOutcome, int> outcomes, int candidates)
+	private static void PrintSummary(Dictionary<UploadToAudiobookshelf.UploadOutcome, int> outcomes, int candidates, int notFound)
 	{
 		int count(UploadToAudiobookshelf.UploadOutcome outcome) => outcomes.GetValueOrDefault(outcome);
 
 		// Anything counted as a candidate but never processed was rejected before ProcessAsync ran.
-		var skipped = int.Max(0, candidates - outcomes.Values.Sum());
+		var skipped = notFound + int.Max(0, candidates - outcomes.Values.Sum());
 
 		Console.WriteLine();
 		Console.WriteLine("Audiobookshelf upload summary:");

--- a/Source/LibationCli/Options/_ProcessableOptionsBase.cs
+++ b/Source/LibationCli/Options/_ProcessableOptionsBase.cs
@@ -81,7 +81,7 @@ public abstract class ProcessableOptionsBase : OptionsBase
 		return strProc;
 	}
 
-	protected async Task RunAsync(Processable Processable, Action<LibraryBook>? config = null)
+	protected async Task RunAsync(Processable Processable, Action<LibraryBook>? config = null, Action<string>? notFound = null)
 	{
 		var productIds = GetProductIds().ToArray();
 		if (productIds.Length > 0)
@@ -93,12 +93,13 @@ public abstract class ProcessableOptionsBase : OptionsBase
 					config?.Invoke(lb);
 					await ProcessOneAsync(Processable, lb, true);
 				}
-				else
-				{
+			else
+			{
 					var msg = $"Book with ASIN '{asin}' not found in library. Skipping.";
 					Console.Error.WriteLine(msg);
 					Serilog.Log.Logger.Error(msg);
-				}
+					notFound?.Invoke(asin);
+			}
 			}
 		}
 		else

--- a/Source/LibationCli/Program.cs
+++ b/Source/LibationCli/Program.cs
@@ -206,6 +206,9 @@ class Program
 			helpText.AddPreOptionsLine(preOptionsLine);
 		helpText.AddVerbs(VerbTypes);
 		error.WriteLine(helpText);
+
+		foreach (var group in CliCommandGroups.All)
+			error.WriteLine($"  {group.Name,-21}{group.HelpText}");
 	}
 
 	private static void WriteVerbOptionsHelp(ParserResult<object> result, TextWriter error)

--- a/Source/LibationCli/Program.cs
+++ b/Source/LibationCli/Program.cs
@@ -64,6 +64,13 @@ class Program
 		}
 
 		args = route.ParserArgs;
+		if (route.Kind == CliRouteKind.UnknownSubcommand)
+		{
+			Console.Error.WriteLine($"Unknown ABS command '{args[1]}'.");
+			Console.Error.WriteLine(HelpVerb.GetGroupHelpText(route.Group!));
+			Environment.ExitCode = (int)ExitCode.ParseError;
+			return;
+		}
 
 		if (TryPrintGlobalHelpOnly(args))
 			return;

--- a/Source/LibationCli/Program.cs
+++ b/Source/LibationCli/Program.cs
@@ -55,6 +55,15 @@ class Program
 			args = input.Split(' ', StringSplitOptions.RemoveEmptyEntries);
 		var setBreakPointHere = args;
 #endif
+		var route = CliCommandRouter.Route(args, CliCommandGroups.All);
+		if (route.Kind == CliRouteKind.GroupHelp)
+		{
+			Console.Error.WriteLine(HelpVerb.GetGroupHelpText(route.Group!));
+			Environment.ExitCode = (int)ExitCode.ProcessCompletedSuccessfully;
+			return;
+		}
+
+		args = route.ParserArgs;
 
 		if (TryPrintGlobalHelpOnly(args))
 			return;

--- a/Source/LibationCli/Program.cs
+++ b/Source/LibationCli/Program.cs
@@ -2,6 +2,7 @@
 using CommandLine.Text;
 using Dinah.Core;
 using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
@@ -71,9 +72,12 @@ class Program
 		await outcome.Result!.WithParsedAsync<OptionsBase>(opt => opt.Run());
 	}
 
-	internal static CliParseOutcome ParseInvocation(string[] args, TextWriter error)
+	internal static CliParseOutcome ParseInvocation(
+		string[] args,
+		TextWriter error,
+		IReadOnlyList<CliCommandGroup>? groups = null)
 	{
-		var route = CliCommandRouter.Route(args, CliCommandGroups.All);
+		var route = CliCommandRouter.Route(args, groups ?? CliCommandGroups.All);
 		if (route.Kind == CliRouteKind.GroupHelp)
 		{
 			error.WriteLine(HelpVerb.GetGroupHelpText(route.Group!));
@@ -83,7 +87,7 @@ class Program
 		args = route.ParserArgs;
 		if (route.Kind == CliRouteKind.UnknownSubcommand)
 		{
-			error.WriteLine($"Unknown ABS command '{args[1]}'.");
+			error.WriteLine($"Unknown {route.Group!.Name.ToUpperInvariant()} command '{args[1]}'.");
 			error.WriteLine(HelpVerb.GetGroupHelpText(route.Group!));
 			return new(null, ExitCode.ParseError);
 		}

--- a/Source/LibationCli/Program.cs
+++ b/Source/LibationCli/Program.cs
@@ -35,7 +35,9 @@ internal sealed record CliParseOutcome(ParserResult<object>? Result, ExitCode? E
 
 class Program
 {
-	public static readonly Type[] VerbTypes = Setup.LoadVerbs();
+	public static readonly Type[] VerbTypes = Setup.LoadVerbs()
+		.Where(type => type != typeof(AbsUploadOptions))
+		.ToArray();
 	static async Task Main(string[] args)
 	{
 		Console.OutputEncoding = Console.InputEncoding = System.Text.Encoding.UTF8;
@@ -97,7 +99,10 @@ class Program
 
 		args = NormalizeVerbShortHelpAliases(args);
 
-		var result = new Parser(ConfigureParser).ParseArguments(args, VerbTypes);
+		Type[] parserVerbTypes = route.Subcommand is { } subcommand
+			? [subcommand.OptionsType]
+			: VerbTypes;
+		var result = new Parser(ConfigureParser).ParseArguments(args, parserVerbTypes);
 
 		if (result.Value is HelpVerb helper)
 		{

--- a/Source/LibationCli/Program.cs
+++ b/Source/LibationCli/Program.cs
@@ -2,6 +2,7 @@
 using CommandLine.Text;
 using Dinah.Core;
 using System;
+using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
 
@@ -28,6 +29,9 @@ public enum ExitCode
 	ParseError = 2,
 	RunTimeError = 3
 }
+
+internal sealed record CliParseOutcome(ParserResult<object>? Result, ExitCode? ExitCode);
+
 class Program
 {
 	public static readonly Type[] VerbTypes = Setup.LoadVerbs();
@@ -55,76 +59,86 @@ class Program
 			args = input.Split(' ', StringSplitOptions.RemoveEmptyEntries);
 		var setBreakPointHere = args;
 #endif
+		var outcome = ParseInvocation(args, Console.Error);
+		if (outcome.ExitCode is { } exitCode)
+		{
+			Environment.ExitCode = (int)exitCode;
+			return;
+		}
+
+		//Everything parsed correctly, so execute the command
+		// async: run parsed options
+		await outcome.Result!.WithParsedAsync<OptionsBase>(opt => opt.Run());
+	}
+
+	internal static CliParseOutcome ParseInvocation(string[] args, TextWriter error)
+	{
 		var route = CliCommandRouter.Route(args, CliCommandGroups.All);
 		if (route.Kind == CliRouteKind.GroupHelp)
 		{
-			Console.Error.WriteLine(HelpVerb.GetGroupHelpText(route.Group!));
-			Environment.ExitCode = (int)ExitCode.ProcessCompletedSuccessfully;
-			return;
+			error.WriteLine(HelpVerb.GetGroupHelpText(route.Group!));
+			return new(null, ExitCode.ProcessCompletedSuccessfully);
 		}
 
 		args = route.ParserArgs;
 		if (route.Kind == CliRouteKind.UnknownSubcommand)
 		{
-			Console.Error.WriteLine($"Unknown ABS command '{args[1]}'.");
-			Console.Error.WriteLine(HelpVerb.GetGroupHelpText(route.Group!));
-			Environment.ExitCode = (int)ExitCode.ParseError;
-			return;
+			error.WriteLine($"Unknown ABS command '{args[1]}'.");
+			error.WriteLine(HelpVerb.GetGroupHelpText(route.Group!));
+			return new(null, ExitCode.ParseError);
 		}
 
-		if (TryPrintGlobalHelpOnly(args))
-			return;
+		if (TryPrintGlobalHelpOnly(args, error))
+			return new(null, ExitCode.ProcessCompletedSuccessfully);
 
 		args = NormalizeVerbShortHelpAliases(args);
 
 		var result = new Parser(ConfigureParser).ParseArguments(args, VerbTypes);
 
 		if (result.Value is HelpVerb helper)
-			Console.Error.WriteLine(helper.GetHelpText());
-		else if (result.TypeInfo.Current == typeof(HelpVerb))
+		{
+			error.WriteLine(helper.GetHelpText());
+			return new(result, ExitCode.ProcessCompletedSuccessfully);
+		}
+
+		if (result.TypeInfo.Current == typeof(HelpVerb))
 		{
 			//Error parsing the command, but the verb type was identified as HelpVerb
 			//Print LibationCli usage
 			var helpText = HelpVerb.CreateHelpText();
 			helpText.AddVerbs(VerbTypes);
-			Console.Error.WriteLine(helpText);
+			error.WriteLine(helpText);
+			return new(result, ExitCode.ProcessCompletedSuccessfully);
 		}
-		else if (result.Errors.Any())
-			HandleErrors(result);
-		else
-		{
-			//Everything parsed correctly, so execute the command
-			// async: run parsed options
-			await result.WithParsedAsync<OptionsBase>(opt => opt.Run());
-		}
+
+		if (result.Errors.Any())
+			return new(result, HandleErrors(result, error));
+
+		return new(result, null);
 	}
 
-	private static void HandleErrors(ParserResult<object> result)
+	private static ExitCode HandleErrors(ParserResult<object> result, TextWriter error)
 	{
 		var errorsList = result.Errors.ToList();
 
 		if (errorsList.Any(e => e.Tag == ErrorType.HelpRequestedError))
 		{
-			Environment.ExitCode = (int)ExitCode.ProcessCompletedSuccessfully;
-			WriteVerbOptionsHelp(result);
-			return;
+			WriteVerbOptionsHelp(result, error);
+			return ExitCode.ProcessCompletedSuccessfully;
 		}
 
 		if (errorsList.OfType<HelpVerbRequestedError>().FirstOrDefault() is { } helpVerbErr)
 		{
-			Environment.ExitCode = (int)ExitCode.ProcessCompletedSuccessfully;
-			WriteHelpForVerbRequestedError(helpVerbErr);
-			return;
+			WriteHelpForVerbRequestedError(helpVerbErr, error);
+			return ExitCode.ProcessCompletedSuccessfully;
 		}
 
 		if (errorsList.Any(e => e.Tag == ErrorType.VersionRequestedError))
 		{
-			Environment.ExitCode = (int)ExitCode.ProcessCompletedSuccessfully;
-			Console.Error.WriteLine(HelpVerb.CreateHelpText().Heading);
-			return;
+			error.WriteLine(HelpVerb.CreateHelpText().Heading);
+			return ExitCode.ProcessCompletedSuccessfully;
 		}
 
-		Environment.ExitCode = (int)ExitCode.ParseError;
 		var helpText = HelpVerb.CreateHelpText();
 
 		if (errorsList.OfType<NoVerbSelectedError>().Any())
@@ -148,19 +162,19 @@ class Program
 
 			helpText.AddOptions(result);
 		}
-		Console.Error.WriteLine(helpText);
+		error.WriteLine(helpText);
+		return ExitCode.ParseError;
 	}
 
 	/// <summary>
 	/// Multi-verb parsing treats the first token as a verb name, so bare <c>--help</c> / <c>-h</c> must be handled here.
 	/// </summary>
-	private static bool TryPrintGlobalHelpOnly(string[] args)
+	private static bool TryPrintGlobalHelpOnly(string[] args, TextWriter error)
 	{
 		if (args is not { Length: 1 } || !GlobalCliHelp.IsGlobalHelpToken(args[0]))
 			return false;
 
-		WriteGlobalVerbListHelp();
-		Environment.ExitCode = (int)ExitCode.ProcessCompletedSuccessfully;
+		WriteGlobalVerbListHelp(error);
 		return true;
 	}
 
@@ -185,37 +199,37 @@ class Program
 		return copy;
 	}
 
-	private static void WriteGlobalVerbListHelp(string? preOptionsLine = null)
+	private static void WriteGlobalVerbListHelp(TextWriter error, string? preOptionsLine = null)
 	{
 		var helpText = HelpVerb.CreateHelpText();
 		if (preOptionsLine is not null)
 			helpText.AddPreOptionsLine(preOptionsLine);
 		helpText.AddVerbs(VerbTypes);
-		Console.Error.WriteLine(helpText);
+		error.WriteLine(helpText);
 	}
 
-	private static void WriteVerbOptionsHelp(ParserResult<object> result)
+	private static void WriteVerbOptionsHelp(ParserResult<object> result, TextWriter error)
 	{
 		var helpText = HelpVerb.CreateHelpText();
 		helpText.AddDashesToOption = true;
 		helpText.AutoHelp = true;
 		helpText.AddOptions(result);
-		Console.Error.WriteLine(helpText);
+		error.WriteLine(helpText);
 	}
 
-	private static void WriteHelpForVerbRequestedError(HelpVerbRequestedError helpVerbErr)
+	private static void WriteHelpForVerbRequestedError(HelpVerbRequestedError helpVerbErr, TextWriter error)
 	{
 		if (!helpVerbErr.Matched || helpVerbErr.Type is null || string.IsNullOrWhiteSpace(helpVerbErr.Verb))
 		{
-			WriteGlobalVerbListHelp();
+			WriteGlobalVerbListHelp(error);
 			return;
 		}
 
 		var subResult = new Parser(ConfigureParser).ParseArguments(new[] { helpVerbErr.Verb }, VerbTypes);
 		if (subResult.TypeInfo.Current != typeof(NullInstance))
-			WriteVerbOptionsHelp(subResult);
+			WriteVerbOptionsHelp(subResult, error);
 		else
-			WriteGlobalVerbListHelp();
+			WriteGlobalVerbListHelp(error);
 	}
 
 	private static void ConfigureParser(ParserSettings settings)

--- a/Source/LibationCli/_InternalsVisible.cs
+++ b/Source/LibationCli/_InternalsVisible.cs
@@ -1,0 +1,1 @@
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo(nameof(LibationCli) + ".Tests")]

--- a/Source/LibationUiBase/LibationContributor.cs
+++ b/Source/LibationUiBase/LibationContributor.cs
@@ -51,6 +51,7 @@ public class LibationContributor
 			GitHubUser("Youssef1313"),
 			GitHubUser("niontrix"),
 			GitHubUser("CryptoJones"),
+			GitHubUser("caiowilson"),
             GitHubUser("m-j-r"),
             GitHubUser("Demoniskk"),
             GitHubUser("oxivanisher"),

--- a/Source/_Tests/FileLiberator.Tests/UploadToAudiobookshelfTests.cs
+++ b/Source/_Tests/FileLiberator.Tests/UploadToAudiobookshelfTests.cs
@@ -104,16 +104,28 @@ public class UploadToAudiobookshelfTests
 	}
 
 	[TestMethod]
-	public void BuildUploadFileList_preserves_audio_file_order()
+	public void BuildUploadFileList_sorts_multipart_audio_paths()
 	{
 		var result = UploadToAudiobookshelf.BuildUploadFileList(
-			["/books/part1.m4b", "/books/part2.m4b", "/books/part3.m4b"],
+			["/books/part3.m4b", "/books/part1.m4b", "/books/part2.m4b"],
 			coverPath: null);
 
 		result.Should().HaveCount(3);
 		result[0].Should().Be("/books/part1.m4b");
 		result[1].Should().Be("/books/part2.m4b");
 		result[2].Should().Be("/books/part3.m4b");
+	}
+
+	[TestMethod]
+	public void BuildUploadFileList_prefers_m4b_when_m4b_and_mp3_are_available()
+	{
+		var result = UploadToAudiobookshelf.BuildUploadFileList(
+			["/books/part1.mp3", "/books/part2.m4b", "/books/part1.m4b", "/books/part2.mp3"],
+			coverPath: null);
+
+		result.Should().HaveCount(2);
+		result[0].Should().Be("/books/part1.m4b");
+		result[1].Should().Be("/books/part2.m4b");
 	}
 
 	[TestMethod]

--- a/Source/_Tests/FileLiberator.Tests/UploadToAudiobookshelfTests.cs
+++ b/Source/_Tests/FileLiberator.Tests/UploadToAudiobookshelfTests.cs
@@ -1,9 +1,11 @@
 using AssertionHelper;
 using DataLayer;
+using FileManager;
 using LibationFileManager;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
 using System.IO;
+using System.Linq;
 using System.Threading.Tasks;
 
 namespace FileLiberator.Tests;
@@ -274,7 +276,9 @@ public class UploadToAudiobookshelfTests
 			// Precondition: the cache knows nothing about this book.
 			FilePathCache.GetFiles(productId).Should().HaveCount(0);
 
-			UploadToAudiobookshelf.GetAudioFilesOnDisk(productId).Should().BeEquivalentTo([audioFile]);
+			UploadToAudiobookshelf.GetAudioFilesOnDisk(productId)
+				.Select(path => ((LongPath)path).PathWithoutPrefix)
+				.Should().BeEquivalentTo([audioFile]);
 		}
 		finally
 		{

--- a/Source/_Tests/FileLiberator.Tests/UploadToAudiobookshelfTests.cs
+++ b/Source/_Tests/FileLiberator.Tests/UploadToAudiobookshelfTests.cs
@@ -1,0 +1,272 @@
+using AssertionHelper;
+using DataLayer;
+using LibationFileManager;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.IO;
+using System.Threading.Tasks;
+
+namespace FileLiberator.Tests;
+
+/// <summary>
+/// <see cref="Configuration.CreateMockInstance"/> replaces the process-wide
+/// <see cref="Configuration.Instance"/>, so these tests must not run alongside others.
+/// </summary>
+[TestClass]
+[DoNotParallelize]
+public class UploadToAudiobookshelfTests
+{
+	[TestCleanup]
+	public void RestoreConfiguration() => Configuration.RestoreSingletonInstance();
+
+	private static Configuration ConfiguredForAudiobookshelf()
+	{
+		var config = Configuration.CreateMockInstance();
+		config.AudiobookshelfEnabled = true;
+		config.AudiobookshelfServerUrl = "http://localhost:13378";
+		config.AudiobookshelfApiToken = "test-token";
+		config.AudiobookshelfLibraryId = "test-library-id";
+		config.AudiobookshelfFolderId = "test-folder-id";
+		return config;
+	}
+
+	private static LibraryBook LibraryBookWith(LiberatedStatus bookStatus)
+	{
+		var book = new Book(
+			new AudibleProductId("B0TEST0001"),
+			"Test Title",
+			"Test Subtitle",
+			"Test Description",
+			600,
+			ContentType.Product,
+			[new Contributor("Test Author")],
+			[new Contributor("Test Narrator")],
+			"us");
+
+		book.UserDefinedItem.BookStatus = bookStatus;
+
+		return new LibraryBook(book, new DateTime(2020, 1, 1), "test-account");
+	}
+
+	[TestMethod]
+	public void Validate_rejects_book_whose_liberation_errored()
+	{
+		var sut = UploadToAudiobookshelf.Create(ConfiguredForAudiobookshelf());
+
+		sut.Validate(LibraryBookWith(LiberatedStatus.Error)).Should().BeFalse();
+	}
+
+	[TestMethod]
+	public void Validate_accepts_liberated_book()
+	{
+		var sut = UploadToAudiobookshelf.Create(ConfiguredForAudiobookshelf());
+
+		sut.Validate(LibraryBookWith(LiberatedStatus.Liberated)).Should().BeTrue();
+	}
+
+	[TestMethod]
+	public void Validate_rejects_book_that_was_never_liberated()
+	{
+		var sut = UploadToAudiobookshelf.Create(ConfiguredForAudiobookshelf());
+
+		sut.Validate(LibraryBookWith(LiberatedStatus.NotLiberated)).Should().BeFalse();
+	}
+
+	[TestMethod]
+	public void Validate_rejects_when_audiobookshelf_is_disabled()
+	{
+		var config = ConfiguredForAudiobookshelf();
+		config.AudiobookshelfEnabled = false;
+		var sut = UploadToAudiobookshelf.Create(config);
+
+		sut.Validate(LibraryBookWith(LiberatedStatus.Liberated)).Should().BeFalse();
+	}
+
+	[TestMethod]
+	public void Validate_rejects_when_folder_id_is_not_configured()
+	{
+		var config = ConfiguredForAudiobookshelf();
+		config.AudiobookshelfFolderId = null;
+		var sut = UploadToAudiobookshelf.Create(config);
+
+		sut.Validate(LibraryBookWith(LiberatedStatus.Liberated)).Should().BeFalse();
+	}
+
+	[TestMethod]
+	public void BuildUploadFileList_removes_duplicate_audio_paths()
+	{
+		var result = UploadToAudiobookshelf.BuildUploadFileList(
+			["/books/part1.m4b", "/books/part1.m4b"],
+			coverPath: null);
+
+		result.Should().HaveCount(1);
+		result[0].Should().Be("/books/part1.m4b");
+	}
+
+	[TestMethod]
+	public void BuildUploadFileList_preserves_audio_file_order()
+	{
+		var result = UploadToAudiobookshelf.BuildUploadFileList(
+			["/books/part1.m4b", "/books/part2.m4b", "/books/part3.m4b"],
+			coverPath: null);
+
+		result.Should().HaveCount(3);
+		result[0].Should().Be("/books/part1.m4b");
+		result[1].Should().Be("/books/part2.m4b");
+		result[2].Should().Be("/books/part3.m4b");
+	}
+
+	[TestMethod]
+	public void BuildUploadFileList_appends_cover_art_after_the_audio_files()
+	{
+		var result = UploadToAudiobookshelf.BuildUploadFileList(
+			["/books/part1.m4b"],
+			coverPath: "/books/cover.jpg");
+
+		result.Should().HaveCount(2);
+		result[0].Should().Be("/books/part1.m4b");
+		result[1].Should().Be("/books/cover.jpg");
+	}
+
+	[TestMethod]
+	public void BuildUploadFileList_includes_cover_art_once_when_it_is_also_in_the_audio_list()
+	{
+		var result = UploadToAudiobookshelf.BuildUploadFileList(
+			["/books/part1.m4b", "/books/cover.jpg"],
+			coverPath: "/books/cover.jpg");
+
+		result.Should().HaveCount(2);
+		result[0].Should().Be("/books/part1.m4b");
+		result[1].Should().Be("/books/cover.jpg");
+	}
+
+	[TestMethod]
+	public void BuildUploadFileList_omits_cover_art_when_none_was_resolved()
+	{
+		var result = UploadToAudiobookshelf.BuildUploadFileList(
+			["/books/part1.m4b"],
+			coverPath: null);
+
+		result.Should().HaveCount(1);
+		result[0].Should().Be("/books/part1.m4b");
+	}
+
+	[TestMethod]
+	public void BuildUploadFileList_returns_empty_when_there_are_no_audio_files()
+	{
+		var result = UploadToAudiobookshelf.BuildUploadFileList([], coverPath: null);
+
+		result.Should().HaveCount(0);
+	}
+
+	/// <summary>
+	/// An Audiobookshelf problem must never fail the book. The GUI process queue treats a
+	/// non-success <see cref="Dinah.Core.ErrorHandling.StatusHandler"/> as a bad book: it breaks the
+	/// step loop, raises the Abort/Retry/Ignore dialog, and marks the book Failed. Uploading is a
+	/// courtesy step layered onto liberation, so it reports through
+	/// <see cref="UploadToAudiobookshelf.OutcomeDetermined"/> instead.
+	/// </summary>
+	[TestMethod]
+	public async Task ProcessAsync_does_not_fail_the_book_when_no_audio_files_are_found()
+	{
+		var booksDirectory = CreateEmptyBooksDirectory();
+		try
+		{
+			var config = ConfiguredForAudiobookshelf();
+			config.Books = booksDirectory;
+			var sut = UploadToAudiobookshelf.Create(config);
+
+			var status = await sut.ProcessAsync(LibraryBookWith(LiberatedStatus.Liberated));
+
+			status.IsSuccess.Should().BeTrue();
+		}
+		finally
+		{
+			Directory.Delete(booksDirectory, recursive: true);
+		}
+	}
+
+	[TestMethod]
+	public async Task ProcessAsync_raises_the_no_files_found_outcome()
+	{
+		var booksDirectory = CreateEmptyBooksDirectory();
+		try
+		{
+			var config = ConfiguredForAudiobookshelf();
+			config.Books = booksDirectory;
+			var sut = UploadToAudiobookshelf.Create(config);
+
+			UploadToAudiobookshelf.UploadOutcome? outcome = null;
+			sut.OutcomeDetermined += (_, e) => outcome = e.Outcome;
+
+			await sut.ProcessAsync(LibraryBookWith(LiberatedStatus.Liberated));
+
+			Assert.AreEqual(UploadToAudiobookshelf.UploadOutcome.NoFilesFound, outcome);
+		}
+		finally
+		{
+			Directory.Delete(booksDirectory, recursive: true);
+		}
+	}
+
+	[TestMethod]
+	public async Task ProcessAsync_explains_the_no_files_found_outcome()
+	{
+		var booksDirectory = CreateEmptyBooksDirectory();
+		try
+		{
+			var config = ConfiguredForAudiobookshelf();
+			config.Books = booksDirectory;
+			var sut = UploadToAudiobookshelf.Create(config);
+
+			string? message = null;
+			sut.OutcomeDetermined += (_, e) => message = e.Message;
+
+			await sut.ProcessAsync(LibraryBookWith(LiberatedStatus.Liberated));
+
+			message.Should().BeNotNull();
+		}
+		finally
+		{
+			Directory.Delete(booksDirectory, recursive: true);
+		}
+	}
+
+	private static string CreateEmptyBooksDirectory()
+	{
+		var booksDirectory = Path.Combine(Path.GetTempPath(), $"libation-test-{Guid.NewGuid():N}");
+		Directory.CreateDirectory(booksDirectory);
+		return booksDirectory;
+	}
+
+	/// <summary>
+	/// Books liberated before the path cache existed - or whose cache was lost - have no
+	/// <see cref="FilePathCache"/> entry. Backfill must still find them by scanning the Books
+	/// directory, otherwise the upload silently reports success having sent nothing.
+	/// </summary>
+	[TestMethod]
+	public void GetAudioFilesOnDisk_finds_audio_that_is_absent_from_the_file_path_cache()
+	{
+		const string productId = "B0DISKSCAN1";
+		var booksDirectory = Path.Combine(Path.GetTempPath(), $"libation-test-{Guid.NewGuid():N}");
+		Directory.CreateDirectory(booksDirectory);
+
+		try
+		{
+			var audioFile = Path.Combine(booksDirectory, $"{productId}.m4b");
+			File.WriteAllText(audioFile, "not really audio");
+
+			var config = Configuration.CreateMockInstance();
+			config.Books = booksDirectory;
+
+			// Precondition: the cache knows nothing about this book.
+			FilePathCache.GetFiles(productId).Should().HaveCount(0);
+
+			UploadToAudiobookshelf.GetAudioFilesOnDisk(productId).Should().BeEquivalentTo([audioFile]);
+		}
+		finally
+		{
+			Directory.Delete(booksDirectory, recursive: true);
+		}
+	}
+}

--- a/Source/_Tests/LibationCli.Tests/CliCommandRouterTests.cs
+++ b/Source/_Tests/LibationCli.Tests/CliCommandRouterTests.cs
@@ -1,7 +1,8 @@
 using AssertionHelper;
-using CommandLine;
 using LibationCli;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.IO;
 
 namespace LibationCli.Tests;
 
@@ -33,14 +34,26 @@ public class CliCommandRouterTests
 	}
 
 	[TestMethod]
-	public void Rewritten_abs_upload_arguments_parse_as_upload_options()
+	public void Nested_abs_upload_help_reaches_upload_help_path()
 	{
-		var route = CliCommandRouter.Route(
-			["abs", "upload", "B017V4IM1G", "--id", "B000000001"],
-			CliCommandGroups.All);
-		var result = new Parser().ParseArguments(route.ParserArgs, Program.VerbTypes);
+		using var error = new StringWriter();
+		var outcome = Program.ParseInvocation(["abs", "upload", "--help"], error);
 
-		Assert.IsInstanceOfType<AbsUploadOptions>(result.Value);
+		Assert.AreEqual(ExitCode.ProcessCompletedSuccessfully, outcome.ExitCode);
+		Assert.AreEqual(typeof(AbsUploadOptions), outcome.Result!.TypeInfo.Current);
+		StringAssert.Contains(error.ToString(), "--id");
+	}
+
+	[TestMethod]
+	public void Unknown_abs_subcommand_writes_error_before_group_help_and_exits_parse_error()
+	{
+		using var error = new StringWriter();
+		var outcome = Program.ParseInvocation(["abs", "download"], error);
+		var output = error.ToString();
+
+		Assert.AreEqual(ExitCode.ParseError, outcome.ExitCode);
+		Assert.IsTrue(output.StartsWith($"Unknown ABS command 'download'.{Environment.NewLine}", StringComparison.Ordinal));
+		StringAssert.Contains(output, "Audiobookshelf commands.");
 	}
 
 	[TestMethod]

--- a/Source/_Tests/LibationCli.Tests/CliCommandRouterTests.cs
+++ b/Source/_Tests/LibationCli.Tests/CliCommandRouterTests.cs
@@ -1,0 +1,46 @@
+using AssertionHelper;
+using LibationCli;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace LibationCli.Tests;
+
+[TestClass]
+public class CliCommandRouterTests
+{
+	[TestMethod]
+	public void Abs_without_subcommand_requests_group_help()
+	{
+		var route = CliCommandRouter.Route(["abs"], CliCommandGroups.All);
+
+		Assert.AreEqual(CliRouteKind.GroupHelp, route.Kind);
+		route.Group!.Name.Should().Be("abs");
+	}
+
+	[TestMethod]
+	public void Abs_upload_rewrites_only_the_command_path()
+	{
+		var route = CliCommandRouter.Route(
+			["abs", "upload", "B017V4IM1G", "--id", "B000000001"],
+			CliCommandGroups.All);
+
+		CollectionAssert.AreEqual(new[] { "abs-upload", "B017V4IM1G", "--id", "B000000001" }, route.ParserArgs);
+	}
+
+	[TestMethod]
+	public void Non_group_command_passes_through_unchanged()
+	{
+		var route = CliCommandRouter.Route(["status", "--verbose"], CliCommandGroups.All);
+
+		Assert.AreEqual(CliRouteKind.PassThrough, route.Kind);
+		CollectionAssert.AreEqual(new[] { "status", "--verbose" }, route.ParserArgs);
+	}
+
+	[TestMethod]
+	public void Abs_unknown_subcommand_is_reported()
+	{
+		var route = CliCommandRouter.Route(["abs", "delete"], CliCommandGroups.All);
+
+		Assert.AreEqual(CliRouteKind.UnknownSubcommand, route.Kind);
+		route.Group!.Name.Should().Be("abs");
+	}
+}

--- a/Source/_Tests/LibationCli.Tests/CliCommandRouterTests.cs
+++ b/Source/_Tests/LibationCli.Tests/CliCommandRouterTests.cs
@@ -8,9 +8,12 @@ namespace LibationCli.Tests;
 public class CliCommandRouterTests
 {
 	[TestMethod]
-	public void Abs_without_subcommand_requests_group_help()
+	[DataRow("abs")]
+	[DataRow("help", "abs")]
+	[DataRow("abs", "--help")]
+	public void Abs_group_help_forms_request_group_help(params string[] args)
 	{
-		var route = CliCommandRouter.Route(["abs"], CliCommandGroups.All);
+		var route = CliCommandRouter.Route(args, CliCommandGroups.All);
 
 		Assert.AreEqual(CliRouteKind.GroupHelp, route.Kind);
 		route.Group!.Name.Should().Be("abs");

--- a/Source/_Tests/LibationCli.Tests/CliCommandRouterTests.cs
+++ b/Source/_Tests/LibationCli.Tests/CliCommandRouterTests.cs
@@ -20,10 +20,12 @@ public class CliCommandRouterTests
 	public void Abs_upload_rewrites_only_the_command_path()
 	{
 		var route = CliCommandRouter.Route(
-			["abs", "upload", "B017V4IM1G", "--id", "B000000001"],
+			["abs", "upload", "B017V4IM1G", "--id", "B000000001", "--id", "B000000002"],
 			CliCommandGroups.All);
 
-		CollectionAssert.AreEqual(new[] { "abs-upload", "B017V4IM1G", "--id", "B000000001" }, route.ParserArgs);
+		CollectionAssert.AreEqual(
+			new[] { "abs-upload", "B017V4IM1G", "--id", "B000000001", "--id", "B000000002" },
+			route.ParserArgs);
 	}
 
 	[TestMethod]

--- a/Source/_Tests/LibationCli.Tests/CliCommandRouterTests.cs
+++ b/Source/_Tests/LibationCli.Tests/CliCommandRouterTests.cs
@@ -1,4 +1,5 @@
 using AssertionHelper;
+using CommandLine;
 using LibationCli;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
@@ -29,6 +30,17 @@ public class CliCommandRouterTests
 		CollectionAssert.AreEqual(
 			new[] { "abs-upload", "B017V4IM1G", "--id", "B000000001", "--id", "B000000002" },
 			route.ParserArgs);
+	}
+
+	[TestMethod]
+	public void Rewritten_abs_upload_arguments_parse_as_upload_options()
+	{
+		var route = CliCommandRouter.Route(
+			["abs", "upload", "B017V4IM1G", "--id", "B000000001"],
+			CliCommandGroups.All);
+		var result = new Parser().ParseArguments(route.ParserArgs, Program.VerbTypes);
+
+		Assert.IsInstanceOfType<AbsUploadOptions>(result.Value);
 	}
 
 	[TestMethod]

--- a/Source/_Tests/LibationCli.Tests/CliCommandRouterTests.cs
+++ b/Source/_Tests/LibationCli.Tests/CliCommandRouterTests.cs
@@ -3,6 +3,7 @@ using LibationCli;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
 using System.IO;
+using System.Linq;
 
 namespace LibationCli.Tests;
 
@@ -29,28 +30,32 @@ public class CliCommandRouterTests
 			CliCommandGroups.All);
 
 		CollectionAssert.AreEqual(
-			new[] { "abs-upload", "B017V4IM1G", "--id", "B000000001", "--id", "B000000002" },
+			new[] { "upload", "B017V4IM1G", "--id", "B000000001", "--id", "B000000002" },
 			route.ParserArgs);
 	}
 
 	[DataTestMethod]
-	[DataRow(new[] { "help", "abs", "upload" }, new[] { "help", "abs-upload" })]
-	[DataRow(new[] { "abs", "upload", "--help" }, new[] { "abs-upload", "--help" })]
-	[DataRow(new[] { "abs", "upload", "-h" }, new[] { "abs-upload", "-h" })]
+	[DataRow(new[] { "help", "abs", "upload" }, new[] { "upload", "--help" })]
+	[DataRow(new[] { "abs", "upload", "--help" }, new[] { "upload", "--help" })]
+	[DataRow(new[] { "abs", "upload", "-h" }, new[] { "upload", "-h" })]
 	public void Nested_help_forms_resolve_to_upload(string[] input, string[] expected)
 		=> CollectionAssert.AreEqual(expected, CliCommandRouter.Route(input, CliCommandGroups.All).ParserArgs);
 
-	[TestMethod]
-	public void Legacy_abs_upload_is_passed_through_unchanged()
+	[DataTestMethod]
+	[DataRow("abs-upload", "--help")]
+	[DataRow("upload", "--help")]
+	public void Root_upload_aliases_are_rejected(params string[] args)
 	{
-		var route = CliCommandRouter.Route(["abs-upload", "--id", "B017V4IM1G"], CliCommandGroups.All);
+		using var error = new StringWriter();
 
-		Assert.AreEqual(CliRouteKind.PassThrough, route.Kind);
-		CollectionAssert.AreEqual(new[] { "abs-upload", "--id", "B017V4IM1G" }, route.ParserArgs);
+		var outcome = Program.ParseInvocation(args, error);
+
+		Assert.AreEqual(ExitCode.ParseError, outcome.ExitCode);
+		Assert.IsFalse(error.ToString().Contains("--id", StringComparison.Ordinal));
 	}
 
 	[TestMethod]
-	public void Global_help_lists_the_abs_group_and_legacy_upload_verb()
+	public void Global_help_lists_the_abs_group_without_legacy_upload_verb()
 	{
 		using var error = new StringWriter();
 
@@ -58,7 +63,7 @@ public class CliCommandRouterTests
 
 		Assert.AreEqual(ExitCode.ProcessCompletedSuccessfully, outcome.ExitCode);
 		StringAssert.Contains(error.ToString(), "  abs                  Audiobookshelf commands.");
-		StringAssert.Contains(error.ToString(), "  abs-upload           Upload already-liberated books to Audiobookshelf.");
+		Assert.IsFalse(error.ToString().Contains("abs-upload", StringComparison.Ordinal));
 	}
 
 	[TestMethod]
@@ -86,6 +91,20 @@ public class CliCommandRouterTests
 		Assert.AreEqual(ExitCode.ProcessCompletedSuccessfully, outcome.ExitCode);
 		Assert.AreEqual(typeof(AbsUploadOptions), outcome.Result!.TypeInfo.Current);
 		StringAssert.Contains(error.ToString(), "--id");
+	}
+
+	[TestMethod]
+	public void Nested_abs_upload_parses_positional_and_repeatable_ids()
+	{
+		using var error = new StringWriter();
+
+		var outcome = Program.ParseInvocation(["abs", "upload", "B017V4IM1G", "--id", "B000000001", "--id", "B000000002"], error);
+
+		Assert.IsNull(outcome.ExitCode);
+		var options = outcome.Result!.Value as AbsUploadOptions;
+		Assert.IsNotNull(options);
+		CollectionAssert.AreEqual(new[] { "B017V4IM1G" }, options.Asins!.ToArray());
+		CollectionAssert.AreEqual(new[] { "B000000001", "B000000002" }, options.Ids!.ToArray());
 	}
 
 	[TestMethod]
@@ -132,7 +151,7 @@ public class CliCommandRouterTests
 		var group = new CliCommandGroup(
 			"library",
 			"Library commands.",
-			[new("sync", "library-sync", "Sync the library.")]);
+			[new("sync", "library-sync", "Sync the library.", typeof(AbsUploadOptions))]);
 		using var error = new StringWriter();
 
 		var outcome = Program.ParseInvocation(["library", "delete"], error, [group]);

--- a/Source/_Tests/LibationCli.Tests/CliCommandRouterTests.cs
+++ b/Source/_Tests/LibationCli.Tests/CliCommandRouterTests.cs
@@ -62,6 +62,22 @@ public class CliCommandRouterTests
 	}
 
 	[TestMethod]
+	[DataRow("abs")]
+	[DataRow("help", "abs")]
+	[DataRow("abs", "--help")]
+	public void Abs_group_help_forms_are_handled_by_program(params string[] args)
+	{
+		using var error = new StringWriter();
+
+		var outcome = Program.ParseInvocation(args, error);
+
+		Assert.AreEqual(ExitCode.ProcessCompletedSuccessfully, outcome.ExitCode);
+		Assert.IsNull(outcome.Result);
+		StringAssert.Contains(error.ToString(), "Audiobookshelf commands.");
+		StringAssert.Contains(error.ToString(), "abs upload");
+	}
+
+	[TestMethod]
 	public void Nested_abs_upload_help_reaches_upload_help_path()
 	{
 		using var error = new StringWriter();
@@ -73,6 +89,19 @@ public class CliCommandRouterTests
 	}
 
 	[TestMethod]
+	[DataRow("help", "abs", "upload")]
+	[DataRow("abs", "upload", "-h")]
+	public void Additional_nested_upload_help_forms_are_handled_by_program(params string[] args)
+	{
+		using var error = new StringWriter();
+
+		var outcome = Program.ParseInvocation(args, error);
+
+		Assert.AreEqual(ExitCode.ProcessCompletedSuccessfully, outcome.ExitCode);
+		StringAssert.Contains(error.ToString(), "--id");
+	}
+
+	[TestMethod]
 	public void Unknown_abs_subcommand_writes_error_before_group_help_and_exits_parse_error()
 	{
 		using var error = new StringWriter();
@@ -80,8 +109,38 @@ public class CliCommandRouterTests
 		var output = error.ToString();
 
 		Assert.AreEqual(ExitCode.ParseError, outcome.ExitCode);
-		Assert.IsTrue(output.StartsWith($"Unknown ABS command 'download'.{Environment.NewLine}", StringComparison.Ordinal));
+		Assert.AreEqual("Unknown ABS command 'download'.", new StringReader(output).ReadLine());
 		StringAssert.Contains(output, "Audiobookshelf commands.");
+	}
+
+	[TestMethod]
+	public void Inverse_abs_help_upload_form_is_rejected()
+	{
+		using var error = new StringWriter();
+
+		var outcome = Program.ParseInvocation(["abs", "help", "upload"], error);
+		var output = error.ToString();
+
+		Assert.AreEqual(ExitCode.ParseError, outcome.ExitCode);
+		Assert.AreEqual("Unknown ABS command 'help'.", new StringReader(output).ReadLine());
+		StringAssert.Contains(output, "Audiobookshelf commands.");
+	}
+
+	[TestMethod]
+	public void Unknown_subcommand_uses_the_routed_group_name_in_diagnostic()
+	{
+		var group = new CliCommandGroup(
+			"library",
+			"Library commands.",
+			[new("sync", "library-sync", "Sync the library.")]);
+		using var error = new StringWriter();
+
+		var outcome = Program.ParseInvocation(["library", "delete"], error, [group]);
+		var output = error.ToString();
+
+		Assert.AreEqual(ExitCode.ParseError, outcome.ExitCode);
+		Assert.IsTrue(output.StartsWith($"Unknown LIBRARY command 'delete'.{Environment.NewLine}", StringComparison.Ordinal));
+		StringAssert.Contains(output, "Library commands.");
 	}
 
 	[TestMethod]

--- a/Source/_Tests/LibationCli.Tests/CliCommandRouterTests.cs
+++ b/Source/_Tests/LibationCli.Tests/CliCommandRouterTests.cs
@@ -33,6 +33,34 @@ public class CliCommandRouterTests
 			route.ParserArgs);
 	}
 
+	[DataTestMethod]
+	[DataRow(new[] { "help", "abs", "upload" }, new[] { "help", "abs-upload" })]
+	[DataRow(new[] { "abs", "upload", "--help" }, new[] { "abs-upload", "--help" })]
+	[DataRow(new[] { "abs", "upload", "-h" }, new[] { "abs-upload", "-h" })]
+	public void Nested_help_forms_resolve_to_upload(string[] input, string[] expected)
+		=> CollectionAssert.AreEqual(expected, CliCommandRouter.Route(input, CliCommandGroups.All).ParserArgs);
+
+	[TestMethod]
+	public void Legacy_abs_upload_is_passed_through_unchanged()
+	{
+		var route = CliCommandRouter.Route(["abs-upload", "--id", "B017V4IM1G"], CliCommandGroups.All);
+
+		Assert.AreEqual(CliRouteKind.PassThrough, route.Kind);
+		CollectionAssert.AreEqual(new[] { "abs-upload", "--id", "B017V4IM1G" }, route.ParserArgs);
+	}
+
+	[TestMethod]
+	public void Global_help_lists_the_abs_group_and_legacy_upload_verb()
+	{
+		using var error = new StringWriter();
+
+		var outcome = Program.ParseInvocation(["--help"], error);
+
+		Assert.AreEqual(ExitCode.ProcessCompletedSuccessfully, outcome.ExitCode);
+		StringAssert.Contains(error.ToString(), "  abs                  Audiobookshelf commands.");
+		StringAssert.Contains(error.ToString(), "  abs-upload           Upload already-liberated books to Audiobookshelf.");
+	}
+
 	[TestMethod]
 	public void Nested_abs_upload_help_reaches_upload_help_path()
 	{

--- a/Source/_Tests/LibationCli.Tests/LibationCli.Tests.csproj
+++ b/Source/_Tests/LibationCli.Tests/LibationCli.Tests.csproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <OutputType>Exe</OutputType>
+    <IsPackable>false</IsPackable>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="MSTest" Version="4.2.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\LibationCli\LibationCli.csproj" />
+    <ProjectReference Include="..\AssertionHelper\AssertionHelper.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/docs/advanced/command-line-interface.md
+++ b/docs/advanced/command-line-interface.md
@@ -156,27 +156,27 @@ libationcli convert
 libationcli liberate
 ```
 
-If Audiobookshelf auto-upload is enabled in Settings, `liberate` also uploads each liberated book after download/decrypt (and PDF). See [Audiobookshelf Auto-Upload](/docs/features/audiobookshelf). The separate `convert` command does not upload. To upload books that were already liberated, use [`abs-upload`](#upload-already-liberated-books-to-audiobookshelf-abs-upload).
+If Audiobookshelf auto-upload is enabled in Settings, `liberate` also uploads each liberated book after download/decrypt (and PDF). See [Audiobookshelf Auto-Upload](/docs/features/audiobookshelf). The separate `convert` command does not upload. To upload books that were already liberated, use [`abs upload`](#upload-already-liberated-books-to-audiobookshelf-abs-upload).
 
-## Upload Already-Liberated Books to Audiobookshelf (`abs-upload`)
+## Upload Already-Liberated Books to Audiobookshelf (`abs upload`)
 
-Auto-upload only runs at the moment a book is liberated. Use `abs-upload` to send books liberated earlier, using the files already on disk. Nothing is re-downloaded.
+Auto-upload only runs at the moment a book is liberated. Use `abs upload` to send books liberated earlier, using the files already on disk. Nothing is re-downloaded. The legacy `abs-upload` command remains supported with identical behavior and no warning during this deprecation period.
 
 ```console
-libationcli abs-upload
+libationcli abs upload
 ```
 
 Upload specific titles:
 
 ```console
-libationcli abs-upload B017V4IM1G
-libationcli abs-upload --id B017V4IM1G
+libationcli abs upload B017V4IM1G
+libationcli abs upload --id B017V4IM1G
 ```
 
 Requires Audiobookshelf to be enabled and fully configured; otherwise the command reports what is missing and exits without processing anything. Settings can be supplied per-run with `--override`, for example:
 
 ```console
-libationcli abs-upload -o AudiobookshelfServerUrl="https://abs.example.com" -o AudiobookshelfApiToken="..."
+libationcli abs upload -o AudiobookshelfServerUrl="https://abs.example.com" -o AudiobookshelfApiToken="..."
 ```
 
 Titles already on the server are skipped. The run ends with a summary of uploaded, already-on-server, no-files-found, failed, and skipped counts. Failures are also written to stderr; the command exits 0 either way. See [Audiobookshelf Auto-Upload](/docs/features/audiobookshelf#uploading-books-you-already-liberated).

--- a/docs/advanced/command-line-interface.md
+++ b/docs/advanced/command-line-interface.md
@@ -160,7 +160,7 @@ If Audiobookshelf auto-upload is enabled in Settings, `liberate` also uploads ea
 
 ## Upload Already-Liberated Books to Audiobookshelf (`abs upload`)
 
-Auto-upload only runs at the moment a book is liberated. Use `abs upload` to send books liberated earlier, using the files already on disk. Nothing is re-downloaded. The legacy `abs-upload` command remains supported with identical behavior and no warning during this deprecation period.
+Auto-upload only runs at the moment a book is liberated. Use `abs upload` to send books liberated earlier, using the files already on disk. Nothing is re-downloaded.
 
 ```console
 libationcli abs upload

--- a/docs/advanced/command-line-interface.md
+++ b/docs/advanced/command-line-interface.md
@@ -156,27 +156,27 @@ libationcli convert
 libationcli liberate
 ```
 
-If Audiobookshelf auto-upload is enabled in Settings, `liberate` also uploads each liberated book after download/decrypt (and PDF). See [Audiobookshelf Auto-Upload](/docs/features/audiobookshelf). The separate `convert` command does not upload. To upload books that were already liberated, use [`upload`](#upload-already-liberated-books-to-audiobookshelf).
+If Audiobookshelf auto-upload is enabled in Settings, `liberate` also uploads each liberated book after download/decrypt (and PDF). See [Audiobookshelf Auto-Upload](/docs/features/audiobookshelf). The separate `convert` command does not upload. To upload books that were already liberated, use [`abs-upload`](#upload-already-liberated-books-to-audiobookshelf-abs-upload).
 
-## Upload Already-Liberated Books to Audiobookshelf
+## Upload Already-Liberated Books to Audiobookshelf (`abs-upload`)
 
-Auto-upload only runs at the moment a book is liberated. Use `upload` to send books liberated earlier, using the files already on disk. Nothing is re-downloaded.
+Auto-upload only runs at the moment a book is liberated. Use `abs-upload` to send books liberated earlier, using the files already on disk. Nothing is re-downloaded.
 
 ```console
-libationcli upload
+libationcli abs-upload
 ```
 
 Upload specific titles:
 
 ```console
-libationcli upload B017V4IM1G
-libationcli upload --id B017V4IM1G
+libationcli abs-upload B017V4IM1G
+libationcli abs-upload --id B017V4IM1G
 ```
 
 Requires Audiobookshelf to be enabled and fully configured; otherwise the command reports what is missing and exits without processing anything. Settings can be supplied per-run with `--override`, for example:
 
 ```console
-libationcli upload -o AudiobookshelfServerUrl="https://abs.example.com" -o AudiobookshelfApiToken="..."
+libationcli abs-upload -o AudiobookshelfServerUrl="https://abs.example.com" -o AudiobookshelfApiToken="..."
 ```
 
 Titles already on the server are skipped. The run ends with a summary of uploaded, already-on-server, no-files-found, failed, and skipped counts. Failures are also written to stderr; the command exits 0 either way. See [Audiobookshelf Auto-Upload](/docs/features/audiobookshelf#uploading-books-you-already-liberated).

--- a/docs/advanced/command-line-interface.md
+++ b/docs/advanced/command-line-interface.md
@@ -156,7 +156,30 @@ libationcli convert
 libationcli liberate
 ```
 
-If Audiobookshelf auto-upload is enabled in Settings, `liberate` also uploads each liberated book after download/decrypt (and PDF). See [Audiobookshelf Auto-Upload](/docs/features/audiobookshelf). The separate `convert` command does not upload.
+If Audiobookshelf auto-upload is enabled in Settings, `liberate` also uploads each liberated book after download/decrypt (and PDF). See [Audiobookshelf Auto-Upload](/docs/features/audiobookshelf). The separate `convert` command does not upload. To upload books that were already liberated, use [`upload`](#upload-already-liberated-books-to-audiobookshelf).
+
+## Upload Already-Liberated Books to Audiobookshelf
+
+Auto-upload only runs at the moment a book is liberated. Use `upload` to send books liberated earlier, using the files already on disk. Nothing is re-downloaded.
+
+```console
+libationcli upload
+```
+
+Upload specific titles:
+
+```console
+libationcli upload B017V4IM1G
+libationcli upload --id B017V4IM1G
+```
+
+Requires Audiobookshelf to be enabled and fully configured; otherwise the command reports what is missing and exits without processing anything. Settings can be supplied per-run with `--override`, for example:
+
+```console
+libationcli upload -o AudiobookshelfServerUrl="https://abs.example.com" -o AudiobookshelfApiToken="..."
+```
+
+Titles already on the server are skipped. The run ends with a summary of uploaded, already-on-server, no-files-found, failed, and skipped counts. Failures are also written to stderr; the command exits 0 either way. See [Audiobookshelf Auto-Upload](/docs/features/audiobookshelf#uploading-books-you-already-liberated).
 
 ## Liberate Pdfs Only
 

--- a/docs/features/audiobookshelf.md
+++ b/docs/features/audiobookshelf.md
@@ -62,7 +62,7 @@ Auto-upload only ever fires at the moment a book is liberated. To send books you
 
 ## Uploading books you already liberated
 
-Books liberated before Audiobookshelf was set up - or while it was turned off - are never sent by auto-upload. The `abs upload` command backfills them from the copies already on disk. Nothing is re-downloaded from Audible, and local files are never deleted. The legacy `abs-upload` command remains supported with identical behavior and no warning during this deprecation period.
+Books liberated before Audiobookshelf was set up - or while it was turned off - are never sent by auto-upload. The `abs upload` command backfills them from the copies already on disk. Nothing is re-downloaded from Audible, and local files are never deleted.
 
 Upload every liberated book:
 

--- a/docs/features/audiobookshelf.md
+++ b/docs/features/audiobookshelf.md
@@ -62,19 +62,19 @@ Auto-upload only ever fires at the moment a book is liberated. To send books you
 
 ## Uploading books you already liberated
 
-Books liberated before Audiobookshelf was set up - or while it was turned off - are never sent by auto-upload. The `abs-upload` command backfills them from the copies already on disk. Nothing is re-downloaded from Audible, and local files are never deleted.
+Books liberated before Audiobookshelf was set up - or while it was turned off - are never sent by auto-upload. The `abs upload` command backfills them from the copies already on disk. Nothing is re-downloaded from Audible, and local files are never deleted. The legacy `abs-upload` command remains supported with identical behavior and no warning during this deprecation period.
 
 Upload every liberated book:
 
 ```console
-libationcli abs-upload
+libationcli abs upload
 ```
 
 Upload specific titles:
 
 ```console
-libationcli abs-upload B017V4IM1G
-libationcli abs-upload --id B017V4IM1G
+libationcli abs upload B017V4IM1G
+libationcli abs upload --id B017V4IM1G
 ```
 
 The command:
@@ -98,7 +98,7 @@ If the Audiobookshelf server is unreachable, the token is wrong, or upload fails
 - The queue or CLI does not treat the book as a failed/bad liberate.
 - Status text and the log still report the upload error.
 
-This applies to `libationcli abs-upload` too: a failed upload never marks a book as a bad liberate. Because uploading is that command's only job, it also reports each failure on stderr and counts it in the end-of-run summary. It still exits 0, matching Libation's other commands - read the summary and stderr together to see whether a backfill actually succeeded.
+This applies to `libationcli abs upload` too: a failed upload never marks a book as a bad liberate. Because uploading is that command's only job, it also reports each failure on stderr and counts it in the end-of-run summary. It still exits 0, matching Libation's other commands - read the summary and stderr together to see whether a backfill actually succeeded.
 
 ## Tips
 

--- a/docs/features/audiobookshelf.md
+++ b/docs/features/audiobookshelf.md
@@ -58,6 +58,34 @@ When auto-upload is enabled and configured:
 
 Upload runs for GUI download/decrypt and for CLI `liberate`. It does **not** run on the separate **Convert to MP3** queue or `libationcli convert` - those paths only convert local files.
 
+Auto-upload only ever fires at the moment a book is liberated. To send books you liberated earlier, see [Uploading books you already liberated](#uploading-books-you-already-liberated).
+
+## Uploading books you already liberated
+
+Books liberated before Audiobookshelf was set up - or while it was turned off - are never sent by auto-upload. The `upload` command backfills them from the copies already on disk. Nothing is re-downloaded from Audible, and local files are never deleted.
+
+Upload every liberated book:
+
+```console
+libationcli upload
+```
+
+Upload specific titles:
+
+```console
+libationcli upload B017V4IM1G
+libationcli upload --id B017V4IM1G
+```
+
+The command:
+
+- Considers only books Libation has marked as **liberated**. Books whose liberation errored are skipped, because an errored liberation may have left partial files.
+- Finds audio using both Libation's file-path cache **and** a scan of your Books directory, so books whose cache entry was lost are still found.
+- Checks the server before each upload and skips titles already present - see [Duplicate handling](#duplicate-handling).
+- Prints a summary at the end: uploaded, already on server, no files found, failed, skipped. `skipped` counts books you named by ASIN that were not eligible - most often because they are not marked as liberated.
+
+Libation does not record which books it has already uploaded, so every run re-checks each candidate against the server. That costs a couple of search requests per book, which is noticeable on a large library but makes repeat runs safe to retry.
+
 ## Duplicate handling
 
 Before uploading, Libation searches the target Audiobookshelf library for an existing item with a matching title (and author when available). If a match is found, or Audiobookshelf reports that the destination already exists, Libation skips the upload and continues.
@@ -69,6 +97,8 @@ If the Audiobookshelf server is unreachable, the token is wrong, or upload fails
 - The book remains liberated on disk.
 - The queue or CLI does not treat the book as a failed/bad liberate.
 - Status text and the log still report the upload error.
+
+This applies to `libationcli upload` too: a failed upload never marks a book as a bad liberate. Because uploading is that command's only job, it also reports each failure on stderr and counts it in the end-of-run summary. It still exits 0, matching Libation's other commands - read the summary and stderr together to see whether a backfill actually succeeded.
 
 ## Tips
 

--- a/docs/features/audiobookshelf.md
+++ b/docs/features/audiobookshelf.md
@@ -62,19 +62,19 @@ Auto-upload only ever fires at the moment a book is liberated. To send books you
 
 ## Uploading books you already liberated
 
-Books liberated before Audiobookshelf was set up - or while it was turned off - are never sent by auto-upload. The `upload` command backfills them from the copies already on disk. Nothing is re-downloaded from Audible, and local files are never deleted.
+Books liberated before Audiobookshelf was set up - or while it was turned off - are never sent by auto-upload. The `abs-upload` command backfills them from the copies already on disk. Nothing is re-downloaded from Audible, and local files are never deleted.
 
 Upload every liberated book:
 
 ```console
-libationcli upload
+libationcli abs-upload
 ```
 
 Upload specific titles:
 
 ```console
-libationcli upload B017V4IM1G
-libationcli upload --id B017V4IM1G
+libationcli abs-upload B017V4IM1G
+libationcli abs-upload --id B017V4IM1G
 ```
 
 The command:
@@ -98,7 +98,7 @@ If the Audiobookshelf server is unreachable, the token is wrong, or upload fails
 - The queue or CLI does not treat the book as a failed/bad liberate.
 - Status text and the log still report the upload error.
 
-This applies to `libationcli upload` too: a failed upload never marks a book as a bad liberate. Because uploading is that command's only job, it also reports each failure on stderr and counts it in the end-of-run summary. It still exits 0, matching Libation's other commands - read the summary and stderr together to see whether a backfill actually succeeded.
+This applies to `libationcli abs-upload` too: a failed upload never marks a book as a bad liberate. Because uploading is that command's only job, it also reports each failure on stderr and counts it in the end-of-run summary. It still exits 0, matching Libation's other commands - read the summary and stderr together to see whether a backfill actually succeeded.
 
 ## Tips
 


### PR DESCRIPTION
## What

This draft presents the unreleased Audiobookshelf CLI with `abs upload` as the only public upload syntax.

## Why

The feature has not shipped, so retaining the interim kebab-cased alias would create compatibility work before there are external users who need it.

## How

- Route `abs upload` to a private parser binding and its option type.
- Exclude that option type from root verb discovery, so neither `upload` nor `abs-upload` is a public command.
- Preserve positional ASINs, repeated `--id`, and all supported nested help forms.
- Remove legacy-alias documentation and add parser/help regression coverage.

## Verification

- `PATH="/tmp/libation-dotnet-sdk:$PATH" dotnet test --project Source/_Tests/LibationCli.Tests/LibationCli.Tests.csproj --no-restore` — 22 passed
- `cd Source && PATH="/tmp/libation-dotnet-sdk:$PATH" dotnet test --no-restore` — 1,014 passed, 0 failed, 21 platform skips
- Real CLI checks: nested help forms exit 0; direct `abs-upload` and `upload` exit 2.

## Relationship to #1918

This intentionally overlaps #1918 and is a decision vehicle, not a second feature implementation. It can either replace the compatibility-alias version before merge or be closed if the maintainer prefers the interim alias.