### PR TITLE
fix(cli): polish abs group help discoverability and branding

### DIFF
--- a/Source/LibationCli/HelpVerb.cs
+++ b/Source/LibationCli/HelpVerb.cs
@@ -2,6 +2,9 @@
 using CommandLine;
 using CommandLine.Text;
 using LibationFileManager;
+using System;
+using System.Collections.Generic;
+using System.IO;
 
 namespace LibationCli;
 
@@ -34,6 +37,26 @@ internal class HelpVerb
 		foreach (var subcommand in group.Subcommands)
 			helpText.AddPreOptionsLine($"  {group.Name} {subcommand.Name}  {subcommand.HelpText}");
 		return helpText;
+	}
+
+	/// <summary>
+	/// Write the global verb list plus nested command groups (e.g. <c>abs</c>).
+	/// Groups are appended after <see cref="HelpText"/> because CommandLineParser has no post-options slot.
+	/// </summary>
+	public static void WriteGlobalVerbList(
+		TextWriter error,
+		Type[] verbTypes,
+		IReadOnlyList<CliCommandGroup> groups,
+		string? preOptionsLine = null)
+	{
+		var helpText = CreateHelpText();
+		if (preOptionsLine is not null)
+			helpText.AddPreOptionsLine(preOptionsLine);
+		helpText.AddVerbs(verbTypes);
+		error.WriteLine(helpText);
+
+		foreach (var group in groups)
+			error.WriteLine($"  {group.Name,-21}{group.HelpText}");
 	}
 
 	/// <summary>

--- a/Source/LibationCli/Program.cs
+++ b/Source/LibationCli/Program.cs
@@ -106,33 +106,35 @@ class Program
 
 		if (result.Value is HelpVerb helper)
 		{
-			error.WriteLine(helper.GetHelpText());
+			// AutoHelp normally intercepts bare `help` as HelpVerbRequestedError. Keep this path
+			// consistent if CommandLineParser ever hands us a parsed HelpVerb instead.
+			if (string.IsNullOrWhiteSpace(helper.HelpType))
+				WriteGlobalVerbListHelp(error);
+			else
+				error.WriteLine(helper.GetHelpText());
 			return new(result, ExitCode.ProcessCompletedSuccessfully);
 		}
 
 		if (result.TypeInfo.Current == typeof(HelpVerb))
 		{
 			//Error parsing the command, but the verb type was identified as HelpVerb
-			//Print LibationCli usage
-			var helpText = HelpVerb.CreateHelpText();
-			helpText.AddVerbs(VerbTypes);
-			error.WriteLine(helpText);
+			WriteGlobalVerbListHelp(error);
 			return new(result, ExitCode.ProcessCompletedSuccessfully);
 		}
 
 		if (result.Errors.Any())
-			return new(result, HandleErrors(result, error));
+			return new(result, HandleErrors(result, error, route));
 
 		return new(result, null);
 	}
 
-	private static ExitCode HandleErrors(ParserResult<object> result, TextWriter error)
+	private static ExitCode HandleErrors(ParserResult<object> result, TextWriter error, CliRoute route)
 	{
 		var errorsList = result.Errors.ToList();
 
 		if (errorsList.Any(e => e.Tag == ErrorType.HelpRequestedError))
 		{
-			WriteVerbOptionsHelp(result, error);
+			WriteVerbOptionsHelp(result, error, route);
 			return ExitCode.ProcessCompletedSuccessfully;
 		}
 
@@ -148,29 +150,26 @@ class Program
 			return ExitCode.ProcessCompletedSuccessfully;
 		}
 
-		var helpText = HelpVerb.CreateHelpText();
-
 		if (errorsList.OfType<NoVerbSelectedError>().Any())
 		{
-			//Print LibationCli usage
-			helpText.AddPreOptionsLine("No verb selected");
-			helpText.AddVerbs(VerbTypes);
+			WriteGlobalVerbListHelp(error, "No verb selected");
+			return ExitCode.ParseError;
 		}
-		else
+
+		//print the specified verb's usage
+		var helpText = HelpVerb.CreateHelpText();
+		helpText.AddDashesToOption = true;
+		helpText.AutoHelp = true;
+
+		if (!errorsList.OfType<UnknownOptionError>().Any(o => o.Token.ToLower() == "help"))
 		{
-			//print the specified verb's usage
-			helpText.AddDashesToOption = true;
-			helpText.AutoHelp = true;
-
-			if (!errorsList.OfType<UnknownOptionError>().Any(o => o.Token.ToLower() == "help"))
-			{
-				//verb was not executed with the "--help" option,
-				//so print verb option parsing error info.
-				helpText = HelpText.DefaultParsingErrorsHandler(result, helpText);
-			}
-
-			helpText.AddOptions(result);
+			//verb was not executed with the "--help" option,
+			//so print verb option parsing error info.
+			helpText = HelpText.DefaultParsingErrorsHandler(result, helpText);
 		}
+
+		AddNestedCommandHeading(helpText, route);
+		helpText.AddOptions(result);
 		error.WriteLine(helpText);
 		return ExitCode.ParseError;
 	}
@@ -209,24 +208,29 @@ class Program
 	}
 
 	private static void WriteGlobalVerbListHelp(TextWriter error, string? preOptionsLine = null)
+		=> HelpVerb.WriteGlobalVerbList(error, VerbTypes, CliCommandGroups.All, preOptionsLine);
+
+	private static void WriteVerbOptionsHelp(ParserResult<object> result, TextWriter error, CliRoute? route = null)
 	{
 		var helpText = HelpVerb.CreateHelpText();
-		if (preOptionsLine is not null)
-			helpText.AddPreOptionsLine(preOptionsLine);
-		helpText.AddVerbs(VerbTypes);
-		error.WriteLine(helpText);
-
-		foreach (var group in CliCommandGroups.All)
-			error.WriteLine($"  {group.Name,-21}{group.HelpText}");
-	}
-
-	private static void WriteVerbOptionsHelp(ParserResult<object> result, TextWriter error)
-	{
-		var helpText = HelpVerb.CreateHelpText();
+		AddNestedCommandHeading(helpText, route);
 		helpText.AddDashesToOption = true;
 		helpText.AutoHelp = true;
 		helpText.AddOptions(result);
 		error.WriteLine(helpText);
+	}
+
+	/// <summary>
+	/// Nested commands are rewritten to an internal parser verb (e.g. <c>upload</c>).
+	/// Brand help with the public path (<c>abs upload</c>) so the usage screen matches what users type.
+	/// </summary>
+	private static void AddNestedCommandHeading(HelpText helpText, CliRoute? route)
+	{
+		if (route?.Group is not { } group || route.Subcommand is not { } subcommand)
+			return;
+
+		helpText.AddPreOptionsLine($"{group.Name} {subcommand.Name}");
+		helpText.AddPreOptionsLine(subcommand.HelpText);
 	}
 
 	private static void WriteHelpForVerbRequestedError(HelpVerbRequestedError helpVerbErr, TextWriter error)

--- a/Source/_Tests/LibationCli.Tests/CliCommandRouterTests.cs
+++ b/Source/_Tests/LibationCli.Tests/CliCommandRouterTests.cs
@@ -34,14 +34,14 @@ public class CliCommandRouterTests
 			route.ParserArgs);
 	}
 
-	[DataTestMethod]
+	[TestMethod]
 	[DataRow(new[] { "help", "abs", "upload" }, new[] { "upload", "--help" })]
 	[DataRow(new[] { "abs", "upload", "--help" }, new[] { "upload", "--help" })]
 	[DataRow(new[] { "abs", "upload", "-h" }, new[] { "upload", "-h" })]
 	public void Nested_help_forms_resolve_to_upload(string[] input, string[] expected)
 		=> CollectionAssert.AreEqual(expected, CliCommandRouter.Route(input, CliCommandGroups.All).ParserArgs);
 
-	[DataTestMethod]
+	[TestMethod]
 	[DataRow("abs-upload", "--help")]
 	[DataRow("upload", "--help")]
 	public void Root_upload_aliases_are_rejected(params string[] args)

--- a/Source/_Tests/LibationCli.Tests/CliCommandRouterTests.cs
+++ b/Source/_Tests/LibationCli.Tests/CliCommandRouterTests.cs
@@ -55,15 +55,30 @@ public class CliCommandRouterTests
 	}
 
 	[TestMethod]
-	public void Global_help_lists_the_abs_group_without_legacy_upload_verb()
+	[DataRow("--help")]
+	[DataRow("help")]
+	[DataRow("-h")]
+	public void Global_help_lists_the_abs_group_without_legacy_upload_verb(string helpArg)
 	{
 		using var error = new StringWriter();
 
-		var outcome = Program.ParseInvocation(["--help"], error);
+		var outcome = Program.ParseInvocation([helpArg], error);
 
 		Assert.AreEqual(ExitCode.ProcessCompletedSuccessfully, outcome.ExitCode);
 		StringAssert.Contains(error.ToString(), "  abs                  Audiobookshelf commands.");
 		Assert.IsFalse(error.ToString().Contains("abs-upload", StringComparison.Ordinal));
+	}
+
+	[TestMethod]
+	public void Empty_args_lists_the_abs_group()
+	{
+		using var error = new StringWriter();
+
+		var outcome = Program.ParseInvocation([], error);
+
+		Assert.AreEqual(ExitCode.ParseError, outcome.ExitCode);
+		StringAssert.Contains(error.ToString(), "No verb selected");
+		StringAssert.Contains(error.ToString(), "  abs                  Audiobookshelf commands.");
 	}
 
 	[TestMethod]
@@ -87,10 +102,14 @@ public class CliCommandRouterTests
 	{
 		using var error = new StringWriter();
 		var outcome = Program.ParseInvocation(["abs", "upload", "--help"], error);
+		var output = error.ToString();
 
 		Assert.AreEqual(ExitCode.ProcessCompletedSuccessfully, outcome.ExitCode);
 		Assert.AreEqual(typeof(AbsUploadOptions), outcome.Result!.TypeInfo.Current);
-		StringAssert.Contains(error.ToString(), "--id");
+		StringAssert.Contains(output, "abs upload");
+		StringAssert.Contains(output, "Upload liberated audiobooks to Audiobookshelf.");
+		StringAssert.Contains(output, "--id");
+		Assert.IsFalse(output.Contains("\nupload\n", StringComparison.Ordinal));
 	}
 
 	[TestMethod]
@@ -126,9 +145,11 @@ public class CliCommandRouterTests
 		using var error = new StringWriter();
 
 		var outcome = Program.ParseInvocation(args, error);
+		var output = error.ToString();
 
 		Assert.AreEqual(ExitCode.ProcessCompletedSuccessfully, outcome.ExitCode);
-		StringAssert.Contains(error.ToString(), "--id");
+		StringAssert.Contains(output, "abs upload");
+		StringAssert.Contains(output, "--id");
 	}
 
 	[TestMethod]
@@ -190,4 +211,5 @@ public class CliCommandRouterTests
 		Assert.AreEqual(CliRouteKind.UnknownSubcommand, route.Kind);
 		route.Group!.Name.Should().Be("abs");
 	}
+
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Follow-up to #1918 help polish (non-blockers; PR body left alone).

1. **Empty-args / no-verb usage** now lists nested command groups (e.g. `abs`) the same way `--help` / bare `help` already did.
2. **Nested `abs upload --help`** (and `-h` / `help abs upload`) brands the public command path and short description, instead of looking like an unscoped options dump for the internal `upload` parser verb.

## Test plan

- [x] `LibationCli.Tests` (26) pass
- [x] Manual: empty args shows `abs`
- [x] Manual: `abs upload --help` starts with `abs upload` + Audiobookshelf blurb

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-dabfe3f0-a6a4-477c-afef-e1b37a50f0df?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-dabfe3f0-a6a4-477c-afef-e1b37a50f0df&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

