### PR TITLE
feat: opt-in daily download limit (rolling 24h)

### DIFF
--- a/.vitepress/config.js
+++ b/.vitepress/config.js
@@ -94,6 +94,10 @@ export default defineConfig({
             text: "Audiobookshelf Auto-Upload",
             link: "/docs/features/audiobookshelf",
           },
+          {
+            text: "Daily Download Limit",
+            link: "/docs/features/daily-download-limit",
+          },
           { text: "Naming Templates", link: "/docs/features/naming-templates" },
           {
             text: "Searching & Filtering",

--- a/Scripts/README.md
+++ b/Scripts/README.md
@@ -5,6 +5,7 @@ Developer utilities. None of these ship in a Libation install - they exist only 
 | Script | Purpose | Documented in |
 |--------|---------|---------------|
 | `seed-demo-library.cs` | Seed a library covering every Liberate-column icon, for manual UI testing | [Testing Changes](https://getlibation.com/docs/development/testing) |
+| `seed-download-history.cs` | Seed completed downloads so the daily download limit can be tested without downloading | [Testing Changes](https://getlibation.com/docs/development/testing) |
 | `Bundle_Debian.sh` | Build the Linux `.deb` package | Used by `.github/workflows/build-linux.yml` |
 | `Bundle_Redhat.sh` | Build the Linux RPM package | Used by `.github/workflows/build-linux.yml` |
 | `Bundle_MacOS.sh` | Build the macOS app bundle | Used by `.github/workflows/build-mac.yml` |

--- a/Scripts/seed-download-history.cs
+++ b/Scripts/seed-download-history.cs
@@ -1,0 +1,116 @@
+#:package Microsoft.Data.Sqlite@10.0.7
+
+using Microsoft.Data.Sqlite;
+
+// Seeds Libation's DownloadHistory table with fake completed downloads, for manual testing of the
+// daily download limit without downloading anything.
+//
+//   dotnet run Scripts/seed-download-history.cs [--count 50] [--age-seconds 7200] [--owned]
+//                                               [--mb 300] [--clean] [path-to-Libation-files-folder]
+//
+// The limit uses a rolling 24 hour window, so --age-seconds controls how soon the rows fall out of it:
+//
+//   --age-seconds 7200    two hours ago: the limit stays reached for the next 22 hours
+//   --age-seconds 86325   just under 24 hours ago: a paused queue resumes itself about a minute from now
+//
+// Pass --clean to delete all rows. Libation can be running; each row is just a row.
+
+const string FakeAsinPrefix = "FAKE";
+
+var clean = args.Contains("--clean", StringComparer.OrdinalIgnoreCase);
+var owned = args.Contains("--owned", StringComparer.OrdinalIgnoreCase);
+var count = IntArg("--count") ?? 50;
+var ageSeconds = IntArg("--age-seconds") ?? 7200;
+var megabytes = IntArg("--mb") ?? 300;
+var pathArg = args.FirstOrDefault(a => !a.StartsWith("--") && !int.TryParse(a, out _));
+
+if (FindLibationFiles(pathArg) is not string libationFiles)
+{
+	Console.Error.WriteLine("Could not find a Libation database.");
+	Console.Error.WriteLine("Run Libation once to create it, then pass its folder, e.g.:");
+	Console.Error.WriteLine(@"  dotnet run Scripts/seed-download-history.cs C:\Users\me\AppData\Local\Libation");
+	return 1;
+}
+
+var dbPath = Path.Combine(libationFiles, "LibationContext.db");
+Console.WriteLine($"Database: {dbPath}");
+
+using var connection = new SqliteConnection(new SqliteConnectionStringBuilder { DataSource = dbPath }.ToString());
+connection.Open();
+
+if (!TableExists())
+{
+	Console.Error.WriteLine("This database has no DownloadHistory table yet. Start Libation once so it applies migrations, then retry.");
+	return 1;
+}
+
+if (clean)
+{
+	Console.WriteLine($"Removed {Execute("delete from DownloadHistory")} download history row(s).");
+	return 0;
+}
+
+// Stored as UTC ticks so the rolling window is exact on every provider and across DST changes.
+var completedAt = DateTimeOffset.Now.AddSeconds(-ageSeconds);
+var bytes = megabytes * 1024L * 1024;
+
+using var transaction = connection.BeginTransaction();
+for (var i = 0; i < count; i++)
+{
+	Execute(
+		"""
+		insert into DownloadHistory (CompletedAtUtcTicks, AudibleProductId, IsAudiblePlus, Bytes)
+		values ($ticks, $asin, $isPlus, $bytes)
+		""",
+		("$ticks", completedAt.AddSeconds(i).UtcTicks),
+		("$asin", $"{FakeAsinPrefix}{i:0000}"),
+		("$isPlus", owned ? 0 : 1),
+		("$bytes", bytes));
+}
+transaction.Commit();
+
+Console.WriteLine(
+	$"Inserted {count} {(owned ? "purchased" : "Audible Plus")} download(s) of {megabytes} MB each, " +
+	$"completed {TimeSpan.FromSeconds(ageSeconds):g} ago.");
+Console.WriteLine($"Total rows: {Scalar("select count(*) from DownloadHistory")}");
+Console.WriteLine($"The oldest leaves the 24 hour window at {completedAt.AddHours(24):yyyy-MM-dd HH:mm:ss}");
+return 0;
+
+int? IntArg(string name)
+{
+	var index = Array.FindIndex(args, a => a.Equals(name, StringComparison.OrdinalIgnoreCase));
+	return index >= 0 && index + 1 < args.Length && int.TryParse(args[index + 1], out var value) ? value : null;
+}
+
+bool TableExists()
+	=> Scalar("select count(*) from sqlite_master where type = 'table' and name = 'DownloadHistory'") > 0;
+
+int Execute(string sql, params (string Name, object Value)[] parameters)
+{
+	using var command = connection.CreateCommand();
+	command.CommandText = sql;
+	foreach (var (name, value) in parameters)
+		command.Parameters.AddWithValue(name, value);
+	return command.ExecuteNonQuery();
+}
+
+long Scalar(string sql)
+{
+	using var command = connection.CreateCommand();
+	command.CommandText = sql;
+	return Convert.ToInt64(command.ExecuteScalar());
+}
+
+static string? FindLibationFiles(string? explicitPath)
+{
+	if (explicitPath is not null)
+		return File.Exists(Path.Combine(explicitPath, "LibationContext.db")) ? explicitPath : null;
+
+	string[] candidates =
+	[
+		Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "Libation"),
+		Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), "Libation"),
+	];
+
+	return candidates.FirstOrDefault(c => File.Exists(Path.Combine(c, "LibationContext.db")));
+}

--- a/Source/ApplicationServices/DownloadHistoryStore.cs
+++ b/Source/ApplicationServices/DownloadHistoryStore.cs
@@ -1,0 +1,85 @@
+using DataLayer;
+using LibationFileManager;
+using Microsoft.EntityFrameworkCore;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace ApplicationServices;
+
+/// <summary>
+/// Reads and writes the record of successful audiobook downloads backing the daily download limit.
+/// <para>
+/// Caches nothing: every read is a fresh query, so a queue paused for hours sees entries age out of the
+/// rolling window, and downloads performed by a concurrently running CLI or second container are counted too.
+/// </para>
+/// </summary>
+public static class DownloadHistoryStore
+{
+	/// <summary>Kept a little beyond the 24 hour window so the table stays small without losing anything in use.</summary>
+	private static readonly TimeSpan RetentionPeriod = TimeSpan.FromHours(48);
+
+	/// <summary>
+	/// Records a finished download. Never throws: bookkeeping must not fail a download that already succeeded.
+	/// </summary>
+	public static void Record(string? audibleProductId, bool isAudiblePlus, long bytes, DateTimeOffset? completedAt = null)
+	{
+		try
+		{
+			var when = completedAt ?? DateTimeOffset.Now;
+
+			using var context = DbContexts.GetContext();
+			context.DownloadHistory.Add(new DownloadHistory(when, audibleProductId, isAudiblePlus, bytes));
+
+			var cutoff = (when - RetentionPeriod).UtcTicks;
+			var expired = context.DownloadHistory.Where(dh => dh.CompletedAtUtcTicks < cutoff);
+			context.DownloadHistory.RemoveRange(expired);
+
+			context.SaveChanges();
+
+			Serilog.Log.Logger.Debug(
+				"Recorded download for the daily download limit. {@DebugInfo}",
+				new { audibleProductId, isAudiblePlus, bytes, completedAt = when });
+		}
+		catch (Exception ex)
+		{
+			Serilog.Log.Logger.Error(
+				ex,
+				"Failed to record a completed download for the daily download limit. The download itself succeeded. {@DebugInfo}",
+				new { audibleProductId, isAudiblePlus, bytes });
+		}
+	}
+
+	/// <summary>Downloads completed at or after <paramref name="since"/>. Empty when the query fails.</summary>
+	public static IReadOnlyList<DownloadHistoryEntry> GetSince(DateTimeOffset since)
+	{
+		try
+		{
+			var ticks = since.UtcTicks;
+
+			using var context = DbContexts.GetContext();
+			return context.DownloadHistory
+				.AsNoTracking()
+				.Where(dh => dh.CompletedAtUtcTicks >= ticks)
+				.OrderBy(dh => dh.CompletedAtUtcTicks)
+				.Select(dh => new { dh.CompletedAtUtcTicks, dh.AudibleProductId, dh.IsAudiblePlus, dh.Bytes })
+				.ToList()
+				.Select(dh => new DownloadHistoryEntry(
+					new DateTimeOffset(dh.CompletedAtUtcTicks, TimeSpan.Zero),
+					dh.AudibleProductId,
+					dh.IsAudiblePlus,
+					dh.Bytes))
+				.ToList();
+		}
+		catch (Exception ex)
+		{
+			// Failing open is the safer default: a broken query must not block downloading.
+			Serilog.Log.Logger.Error(ex, "Failed to read download history. Treating the last 24 hours as empty.");
+			return [];
+		}
+	}
+
+	/// <summary>The rolling window the daily download limit uses.</summary>
+	public static IReadOnlyList<DownloadHistoryEntry> GetCurrentWindow(DateTimeOffset now)
+		=> GetSince(now - DailyDownloadLimit.Window);
+}

--- a/Source/DataLayer.Postgres/Migrations/20260814170831_AddDownloadHistory.Designer.cs
+++ b/Source/DataLayer.Postgres/Migrations/20260814170831_AddDownloadHistory.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using DataLayer;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace DataLayer.Postgres.Migrations
 {
     [DbContext(typeof(LibationContext))]
-    partial class LibationContextModelSnapshot : ModelSnapshot
+    [Migration("20260814170831_AddDownloadHistory")]
+    partial class AddDownloadHistory
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Source/DataLayer.Postgres/Migrations/20260814170831_AddDownloadHistory.cs
+++ b/Source/DataLayer.Postgres/Migrations/20260814170831_AddDownloadHistory.cs
@@ -1,0 +1,43 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
+
+#nullable disable
+
+namespace DataLayer.Postgres.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddDownloadHistory : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "DownloadHistory",
+                columns: table => new
+                {
+                    DownloadHistoryId = table.Column<int>(type: "integer", nullable: false)
+                        .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn),
+                    CompletedAtUtcTicks = table.Column<long>(type: "bigint", nullable: false),
+                    AudibleProductId = table.Column<string>(type: "text", nullable: true),
+                    IsAudiblePlus = table.Column<bool>(type: "boolean", nullable: false),
+                    Bytes = table.Column<long>(type: "bigint", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_DownloadHistory", x => x.DownloadHistoryId);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_DownloadHistory_CompletedAtUtcTicks",
+                table: "DownloadHistory",
+                column: "CompletedAtUtcTicks");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "DownloadHistory");
+        }
+    }
+}

--- a/Source/DataLayer.Sqlite/Migrations/20260814170839_AddDownloadHistory.Designer.cs
+++ b/Source/DataLayer.Sqlite/Migrations/20260814170839_AddDownloadHistory.Designer.cs
@@ -3,32 +3,30 @@ using System;
 using DataLayer;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
-using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
 #nullable disable
 
-namespace DataLayer.Postgres.Migrations
+namespace DataLayer.Migrations
 {
     [DbContext(typeof(LibationContext))]
-    partial class LibationContextModelSnapshot : ModelSnapshot
+    [Migration("20260814170839_AddDownloadHistory")]
+    partial class AddDownloadHistory
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
-            modelBuilder
-                .HasAnnotation("ProductVersion", "10.0.7")
-                .HasAnnotation("Relational:MaxIdentifierLength", 63);
-
-            NpgsqlModelBuilderExtensions.UseIdentityByDefaultColumns(modelBuilder);
+            modelBuilder.HasAnnotation("ProductVersion", "10.0.7");
 
             modelBuilder.Entity("CategoryCategoryLadder", b =>
                 {
                     b.Property<int>("_categoriesCategoryId")
-                        .HasColumnType("integer");
+                        .HasColumnType("INTEGER");
 
                     b.Property<int>("_categoryLaddersCategoryLadderId")
-                        .HasColumnType("integer");
+                        .HasColumnType("INTEGER");
 
                     b.HasKey("_categoriesCategoryId", "_categoryLaddersCategoryLadderId");
 
@@ -41,53 +39,51 @@ namespace DataLayer.Postgres.Migrations
                 {
                     b.Property<int>("BookId")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("integer");
-
-                    NpgsqlPropertyBuilderExtensions.UseIdentityByDefaultColumn(b.Property<int>("BookId"));
+                        .HasColumnType("INTEGER");
 
                     b.Property<string>("AudibleProductId")
                         .IsRequired()
-                        .HasColumnType("text");
+                        .HasColumnType("TEXT");
 
                     b.Property<int>("ContentType")
-                        .HasColumnType("integer");
+                        .HasColumnType("INTEGER");
 
                     b.Property<DateTime?>("DatePublished")
-                        .HasColumnType("timestamp without time zone");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("Description")
                         .IsRequired()
-                        .HasColumnType("text");
+                        .HasColumnType("TEXT");
 
                     b.Property<bool>("IsAbridged")
-                        .HasColumnType("boolean");
+                        .HasColumnType("INTEGER");
 
                     b.Property<bool>("IsSpatial")
-                        .HasColumnType("boolean");
+                        .HasColumnType("INTEGER");
 
                     b.Property<string>("Language")
-                        .HasColumnType("text");
+                        .HasColumnType("TEXT");
 
                     b.Property<int>("LengthInMinutes")
-                        .HasColumnType("integer");
+                        .HasColumnType("INTEGER");
 
                     b.Property<string>("Locale")
                         .IsRequired()
-                        .HasColumnType("text");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("PictureId")
-                        .HasColumnType("text");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("PictureLarge")
-                        .HasColumnType("text");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("Subtitle")
                         .IsRequired()
-                        .HasColumnType("text");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("Title")
                         .IsRequired()
-                        .HasColumnType("text");
+                        .HasColumnType("TEXT");
 
                     b.HasKey("BookId");
 
@@ -99,10 +95,10 @@ namespace DataLayer.Postgres.Migrations
             modelBuilder.Entity("DataLayer.BookCategory", b =>
                 {
                     b.Property<int>("BookId")
-                        .HasColumnType("integer");
+                        .HasColumnType("INTEGER");
 
                     b.Property<int>("CategoryLadderId")
-                        .HasColumnType("integer");
+                        .HasColumnType("INTEGER");
 
                     b.HasKey("BookId", "CategoryLadderId");
 
@@ -116,16 +112,16 @@ namespace DataLayer.Postgres.Migrations
             modelBuilder.Entity("DataLayer.BookContributor", b =>
                 {
                     b.Property<int>("BookId")
-                        .HasColumnType("integer");
+                        .HasColumnType("INTEGER");
 
                     b.Property<int>("ContributorId")
-                        .HasColumnType("integer");
+                        .HasColumnType("INTEGER");
 
                     b.Property<int>("Role")
-                        .HasColumnType("integer");
+                        .HasColumnType("INTEGER");
 
                     b.Property<byte>("Order")
-                        .HasColumnType("smallint");
+                        .HasColumnType("INTEGER");
 
                     b.HasKey("BookId", "ContributorId", "Role");
 
@@ -140,17 +136,15 @@ namespace DataLayer.Postgres.Migrations
                 {
                     b.Property<int>("CategoryId")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("integer");
-
-                    NpgsqlPropertyBuilderExtensions.UseIdentityByDefaultColumn(b.Property<int>("CategoryId"));
+                        .HasColumnType("INTEGER");
 
                     b.Property<string>("AudibleCategoryId")
                         .IsRequired()
-                        .HasColumnType("text");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("Name")
                         .IsRequired()
-                        .HasColumnType("text");
+                        .HasColumnType("TEXT");
 
                     b.HasKey("CategoryId");
 
@@ -163,9 +157,7 @@ namespace DataLayer.Postgres.Migrations
                 {
                     b.Property<int>("CategoryLadderId")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("integer");
-
-                    NpgsqlPropertyBuilderExtensions.UseIdentityByDefaultColumn(b.Property<int>("CategoryLadderId"));
+                        .HasColumnType("INTEGER");
 
                     b.HasKey("CategoryLadderId");
 
@@ -176,16 +168,14 @@ namespace DataLayer.Postgres.Migrations
                 {
                     b.Property<int>("ContributorId")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("integer");
-
-                    NpgsqlPropertyBuilderExtensions.UseIdentityByDefaultColumn(b.Property<int>("ContributorId"));
+                        .HasColumnType("INTEGER");
 
                     b.Property<string>("AudibleContributorId")
-                        .HasColumnType("text");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("Name")
                         .IsRequired()
-                        .HasColumnType("text");
+                        .HasColumnType("TEXT");
 
                     b.HasKey("ContributorId");
 
@@ -205,21 +195,19 @@ namespace DataLayer.Postgres.Migrations
                 {
                     b.Property<int>("DownloadHistoryId")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("integer");
-
-                    NpgsqlPropertyBuilderExtensions.UseIdentityByDefaultColumn(b.Property<int>("DownloadHistoryId"));
+                        .HasColumnType("INTEGER");
 
                     b.Property<string>("AudibleProductId")
-                        .HasColumnType("text");
+                        .HasColumnType("TEXT");
 
                     b.Property<long>("Bytes")
-                        .HasColumnType("bigint");
+                        .HasColumnType("INTEGER");
 
                     b.Property<long>("CompletedAtUtcTicks")
-                        .HasColumnType("bigint");
+                        .HasColumnType("INTEGER");
 
                     b.Property<bool>("IsAudiblePlus")
-                        .HasColumnType("boolean");
+                        .HasColumnType("INTEGER");
 
                     b.HasKey("DownloadHistoryId");
 
@@ -231,26 +219,26 @@ namespace DataLayer.Postgres.Migrations
             modelBuilder.Entity("DataLayer.LibraryBook", b =>
                 {
                     b.Property<int>("BookId")
-                        .HasColumnType("integer");
+                        .HasColumnType("INTEGER");
 
                     b.Property<bool>("AbsentFromLastScan")
-                        .HasColumnType("boolean");
+                        .HasColumnType("INTEGER");
 
                     b.Property<string>("Account")
                         .IsRequired()
-                        .HasColumnType("text");
+                        .HasColumnType("TEXT");
 
                     b.Property<DateTime>("DateAdded")
-                        .HasColumnType("timestamp without time zone");
+                        .HasColumnType("TEXT");
 
                     b.Property<DateTime?>("IncludedUntil")
-                        .HasColumnType("timestamp without time zone");
+                        .HasColumnType("TEXT");
 
                     b.Property<bool>("IsAudiblePlus")
-                        .HasColumnType("boolean");
+                        .HasColumnType("INTEGER");
 
                     b.Property<bool>("IsDeleted")
-                        .HasColumnType("boolean");
+                        .HasColumnType("INTEGER");
 
                     b.HasKey("BookId");
 
@@ -261,16 +249,14 @@ namespace DataLayer.Postgres.Migrations
                 {
                     b.Property<int>("SeriesId")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("integer");
-
-                    NpgsqlPropertyBuilderExtensions.UseIdentityByDefaultColumn(b.Property<int>("SeriesId"));
+                        .HasColumnType("INTEGER");
 
                     b.Property<string>("AudibleSeriesId")
                         .IsRequired()
-                        .HasColumnType("text");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("Name")
-                        .HasColumnType("text");
+                        .HasColumnType("TEXT");
 
                     b.HasKey("SeriesId");
 
@@ -282,13 +268,13 @@ namespace DataLayer.Postgres.Migrations
             modelBuilder.Entity("DataLayer.SeriesBook", b =>
                 {
                     b.Property<int>("SeriesId")
-                        .HasColumnType("integer");
+                        .HasColumnType("INTEGER");
 
                     b.Property<int>("BookId")
-                        .HasColumnType("integer");
+                        .HasColumnType("INTEGER");
 
                     b.Property<string>("Order")
-                        .HasColumnType("text");
+                        .HasColumnType("TEXT");
 
                     b.HasKey("SeriesId", "BookId");
 
@@ -319,16 +305,16 @@ namespace DataLayer.Postgres.Migrations
                     b.OwnsOne("DataLayer.Rating", "Rating", b1 =>
                         {
                             b1.Property<int>("BookId")
-                                .HasColumnType("integer");
+                                .HasColumnType("INTEGER");
 
                             b1.Property<float>("OverallRating")
-                                .HasColumnType("real");
+                                .HasColumnType("REAL");
 
                             b1.Property<float>("PerformanceRating")
-                                .HasColumnType("real");
+                                .HasColumnType("REAL");
 
                             b1.Property<float>("StoryRating")
-                                .HasColumnType("real");
+                                .HasColumnType("REAL");
 
                             b1.HasKey("BookId");
 
@@ -342,16 +328,14 @@ namespace DataLayer.Postgres.Migrations
                         {
                             b1.Property<int>("SupplementId")
                                 .ValueGeneratedOnAdd()
-                                .HasColumnType("integer");
-
-                            NpgsqlPropertyBuilderExtensions.UseIdentityByDefaultColumn(b1.Property<int>("SupplementId"));
+                                .HasColumnType("INTEGER");
 
                             b1.Property<int>("BookId")
-                                .HasColumnType("integer");
+                                .HasColumnType("INTEGER");
 
                             b1.Property<string>("Url")
                                 .IsRequired()
-                                .HasColumnType("text");
+                                .HasColumnType("TEXT");
 
                             b1.HasKey("SupplementId");
 
@@ -368,32 +352,32 @@ namespace DataLayer.Postgres.Migrations
                     b.OwnsOne("DataLayer.UserDefinedItem", "UserDefinedItem", b1 =>
                         {
                             b1.Property<int>("BookId")
-                                .HasColumnType("integer");
+                                .HasColumnType("INTEGER");
 
                             b1.Property<int>("BookStatus")
-                                .HasColumnType("integer");
+                                .HasColumnType("INTEGER");
 
                             b1.Property<bool>("IsFinished")
-                                .HasColumnType("boolean");
+                                .HasColumnType("INTEGER");
 
                             b1.Property<DateTime?>("LastDownloaded")
-                                .HasColumnType("timestamp without time zone");
+                                .HasColumnType("TEXT");
 
                             b1.Property<string>("LastDownloadedFileVersion")
-                                .HasColumnType("text");
+                                .HasColumnType("TEXT");
 
                             b1.Property<long?>("LastDownloadedFormat")
-                                .HasColumnType("bigint");
+                                .HasColumnType("INTEGER");
 
                             b1.Property<string>("LastDownloadedVersion")
-                                .HasColumnType("text");
+                                .HasColumnType("TEXT");
 
                             b1.Property<int?>("PdfStatus")
-                                .HasColumnType("integer");
+                                .HasColumnType("INTEGER");
 
                             b1.Property<string>("Tags")
                                 .IsRequired()
-                                .HasColumnType("text");
+                                .HasColumnType("TEXT");
 
                             b1.HasKey("BookId");
 
@@ -405,16 +389,16 @@ namespace DataLayer.Postgres.Migrations
                             b1.OwnsOne("DataLayer.Rating", "Rating", b2 =>
                                 {
                                     b2.Property<int>("UserDefinedItemBookId")
-                                        .HasColumnType("integer");
+                                        .HasColumnType("INTEGER");
 
                                     b2.Property<float>("OverallRating")
-                                        .HasColumnType("real");
+                                        .HasColumnType("REAL");
 
                                     b2.Property<float>("PerformanceRating")
-                                        .HasColumnType("real");
+                                        .HasColumnType("REAL");
 
                                     b2.Property<float>("StoryRating")
-                                        .HasColumnType("real");
+                                        .HasColumnType("REAL");
 
                                     b2.HasKey("UserDefinedItemBookId");
 

--- a/Source/DataLayer.Sqlite/Migrations/20260814170839_AddDownloadHistory.cs
+++ b/Source/DataLayer.Sqlite/Migrations/20260814170839_AddDownloadHistory.cs
@@ -1,0 +1,42 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace DataLayer.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddDownloadHistory : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "DownloadHistory",
+                columns: table => new
+                {
+                    DownloadHistoryId = table.Column<int>(type: "INTEGER", nullable: false)
+                        .Annotation("Sqlite:Autoincrement", true),
+                    CompletedAtUtcTicks = table.Column<long>(type: "INTEGER", nullable: false),
+                    AudibleProductId = table.Column<string>(type: "TEXT", nullable: true),
+                    IsAudiblePlus = table.Column<bool>(type: "INTEGER", nullable: false),
+                    Bytes = table.Column<long>(type: "INTEGER", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_DownloadHistory", x => x.DownloadHistoryId);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_DownloadHistory_CompletedAtUtcTicks",
+                table: "DownloadHistory",
+                column: "CompletedAtUtcTicks");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "DownloadHistory");
+        }
+    }
+}

--- a/Source/DataLayer.Sqlite/Migrations/LibationContextModelSnapshot.cs
+++ b/Source/DataLayer.Sqlite/Migrations/LibationContextModelSnapshot.cs
@@ -15,7 +15,7 @@ namespace DataLayer.Migrations
         protected override void BuildModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
-            modelBuilder.HasAnnotation("ProductVersion", "10.0.2");
+            modelBuilder.HasAnnotation("ProductVersion", "10.0.7");
 
             modelBuilder.Entity("CategoryCategoryLadder", b =>
                 {
@@ -186,6 +186,31 @@ namespace DataLayer.Migrations
                             ContributorId = -1,
                             Name = ""
                         });
+                });
+
+            modelBuilder.Entity("DataLayer.DownloadHistory", b =>
+                {
+                    b.Property<int>("DownloadHistoryId")
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType("INTEGER");
+
+                    b.Property<string>("AudibleProductId")
+                        .HasColumnType("TEXT");
+
+                    b.Property<long>("Bytes")
+                        .HasColumnType("INTEGER");
+
+                    b.Property<long>("CompletedAtUtcTicks")
+                        .HasColumnType("INTEGER");
+
+                    b.Property<bool>("IsAudiblePlus")
+                        .HasColumnType("INTEGER");
+
+                    b.HasKey("DownloadHistoryId");
+
+                    b.HasIndex("CompletedAtUtcTicks");
+
+                    b.ToTable("DownloadHistory");
                 });
 
             modelBuilder.Entity("DataLayer.LibraryBook", b =>

--- a/Source/DataLayer/Configurations/DownloadHistoryConfig.cs
+++ b/Source/DataLayer/Configurations/DownloadHistoryConfig.cs
@@ -1,0 +1,15 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace DataLayer.Configurations;
+
+internal class DownloadHistoryConfig : IEntityTypeConfiguration<DownloadHistory>
+{
+	public void Configure(EntityTypeBuilder<DownloadHistory> entity)
+	{
+		entity.HasKey(dh => dh.DownloadHistoryId);
+
+		// Every read is a range query over the rolling window, and every write prunes by age.
+		entity.HasIndex(dh => dh.CompletedAtUtcTicks);
+	}
+}

--- a/Source/DataLayer/EfClasses/DownloadHistory.cs
+++ b/Source/DataLayer/EfClasses/DownloadHistory.cs
@@ -1,0 +1,45 @@
+using System;
+
+namespace DataLayer;
+
+/// <summary>
+/// One successful audiobook download, recorded so the opt-in daily download limit survives restarts.
+/// Recorded for every download regardless of whether a limit is configured: a user who turns the limit
+/// on after a heavy session gets a limit that reflects what actually happened.
+/// <para>
+/// The database is deliberately the home for this instead of a file under LibationFiles: in Docker,
+/// LibationFiles is a throwaway directory inside the container and only the database is on a volume.
+/// </para>
+/// </summary>
+public class DownloadHistory
+{
+	internal int DownloadHistoryId { get; private set; }
+
+	/// <summary>
+	/// UTC ticks rather than a DateTime so range queries mean the same thing on SQLite and PostgreSQL, and so a
+	/// window that spans a DST change stays exactly 24 hours. Local time is for display only.
+	/// </summary>
+	public long CompletedAtUtcTicks { get; private set; }
+
+	public string? AudibleProductId { get; private set; }
+
+	public bool IsAudiblePlus { get; private set; }
+
+	/// <summary>Size on disk of the files written to the Books directory for this title.</summary>
+	public long Bytes { get; private set; }
+
+	public DateTimeOffset CompletedAt => new(CompletedAtUtcTicks, TimeSpan.Zero);
+
+	private DownloadHistory() { }
+
+	public DownloadHistory(DateTimeOffset completedAt, string? audibleProductId, bool isAudiblePlus, long bytes)
+	{
+		CompletedAtUtcTicks = completedAt.UtcTicks;
+		AudibleProductId = audibleProductId;
+		IsAudiblePlus = isAudiblePlus;
+		Bytes = bytes;
+	}
+
+	public override string ToString()
+		=> $"{AudibleProductId} {CompletedAt.ToLocalTime()} {(IsAudiblePlus ? "Plus" : "owned")} {Bytes} bytes";
+}

--- a/Source/DataLayer/LibationContext.cs
+++ b/Source/DataLayer/LibationContext.cs
@@ -26,6 +26,7 @@ public class LibationContext : DbContext, INotifyDisposed
 	public DbSet<Series> Series { get; private set; }
 	public DbSet<Category> Categories { get; private set; }
 	public DbSet<CategoryLadder> CategoryLadders { get; private set; }
+	public DbSet<DownloadHistory> DownloadHistory { get; private set; }
 
 	public event EventHandler? ObjectDisposed;
 	public override void Dispose()
@@ -56,6 +57,7 @@ public class LibationContext : DbContext, INotifyDisposed
 		modelBuilder.ApplyConfiguration(new CategoryConfig());
 		modelBuilder.ApplyConfiguration(new CategoryLadderConfig());
 		modelBuilder.ApplyConfiguration(new BookCategoryConfig());
+		modelBuilder.ApplyConfiguration(new DownloadHistoryConfig());
 
 		// views are now supported via "keyless entity types" (instead of "entity types" or the prev "query types"):
 		// https://docs.microsoft.com/en-us/ef/core/modeling/keyless-entity-types

--- a/Source/FileLiberator/DownloadDecryptBook.cs
+++ b/Source/FileLiberator/DownloadDecryptBook.cs
@@ -113,6 +113,7 @@ public class DownloadDecryptBook : AudioDecodable, IProcessable<DownloadDecryptB
 
 				Serilog.Log.Verbose("Updating liberated status for {@Book}", libraryBook.LogFriendly());
 				await libraryBook.UpdateBookStatusAsync(LiberatedStatus.Liberated, Configuration.LibationVersion, audioFormat, audioVersion);
+				RecordDownloadForDailyLimit(libraryBook, result.ResultFiles);
 				Serilog.Log.Verbose("Setting directory time for {@Book}", libraryBook.LogFriendly());
 				SetDirectoryTime(libraryBook, finalStorageDir);
 				Serilog.Log.Verbose("Deleting cache files for {@Book}", libraryBook.LogFriendly());
@@ -310,6 +311,24 @@ public class DownloadDecryptBook : AudioDecodable, IProcessable<DownloadDecryptB
 	#endregion
 
 	#region Post-success routines
+	/// <summary>
+	/// Records the finished download for the daily download limit. Always recorded, even when no limit is
+	/// configured, so that turning the limit on later reflects downloads already performed.
+	/// </summary>
+	private static void RecordDownloadForDailyLimit(LibraryBook libraryBook, List<TempFile> movedFiles)
+	{
+		try
+		{
+			// Files have already been moved, so these paths are their final locations in the Books directory.
+			var bytes = movedFiles.Sum(f => File.Exists(f.FilePath) ? new FileInfo(f.FilePath).Length : 0);
+			DownloadHistoryStore.Record(libraryBook.Book.AudibleProductId, libraryBook.IsAudiblePlus, bytes);
+		}
+		catch (Exception ex)
+		{
+			Serilog.Log.Logger.Error(ex, "Failed to measure a completed download for the daily download limit. The download itself succeeded. {@Book}", libraryBook.LogFriendly());
+		}
+	}
+
 	/// <summary>Read the audio format from the audio file's metadata.</summary>
 	public AudioFormat GetFileFormatInfo(DownloadOptions options, TempFile firstAudioFile)
 	{

--- a/Source/LibationAvalonia/Controls/Settings/DownloadDecrypt.axaml
+++ b/Source/LibationAvalonia/Controls/Settings/DownloadDecrypt.axaml
@@ -8,9 +8,67 @@
 			 x:DataType="vm:DownloadDecryptSettingsVM"
              x:Class="LibationAvalonia.Controls.Settings.DownloadDecrypt">
 	
-	<Grid RowDefinitions="Auto,Auto,Auto,*">
+	<Grid RowDefinitions="Auto,Auto,Auto,Auto,*">
 		<controls:GroupBox
 			Grid.Row="0"
+			Margin="5"
+			Label="{Binding DailyDownloadLimitGroupboxText}">
+
+			<StackPanel Margin="0,5">
+
+				<TextBlock
+					Margin="0,0,0,8"
+					TextWrapping="Wrap"
+					Text="{Binding DailyDownloadLimitDescriptionText}" />
+
+				<controls:WheelComboBox
+					HorizontalAlignment="Left"
+					MinWidth="200"
+					ToolTip.Tip="{Binding DailyDownloadLimitTip}"
+					ItemsSource="{Binding DailyDownloadLimitScopes}"
+					SelectedItem="{Binding DailyDownloadLimit}" />
+
+				<StackPanel
+					Margin="0,8,0,0"
+					Orientation="Horizontal"
+					IsVisible="{Binding DailyDownloadLimitQuantityVisible}">
+
+					<TextBlock
+						VerticalAlignment="Center"
+						Text="{Binding DailyDownloadLimitQuantityText}" />
+
+					<NumericUpDown
+						Classes="SmallNumericUpDown"
+						Margin="5,0,0,0"
+						MinWidth="140"
+						Minimum="1"
+						Maximum="2147483647"
+						Increment="1"
+						FormatString="N0"
+						ParsingNumberStyle="Integer"
+						Value="{Binding DailyDownloadLimitQuantity, Mode=TwoWay}" />
+
+					<controls:WheelComboBox
+						Margin="10,0,0,0"
+						MinWidth="90"
+						ItemsSource="{Binding DailyDownloadLimitUnits}"
+						SelectedItem="{Binding DailyDownloadLimitUnit}" />
+
+				</StackPanel>
+
+				<TextBlock
+					Margin="0,6,0,0"
+					FontStyle="Italic"
+					Opacity="0.8"
+					TextWrapping="Wrap"
+					IsVisible="{Binding DailyDownloadLimitApproximateNoteVisible}"
+					Text="{Binding DailyDownloadLimitApproximateNoteText}" />
+
+			</StackPanel>
+		</controls:GroupBox>
+
+		<controls:GroupBox
+			Grid.Row="1"
 			Margin="5"
 			Label="{Binding BadBookGroupboxText}">
 
@@ -66,7 +124,7 @@
 
 		<controls:GroupBox
 			Margin="5"
-			Grid.Row="1"
+			Grid.Row="2"
 			Label="Custom File Naming">
 
 			<Grid
@@ -146,7 +204,7 @@
 			</Grid>
 		</controls:GroupBox>
 		<controls:GroupBox
-			Grid.Row="2"
+			Grid.Row="3"
 			Margin="5"
 			Label="Temporary Files Location">
 
@@ -166,7 +224,7 @@
 		</controls:GroupBox>
 
 		<StackPanel
-			Grid.Row="3"
+			Grid.Row="4"
 			Orientation="Horizontal">
 
 			<CheckBox

--- a/Source/LibationAvalonia/ViewModels/Settings/DownloadDecryptSettingsVM.cs
+++ b/Source/LibationAvalonia/ViewModels/Settings/DownloadDecryptSettingsVM.cs
@@ -1,7 +1,10 @@
 ﻿using Dinah.Core;
 using LibationFileManager;
+using LibationUiBase;
 using ReactiveUI;
+using System;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace LibationAvalonia.ViewModels.Settings;
 
@@ -25,6 +28,10 @@ public class DownloadDecryptSettingsVM : ViewModelBase
 		InProgressDirectory = config.InProgress;
 		UseCoverAsFolderIcon = config.UseCoverAsFolderIcon;
 		SaveMetadataToFile = config.SaveMetadataToFile;
+
+		_dailyDownloadLimit = DailyDownloadLimitScopes.SingleOrDefault(s => s.Value == config.DailyDownloadLimit) ?? DailyDownloadLimitScopes[0];
+		_dailyDownloadLimitQuantity = config.DailyDownloadLimitQuantity;
+		_dailyDownloadLimitUnit = DailyDownloadLimitUnits.SingleOrDefault(u => u.Value == config.DailyDownloadLimitUnit) ?? DailyDownloadLimitUnits[0];
 	}
 
 	public List<Configuration.KnownDirectories> KnownDirectories { get; } = new()
@@ -52,7 +59,65 @@ public class DownloadDecryptSettingsVM : ViewModelBase
 
 		config.UseCoverAsFolderIcon = UseCoverAsFolderIcon;
 		config.SaveMetadataToFile = SaveMetadataToFile;
+
+		config.DailyDownloadLimit = DailyDownloadLimit?.Value ?? config.DailyDownloadLimit;
+		config.DailyDownloadLimitQuantity = DailyDownloadLimitQuantity;
+		config.DailyDownloadLimitUnit = DailyDownloadLimitUnit?.Value ?? config.DailyDownloadLimitUnit;
 	}
+
+	#region daily download limit
+
+	public EnumDisplay<Configuration.DailyLimitScope>[] DailyDownloadLimitScopes { get; }
+		= Enum.GetValues<Configuration.DailyLimitScope>()
+		.Select(v => new EnumDisplay<Configuration.DailyLimitScope>(v))
+		.ToArray();
+
+	public EnumDisplay<Configuration.DailyLimitUnit>[] DailyDownloadLimitUnits { get; }
+		= Enum.GetValues<Configuration.DailyLimitUnit>()
+		.Select(v => new EnumDisplay<Configuration.DailyLimitUnit>(v))
+		.ToArray();
+
+	private EnumDisplay<Configuration.DailyLimitScope> _dailyDownloadLimit;
+	public EnumDisplay<Configuration.DailyLimitScope> DailyDownloadLimit
+	{
+		get => _dailyDownloadLimit;
+		set
+		{
+			this.RaiseAndSetIfChanged(ref _dailyDownloadLimit, value);
+			this.RaisePropertyChanged(nameof(DailyDownloadLimitQuantityVisible));
+		}
+	}
+
+	private int _dailyDownloadLimitQuantity;
+	public int DailyDownloadLimitQuantity { get => _dailyDownloadLimitQuantity; set => this.RaiseAndSetIfChanged(ref _dailyDownloadLimitQuantity, value); }
+
+	private EnumDisplay<Configuration.DailyLimitUnit> _dailyDownloadLimitUnit;
+	public EnumDisplay<Configuration.DailyLimitUnit> DailyDownloadLimitUnit
+	{
+		get => _dailyDownloadLimitUnit;
+		set
+		{
+			this.RaiseAndSetIfChanged(ref _dailyDownloadLimitUnit, value);
+			this.RaisePropertyChanged(nameof(DailyDownloadLimitApproximateNoteVisible));
+		}
+	}
+
+	/// <summary>The quantity and unit only mean anything once a scope other than "No limit" is chosen.</summary>
+	public bool DailyDownloadLimitQuantityVisible => DailyDownloadLimit?.Value is not Configuration.DailyLimitScope.NoLimit;
+
+	public bool DailyDownloadLimitApproximateNoteVisible
+		=> DailyDownloadLimitQuantityVisible && DailyDownloadLimitUnit?.Value is not Configuration.DailyLimitUnit.Books;
+
+	public string DailyDownloadLimitGroupboxText { get; } = Configuration.GetDescription(nameof(Configuration.DailyDownloadLimit));
+	public string DailyDownloadLimitTip { get; } = Configuration.GetHelpText(nameof(Configuration.DailyDownloadLimit));
+	public string DailyDownloadLimitQuantityText { get; } = Configuration.GetDescription(nameof(Configuration.DailyDownloadLimitQuantity));
+	public string DailyDownloadLimitUnitText { get; } = Configuration.GetDescription(nameof(Configuration.DailyDownloadLimitUnit));
+	public string DailyDownloadLimitApproximateNoteText { get; }
+		= "MB and GB are approximate: Libation does not know precisely how large an audiobook is before downloading it, so it assumes about 400 MB per book when deciding whether another download would exceed the limit.";
+	public string DailyDownloadLimitDescriptionText { get; }
+		= "Rolling 24 hours, not a calendar day. Only downloads Libation completes are counted; books you download from the Audible app or website are not.";
+
+	#endregion
 
 	public string UseCoverAsFolderIconText { get; } = Configuration.GetDescription(nameof(Configuration.UseCoverAsFolderIcon));
 	public string SaveMetadataToFileText { get; } = Configuration.GetDescription(nameof(Configuration.SaveMetadataToFile));

--- a/Source/LibationAvalonia/Views/ProcessQueueControl.axaml.cs
+++ b/Source/LibationAvalonia/Views/ProcessQueueControl.axaml.cs
@@ -152,9 +152,8 @@ public partial class ProcessQueueControl : UserControl
 
 	public async void CancelAllBtn_Click(object? sender, Avalonia.Interactivity.RoutedEventArgs e)
 	{
-		Queue?.ClearQueue();
-		if (Queue?.Current is not null)
-			await Queue.Current.CancelAsync();
+		if (_viewModel is ProcessQueueViewModel vm)
+			await vm.CancelAllAsync();
 	}
 
 	public void ClearFinishedBtn_Click(object? sender, Avalonia.Interactivity.RoutedEventArgs e)
@@ -182,9 +181,8 @@ public partial class ProcessQueueControl : UserControl
 
 	private async void cancelAllBtn_Click(object? sender, EventArgs e)
 	{
-		Queue?.ClearQueue();
-		if (Queue?.Current is not null)
-			await Queue.Current.CancelAsync();
+		if (_viewModel is ProcessQueueViewModel vm)
+			await vm.CancelAllAsync();
 	}
 
 	private void btnClearFinished_Click(object? sender, EventArgs e)

--- a/Source/LibationCli/ContentLicenseDeniedCliSummary.cs
+++ b/Source/LibationCli/ContentLicenseDeniedCliSummary.cs
@@ -1,4 +1,6 @@
+using ApplicationServices;
 using AudibleApi;
+using LibationFileManager;
 using System;
 using System.Collections.Generic;
 
@@ -22,5 +24,39 @@ internal static class ContentLicenseDeniedCliSummary
 			yield return $"Membership: {mem}";
 		if (ex.AYCL?.Message is { } aycl && !string.IsNullOrWhiteSpace(aycl))
 			yield return $"AYCL (aka: Plus catalog): {aycl}";
+
+		foreach (var line in SuggestDailyLimitLines())
+			yield return line;
+	}
+
+	/// <summary>
+	/// Audible never says "you are being throttled", so this suggestion relies on Libation's own record of recent
+	/// downloads. Silent unless that record makes throttling a plausible explanation and no limit is set yet.
+	/// </summary>
+	private static IEnumerable<string> SuggestDailyLimitLines()
+	{
+		string? suggestion;
+		try
+		{
+			var now = DateTimeOffset.Now;
+			suggestion = DailyDownloadLimitUserMessage.BuildSuggestionParagraph(
+				Configuration.Instance,
+				DownloadHistoryStore.GetCurrentWindow(now),
+				now);
+		}
+		catch (Exception ex)
+		{
+			Serilog.Log.Logger.Error(ex, "Failed to build the daily download limit suggestion");
+			yield break;
+		}
+
+		if (suggestion is null)
+			yield break;
+
+		Serilog.Log.Logger.Information("Suggesting a daily download limit after a license denial. {Suggestion}", suggestion);
+
+		yield return string.Empty;
+		foreach (var line in suggestion.Split('\n'))
+			yield return line.TrimEnd('\r');
 	}
 }

--- a/Source/LibationCli/Options/LiberateOptions.cs
+++ b/Source/LibationCli/Options/LiberateOptions.cs
@@ -68,7 +68,15 @@ public class LiberateOptions : ProcessableOptionsBase
 		}
 
 		PrepareBookForLiberate(libraryBook, isTargetedRun: true);
-		await ProcessOneAsync(GetProcessable(licenseInfo), libraryBook, true);
+
+		var processable = GetProcessable(licenseInfo);
+		if (IsSkippedByDailyLimit(processable, libraryBook))
+		{
+			Console.WriteLine(DailyDownloadLimitUserMessage.BuildCliSkippedSummary(1));
+			return;
+		}
+
+		await ProcessOneAsync(processable, libraryBook, true);
 	}
 
 	private static DownloadOptions.LicenseInfo? ReadLicenseFromFile(string licFile)

--- a/Source/LibationCli/Options/_ProcessableOptionsBase.cs
+++ b/Source/LibationCli/Options/_ProcessableOptionsBase.cs
@@ -83,6 +83,8 @@ public abstract class ProcessableOptionsBase : OptionsBase
 
 	protected async Task RunAsync(Processable Processable, Action<LibraryBook>? config = null, Action<string>? notFound = null)
 	{
+		var skippedForDailyLimit = 0;
+
 		var productIds = GetProductIds().ToArray();
 		if (productIds.Length > 0)
 		{
@@ -91,7 +93,10 @@ public abstract class ProcessableOptionsBase : OptionsBase
 				if (DbContexts.GetLibraryBook_Flat_NoTracking(asin, caseSensative: false) is LibraryBook lb)
 				{
 					config?.Invoke(lb);
-					await ProcessOneAsync(Processable, lb, true);
+					if (IsSkippedByDailyLimit(Processable, lb))
+						skippedForDailyLimit++;
+					else
+						await ProcessOneAsync(Processable, lb, true);
 				}
 			else
 			{
@@ -108,13 +113,62 @@ public abstract class ProcessableOptionsBase : OptionsBase
 			foreach (var lb in Processable.GetValidLibraryBooks(libraryBooks))
 			{
 				config?.Invoke(lb);
-				await ProcessOneAsync(Processable, lb, false);
+				if (IsSkippedByDailyLimit(Processable, lb))
+					skippedForDailyLimit++;
+				else
+					await ProcessOneAsync(Processable, lb, false);
 			}
+		}
+
+		if (skippedForDailyLimit > 0)
+		{
+			var summary = DailyDownloadLimitUserMessage.BuildCliSkippedSummary(skippedForDailyLimit);
+			Console.WriteLine(summary);
+			Serilog.Log.Logger.Information(summary);
 		}
 
 		var done = "Done. All books have been processed";
 		Console.WriteLine(done);
 		Serilog.Log.Logger.Information(done);
+	}
+
+	protected bool announcedDailyLimit;
+
+	/// <summary>
+	/// True when the user's daily download limit covers this title and has been reached. Unlike the GUI queue the
+	/// CLI never waits: a command-line run must not sit idle for hours, and in Docker the entrypoint has to return
+	/// so its own sleep loop keeps working. Skipped titles stay un-liberated and are retried on the next run.
+	/// </summary>
+	protected bool IsSkippedByDailyLimit(Processable processable, LibraryBook libraryBook)
+	{
+		// Only audiobook downloads are limited, and only titles the configured scope covers, so the common
+		// case of no limit (or a Plus-only limit against an owned title) costs nothing.
+		if (processable is not DownloadDecryptBook
+			|| !DailyDownloadLimit.AppliesTo(libraryBook.IsAudiblePlus, Configuration.Instance))
+			return false;
+
+		var now = DateTimeOffset.Now;
+		var allowance = DailyDownloadLimit.Evaluate(Configuration.Instance, DownloadHistoryStore.GetCurrentWindow(now), now);
+
+		if (!allowance.Blocks(libraryBook.IsAudiblePlus))
+			return false;
+
+		if (!announcedDailyLimit)
+		{
+			announcedDailyLimit = true;
+			foreach (var line in DailyDownloadLimitUserMessage.BuildCliSkippedLines(allowance))
+			{
+				Console.Error.WriteLine(line);
+				Serilog.Log.Logger.Information(line);
+			}
+		}
+
+		Serilog.Log.Logger.Information(
+			"Daily download limit reached; skipping {libraryBook}. {@DebugInfo}",
+			libraryBook.LogFriendly(),
+			new { allowance.Scope, allowance.Unit, allowance.Quantity, allowance.UsedBooks, allowance.UsedBytes, allowance.NextCapacityAt });
+
+		return true;
 	}
 
 	protected async Task ProcessOneAsync(Processable Processable, LibraryBook libraryBook, bool validate)

--- a/Source/LibationFileManager/Configuration.HelpText.cs
+++ b/Source/LibationFileManager/Configuration.HelpText.cs
@@ -141,6 +141,29 @@ public partial class Configuration
 
 			This may take a while, depending on the number of audio files in the folder and the speed of your storage device.
 			""" },
+		{nameof(DailyDownloadLimit), """
+			Stop downloading once you have downloaded this much
+			within the last 24 hours. This is a rolling window,
+			not a calendar day: capacity frees up 24 hours after
+			each download, not at midnight.
+
+			Only downloads that Libation completed successfully
+			are counted. Books you download from the Audible app
+			or website are not counted, because Libation cannot
+			see them.
+
+			"Plus titles only" limits just the Audible Plus
+			catalog titles (the ones with the orange plus badge),
+			which is where Audible is known to throttle heavy
+			use. Titles you own keep downloading.
+			""" },
+		{nameof(DailyDownloadLimitUnit), """
+			MB and GB are approximate. Libation does not know
+			precisely how large an audiobook is before it has
+			been downloaded, so it assumes about 400 MB per book
+			when deciding whether another download would exceed
+			your limit.
+			""" },
 		{nameof(ImportPlusTitles), """
 			When enabled, books from the Audible Plus catalog (titles you stream or borrow under your membership, not purchased) are imported into Libation.
 

--- a/Source/LibationFileManager/Configuration.Logging.cs
+++ b/Source/LibationFileManager/Configuration.Logging.cs
@@ -240,6 +240,8 @@ public partial class Configuration
 			_ = CreationTime;
 			_ = LastWriteTime;
 			_ = BadBook;
+			_ = DailyDownloadLimit;
+			_ = DailyDownloadLimitUnit;
 		}
 		catch (InvalidConfigurationValueException ex)
 		{

--- a/Source/LibationFileManager/Configuration.PersistentSettings.cs
+++ b/Source/LibationFileManager/Configuration.PersistentSettings.cs
@@ -281,6 +281,28 @@ public partial class Configuration
 	}
 
 	[JsonConverter(typeof(StringEnumConverter))]
+	public enum DailyLimitScope
+	{
+		[Description("No limit")]
+		NoLimit = 0,
+		[Description("Plus titles only")]
+		PlusOnly = 1,
+		[Description("All books")]
+		AllBooks = 2
+	}
+
+	[JsonConverter(typeof(StringEnumConverter))]
+	public enum DailyLimitUnit
+	{
+		[Description("books")]
+		Books = 0,
+		[Description("MB")]
+		MB = 1,
+		[Description("GB")]
+		GB = 2
+	}
+
+	[JsonConverter(typeof(StringEnumConverter))]
 	public enum Theme
 	{
 		System = 0,
@@ -407,6 +429,20 @@ public partial class Configuration
 			SetNonString(limit);
 		}
 	}
+
+	#region daily download limit
+
+	[Description("Daily download limit (rolling 24 hours):")]
+	public DailyLimitScope DailyDownloadLimit { get => GetNonString(defaultValue: DailyLimitScope.NoLimit); set => SetNonString(value); }
+
+	/// <summary>Clamped so a hand-edited Settings.json holding 0 or a negative number cannot block all downloads.</summary>
+	[Description("Limit:")]
+	public int DailyDownloadLimitQuantity { get => Math.Max(1, GetNonString(defaultValue: 50)); set => SetNonString(Math.Max(1, value)); }
+
+	[Description("Unit:")]
+	public DailyLimitUnit DailyDownloadLimitUnit { get => GetNonString(defaultValue: DailyLimitUnit.Books); set => SetNonString(value); }
+
+	#endregion
 
 	#region templates: custom file naming
 

--- a/Source/LibationFileManager/DailyDownloadLimit.cs
+++ b/Source/LibationFileManager/DailyDownloadLimit.cs
@@ -1,0 +1,147 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace LibationFileManager;
+
+/// <summary>One successful audiobook download recorded by Libation.</summary>
+/// <param name="CompletedAt">When the download finished. Compared against <see cref="DateTimeOffset.Now"/>, so a
+/// queue that runs for days across a DST change still measures exactly 24 hours.</param>
+/// <param name="Bytes">Size on disk of the files written to the Books directory for this title.</param>
+public record DownloadHistoryEntry(DateTimeOffset CompletedAt, string? AudibleProductId, bool IsAudiblePlus, long Bytes);
+
+/// <summary>
+/// Decides whether another audiobook may be downloaded, given the user's opt-in daily limit and the
+/// downloads Libation recorded in the last 24 hours. Pure: no clock, no I/O, no caching. Callers pass
+/// a fresh <c>now</c> and a fresh history read on every check so a paused queue can resume days later.
+/// </summary>
+public static class DailyDownloadLimit
+{
+	/// <summary>Rolling window. Not a calendar day: capacity frees up 24 hours after each download.</summary>
+	public static readonly TimeSpan Window = TimeSpan.FromHours(24);
+
+	/// <summary>
+	/// Below this many recent downloads, a license denial is unlikely to be Audible throttling, so
+	/// suggesting a daily limit would point the user at the wrong problem.
+	/// </summary>
+	public const int SuggestionMinimumRecentDownloads = 10;
+
+	private const long BytesPerMB = 1024L * 1024;
+	private const long BytesPerGB = 1024L * 1024 * 1024;
+
+	/// <summary>
+	/// The limit state for the configured scope. "Unlimited" is expressed by <see cref="IsLimited"/> and a null
+	/// <see cref="RemainingBooks"/> rather than a sentinel count, so no caller can mistake it for a real number.
+	/// </summary>
+	/// <param name="AllowsAnother">Whether one more counted download would stay within the limit.</param>
+	/// <param name="UsedBooks">Downloads inside the window that count against the configured scope.</param>
+	/// <param name="RemainingBooks">Display only, null when unlimited. Approximate in MB/GB mode.</param>
+	/// <param name="NextCapacityAt">When enough of the window ages out to allow another download. Null when not blocked.</param>
+	public readonly record struct Allowance(
+		bool IsLimited,
+		bool AllowsAnother,
+		Configuration.DailyLimitScope Scope,
+		Configuration.DailyLimitUnit Unit,
+		int Quantity,
+		int UsedBooks,
+		long UsedBytes,
+		int? RemainingBooks,
+		DateTimeOffset? NextCapacityAt)
+	{
+		/// <summary>True when this title specifically cannot be downloaded right now.</summary>
+		public bool Blocks(bool isPlus) => IsLimited && !AllowsAnother && ScopeCounts(Scope, isPlus);
+
+		/// <summary>Limit expressed in bytes, or null when the limit is a book count.</summary>
+		public long? LimitBytes => Unit is Configuration.DailyLimitUnit.Books ? null : ToBytes(Quantity, Unit);
+	}
+
+	/// <summary>Recent activity regardless of the limit setting, for the throttling suggestion.</summary>
+	public readonly record struct RecentActivity(int TotalDownloads, int PlusDownloads, long TotalBytes);
+
+	/// <summary>Whether the configured scope subjects this title to the limit at all.</summary>
+	public static bool AppliesTo(bool isPlus, Configuration config) => ScopeCounts(config.DailyDownloadLimit, isPlus);
+
+	private static bool ScopeCounts(Configuration.DailyLimitScope scope, bool isPlus)
+		=> scope switch
+		{
+			Configuration.DailyLimitScope.AllBooks => true,
+			Configuration.DailyLimitScope.PlusOnly => isPlus,
+			_ => false
+		};
+
+	private static long ToBytes(int quantity, Configuration.DailyLimitUnit unit)
+		=> unit switch
+		{
+			Configuration.DailyLimitUnit.MB => quantity * BytesPerMB,
+			Configuration.DailyLimitUnit.GB => quantity * BytesPerGB,
+			_ => 0
+		};
+
+	public static Allowance Evaluate(Configuration config, IReadOnlyList<DownloadHistoryEntry> history, DateTimeOffset now)
+	{
+		var scope = config.DailyDownloadLimit;
+		var unit = config.DailyDownloadLimitUnit;
+		var quantity = Math.Max(1, config.DailyDownloadLimitQuantity);
+
+		if (scope is Configuration.DailyLimitScope.NoLimit)
+			return new Allowance(false, true, scope, unit, quantity, 0, 0, null, null);
+
+		var counted = history
+			.Where(e => e.CompletedAt > now - Window && ScopeCounts(scope, e.IsAudiblePlus))
+			.OrderBy(e => e.CompletedAt)
+			.ToList();
+
+		var usedBooks = counted.Count;
+		var usedBytes = counted.Sum(e => e.Bytes);
+
+		// A byte limit smaller than one estimated book would otherwise block downloading forever, and the
+		// user would see "limit reached" having downloaded nothing.
+		var allowsAnother = usedBooks == 0 || WouldFit(usedBytes, usedBooks);
+
+		return new Allowance(
+			IsLimited: true,
+			AllowsAnother: allowsAnother,
+			Scope: scope,
+			Unit: unit,
+			Quantity: quantity,
+			UsedBooks: usedBooks,
+			UsedBytes: usedBytes,
+			RemainingBooks: RemainingBooks(usedBytes, usedBooks, allowsAnother),
+			NextCapacityAt: allowsAnother ? null : NextCapacityAt(counted, usedBytes));
+
+		bool WouldFit(long bytes, int books)
+			=> unit is Configuration.DailyLimitUnit.Books
+			? books < quantity
+			: bytes + DiskSpaceHelper.EstimatedBytesPerAudiobookBackup <= ToBytes(quantity, unit);
+
+		int RemainingBooks(long bytes, int books, bool allows)
+		{
+			if (unit is Configuration.DailyLimitUnit.Books)
+				return Math.Max(0, quantity - books);
+
+			var free = ToBytes(quantity, unit) - bytes;
+			var whole = free <= 0 ? 0 : (int)Math.Min(int.MaxValue, free / DiskSpaceHelper.EstimatedBytesPerAudiobookBackup);
+			// Keep the count honest about the always-allow-one rule.
+			return whole == 0 && allows ? 1 : whole;
+		}
+
+		// Walk oldest first: capacity returns when enough entries have aged out for one more book to fit.
+		DateTimeOffset? NextCapacityAt(List<DownloadHistoryEntry> countedOldestFirst, long bytes)
+		{
+			long freed = 0;
+			for (var i = 0; i < countedOldestFirst.Count; i++)
+			{
+				freed += countedOldestFirst[i].Bytes;
+				if (WouldFit(bytes - freed, countedOldestFirst.Count - i - 1))
+					return countedOldestFirst[i].CompletedAt + Window;
+			}
+			return countedOldestFirst.Count == 0 ? null : countedOldestFirst[^1].CompletedAt + Window;
+		}
+	}
+
+	public static RecentActivity SummarizeRecent(IReadOnlyList<DownloadHistoryEntry> history, DateTimeOffset now)
+	{
+		var recent = history.Where(e => e.CompletedAt > now - Window).ToList();
+		return new RecentActivity(recent.Count, recent.Count(e => e.IsAudiblePlus), recent.Sum(e => e.Bytes));
+	}
+}

--- a/Source/LibationFileManager/DailyDownloadLimitUserMessage.cs
+++ b/Source/LibationFileManager/DailyDownloadLimitUserMessage.cs
@@ -26,24 +26,27 @@ public static class DailyDownloadLimitUserMessage
 			To download more now, change or turn off the limit in {SettingsLocation}. Libation picks up the new setting within a few seconds, so there is no need to requeue anything. To stop instead, use Cancel All in the process queue.
 			""";
 
-	/// <summary>Per-book status shown in the queue while paused. Recomputed on each re-check.</summary>
+	/// <summary>
+	/// Per-book status shown in the queue while paused, recomputed on each re-check. Kept short: the process
+	/// queue column is narrow and clips rather than wrapping, so the resume time has to fit on one short line.
+	/// </summary>
 	public static string BuildWaitingStatus(DailyDownloadLimit.Allowance allowance)
 		=> allowance.NextCapacityAt is DateTimeOffset next
-		? $"Daily limit reached, resumes about {next.ToLocalTime():t}"
+		? $"Daily limit, resumes {next.ToLocalTime():t}"
 		: "Daily limit reached, waiting";
 
 	public static string BuildQueueLogEntry(DailyDownloadLimit.Allowance allowance, string bookTitleWithSubtitle)
-		=> $"Daily download limit reached ({DescribeUsage(allowance)}). Waiting before downloading {bookTitleWithSubtitle}. "
+		=> $"Daily download limit reached. {DescribeUsage(allowance)} Waiting before downloading {bookTitleWithSubtitle}. "
 		+ $"Libation will continue on its own {DescribeResumption(allowance)}, or change the limit in {SettingsLocation}.";
 
 	public static string BuildDeferredLogEntry(DailyDownloadLimit.Allowance allowance, string bookTitleWithSubtitle)
-		=> $"Daily download limit reached for Audible Plus titles ({DescribeUsage(allowance)}). "
+		=> $"Daily download limit reached for Audible Plus titles. {DescribeUsage(allowance)} "
 		+ $"Moved {bookTitleWithSubtitle} to the end of the queue and continued with titles the limit does not cover.";
 
 	/// <summary>stderr lines for the CLI, which skips blocked titles instead of waiting.</summary>
 	public static IEnumerable<string> BuildCliSkippedLines(DailyDownloadLimit.Allowance allowance)
 	{
-		yield return $"Daily download limit reached: {DescribeUsage(allowance)}.";
+		yield return $"Daily download limit reached. {DescribeUsage(allowance)}";
 		yield return $"Skipping the titles it covers. Capacity returns {DescribeResumption(allowance)}.";
 		yield return $"To change or turn off the limit, set \"{nameof(Configuration.DailyDownloadLimit)}\" in Settings.json (or use {SettingsLocation} in the Libation app).";
 	}
@@ -76,13 +79,14 @@ public static class DailyDownloadLimitUserMessage
 			""";
 	}
 
+	/// <summary>A complete sentence, so it can stand alone as its own paragraph or line.</summary>
 	private static string DescribeUsage(DailyDownloadLimit.Allowance allowance)
 	{
 		var scope = allowance.Scope is Configuration.DailyLimitScope.PlusOnly ? "Audible Plus titles" : "books";
 
 		return allowance.LimitBytes is long limitBytes
-			? $"your limit is {allowance.Quantity} {allowance.Unit} of {scope} per 24 hours, and Libation has downloaded about {DiskSpaceHelper.FormatBytes(allowance.UsedBytes)} of {DiskSpaceHelper.FormatBytes(limitBytes)} in the last 24 hours ({allowance.UsedBooks} title(s))"
-			: $"your limit is {allowance.Quantity} {scope} per 24 hours, and Libation has downloaded {allowance.UsedBooks} in the last 24 hours";
+			? $"Your limit is {allowance.Quantity} {allowance.Unit} of {scope} per 24 hours, and Libation has downloaded about {DiskSpaceHelper.FormatBytes(allowance.UsedBytes)} of {DiskSpaceHelper.FormatBytes(limitBytes)} in the last 24 hours, across {allowance.UsedBooks} title(s)."
+			: $"Your limit is {allowance.Quantity} {scope} per 24 hours, and Libation has downloaded {allowance.UsedBooks} in the last 24 hours.";
 	}
 
 	private static string DescribeResumption(DailyDownloadLimit.Allowance allowance)

--- a/Source/LibationFileManager/DailyDownloadLimitUserMessage.cs
+++ b/Source/LibationFileManager/DailyDownloadLimitUserMessage.cs
@@ -1,0 +1,92 @@
+using System;
+using System.Collections.Generic;
+
+namespace LibationFileManager;
+
+/// <summary>
+/// User-facing copy for the opt-in daily download limit, plus the suggestion to turn it on when Audible
+/// looks like it is throttling. Lives here rather than in LibationUiBase because LibationCli needs the same
+/// wording and does not reference LibationUiBase.
+/// </summary>
+public static class DailyDownloadLimitUserMessage
+{
+	public const string DialogCaption = "Daily download limit reached";
+
+	private const string SettingsLocation = "Settings > Download/Decrypt > Daily download limit";
+
+	/// <summary>Shown once when the queue pauses. Informational only: the queue resumes on its own.</summary>
+	public static string BuildQueuePausedBody(DailyDownloadLimit.Allowance allowance, string bookTitleWithSubtitle)
+		=> $"""
+			Libation has paused before downloading {bookTitleWithSubtitle} because you have reached your daily download limit.
+
+			{DescribeUsage(allowance)}
+
+			Nothing is lost and nothing was cancelled. Your books are still queued, and Libation will continue on its own {DescribeResumption(allowance)}.
+
+			To download more now, change or turn off the limit in {SettingsLocation}. Libation picks up the new setting within a few seconds, so there is no need to requeue anything. To stop instead, use Cancel All in the process queue.
+			""";
+
+	/// <summary>Per-book status shown in the queue while paused. Recomputed on each re-check.</summary>
+	public static string BuildWaitingStatus(DailyDownloadLimit.Allowance allowance)
+		=> allowance.NextCapacityAt is DateTimeOffset next
+		? $"Daily limit reached, resumes about {next.ToLocalTime():t}"
+		: "Daily limit reached, waiting";
+
+	public static string BuildQueueLogEntry(DailyDownloadLimit.Allowance allowance, string bookTitleWithSubtitle)
+		=> $"Daily download limit reached ({DescribeUsage(allowance)}). Waiting before downloading {bookTitleWithSubtitle}. "
+		+ $"Libation will continue on its own {DescribeResumption(allowance)}, or change the limit in {SettingsLocation}.";
+
+	public static string BuildDeferredLogEntry(DailyDownloadLimit.Allowance allowance, string bookTitleWithSubtitle)
+		=> $"Daily download limit reached for Audible Plus titles ({DescribeUsage(allowance)}). "
+		+ $"Moved {bookTitleWithSubtitle} to the end of the queue and continued with titles the limit does not cover.";
+
+	/// <summary>stderr lines for the CLI, which skips blocked titles instead of waiting.</summary>
+	public static IEnumerable<string> BuildCliSkippedLines(DailyDownloadLimit.Allowance allowance)
+	{
+		yield return $"Daily download limit reached: {DescribeUsage(allowance)}.";
+		yield return $"Skipping the titles it covers. Capacity returns {DescribeResumption(allowance)}.";
+		yield return $"To change or turn off the limit, set \"{nameof(Configuration.DailyDownloadLimit)}\" in Settings.json (or use {SettingsLocation} in the Libation app).";
+	}
+
+	public static string BuildCliSkippedSummary(int skippedCount)
+		=> $"Skipped {skippedCount} title(s) because of your daily download limit. They remain un-liberated and will be tried on the next run.";
+
+	/// <summary>
+	/// Suggests turning the limit on after a license denial that looks like Audible throttling. Returns null when
+	/// the suggestion would be unhelpful: a limit is already configured, or too little was downloaded recently for
+	/// throttling to be a plausible explanation.
+	/// </summary>
+	public static string? BuildSuggestionParagraph(Configuration config, IReadOnlyList<DownloadHistoryEntry> history, DateTimeOffset now)
+	{
+		if (config.DailyDownloadLimit is not Configuration.DailyLimitScope.NoLimit)
+			return null;
+
+		var recent = DailyDownloadLimit.SummarizeRecent(history, now);
+		if (recent.TotalDownloads < DailyDownloadLimit.SuggestionMinimumRecentDownloads)
+			return null;
+
+		var plus = recent.PlusDownloads == recent.TotalDownloads
+			? "all of them from the Plus catalog"
+			: $"{recent.PlusDownloads} of them from the Plus catalog";
+
+		return $"""
+			Libation successfully downloaded {recent.TotalDownloads} titles in the last 24 hours, {plus}. That is the kind of volume that leads Audible to deny licenses for a day or two.
+
+			To have Libation pace itself from now on, turn on a daily download limit in {SettingsLocation}. "Plus titles only" with a limit of 50 books is a reasonable starting point; titles you own are not affected. Libation counts only the downloads it performs, over a rolling 24 hours.
+			""";
+	}
+
+	private static string DescribeUsage(DailyDownloadLimit.Allowance allowance)
+	{
+		var scope = allowance.Scope is Configuration.DailyLimitScope.PlusOnly ? "Audible Plus titles" : "books";
+
+		return allowance.LimitBytes is long limitBytes
+			? $"your limit is {allowance.Quantity} {allowance.Unit} of {scope} per 24 hours, and Libation has downloaded about {DiskSpaceHelper.FormatBytes(allowance.UsedBytes)} of {DiskSpaceHelper.FormatBytes(limitBytes)} in the last 24 hours ({allowance.UsedBooks} title(s))"
+			: $"your limit is {allowance.Quantity} {scope} per 24 hours, and Libation has downloaded {allowance.UsedBooks} in the last 24 hours";
+	}
+
+	private static string DescribeResumption(DailyDownloadLimit.Allowance allowance)
+		=> allowance.NextCapacityAt is DateTimeOffset next
+		? $"at about {next.ToLocalTime():t} ({next.ToLocalTime():d}), when the oldest of those downloads is more than 24 hours old"
+		: "once the oldest of those downloads is more than 24 hours old";
+}

--- a/Source/LibationFileManager/DiskSpaceHelper.cs
+++ b/Source/LibationFileManager/DiskSpaceHelper.cs
@@ -31,6 +31,16 @@ public static class DiskSpaceHelper
 		Books = 2,
 	}
 
+	/// <summary>Single byte formatter for user-facing copy, so free space and download limits read the same way.</summary>
+	public static string FormatBytes(long bytes)
+	{
+		const long gb = 1024L * 1024 * 1024;
+		if (bytes >= gb)
+			return $"{bytes / (double)gb:F1} GB";
+		const long mb = 1024 * 1024;
+		return $"{bytes / (double)mb:F0} MB";
+	}
+
 	public static bool IsDiskFullException(Exception? ex)
 	{
 		for (var current = ex; current is not null; current = current.InnerException)

--- a/Source/LibationUiBase/ContentLicenseDeniedUserMessage.cs
+++ b/Source/LibationUiBase/ContentLicenseDeniedUserMessage.cs
@@ -1,3 +1,7 @@
+using ApplicationServices;
+using LibationFileManager;
+using System;
+
 namespace LibationUiBase;
 
 /// <summary>
@@ -19,7 +23,7 @@ public static class ContentLicenseDeniedUserMessage
 			Heavy use of the Audible Plus catalog in a short time can also produce "license denied" responses; community reports often involve on the order of dozens of titles — Audible does not publish a fixed limit. Waiting 24 to 48 hours before trying again is usually enough.
 
 			If the problem continues after several days, open an issue on Libation's GitHub and include your logs.
-			""";
+			""" + AppendSuggestion();
 
 	/// <summary>License denied on an Audible Plus title — often rate limiting, not a Libation defect.</summary>
 	public static string BuildDialogBodyForPlusCatalog(string bookTitleWithSubtitle)
@@ -31,5 +35,33 @@ public static class ContentLicenseDeniedUserMessage
 			Try waiting 24 to 48 hours and liberate again. If it still fails after several days, open an issue on Libation's GitHub with logs.
 
 			If you should not have access to this title (for example it left Plus before you downloaded), confirm in the Audible app or website.
-			""";
+			""" + AppendSuggestion();
+
+	/// <summary>
+	/// Audible reports no distinct "throttled" reason, so this suggestion is what turns a guess into evidence:
+	/// it only appears when Libation's own record shows enough recent downloads for throttling to be plausible,
+	/// and when the user has no daily limit configured yet. Logged as well as shown.
+	/// </summary>
+	private static string AppendSuggestion()
+	{
+		try
+		{
+			var now = DateTimeOffset.Now;
+			var suggestion = DailyDownloadLimitUserMessage.BuildSuggestionParagraph(
+				Configuration.Instance,
+				DownloadHistoryStore.GetCurrentWindow(now),
+				now);
+
+			if (suggestion is null)
+				return string.Empty;
+
+			Serilog.Log.Logger.Information("Suggesting a daily download limit after a license denial. {Suggestion}", suggestion);
+			return Environment.NewLine + Environment.NewLine + suggestion;
+		}
+		catch (Exception ex)
+		{
+			Serilog.Log.Logger.Error(ex, "Failed to build the daily download limit suggestion");
+			return string.Empty;
+		}
+	}
 }

--- a/Source/LibationUiBase/DiskFullUserMessage.cs
+++ b/Source/LibationUiBase/DiskFullUserMessage.cs
@@ -76,12 +76,5 @@ public static class DiskFullUserMessage
 		return "Libation paths";
 	}
 
-	private static string FormatBytes(long bytes)
-	{
-		const long gb = 1024L * 1024 * 1024;
-		if (bytes >= gb)
-			return $"{bytes / (double)gb:F1} GB";
-		const long mb = 1024 * 1024;
-		return $"{bytes / (double)mb:F0} MB";
-	}
+	private static string FormatBytes(long bytes) => DiskSpaceHelper.FormatBytes(bytes);
 }

--- a/Source/LibationUiBase/ProcessQueue/ProcessBookViewModel.cs
+++ b/Source/LibationUiBase/ProcessQueue/ProcessBookViewModel.cs
@@ -63,7 +63,19 @@ public class ProcessBookViewModel : ReactiveObject
 	public bool IsDownloading => Status is ProcessBookStatus.Working;
 	public bool Queued => Status is ProcessBookStatus.Queued;
 
-	public string StatusText => (Result, LibraryBook.IsAudiblePlus) switch
+	/// <summary>
+	/// Transient status shown instead of the usual text, e.g. while the queue waits on the daily download limit.
+	/// Null when the book's own state should speak for itself.
+	/// </summary>
+	public string? StatusOverride { get => field; set { RaiseAndSetIfChanged(ref field, value); RaisePropertyChanged(nameof(StatusText)); } }
+
+	/// <summary>
+	/// True when this queue item downloads an audiobook, so the daily download limit applies to it.
+	/// PDF-only and mp3-conversion items are never limited.
+	/// </summary>
+	public bool IncludesBookDownload { get; private set; }
+
+	public string StatusText => StatusOverride ?? (Result, LibraryBook.IsAudiblePlus) switch
 	{
 		(ProcessBookResult.Success, _) => "Finished",
 		(ProcessBookResult.Cancelled, _) => "Cancelled",
@@ -267,7 +279,11 @@ public class ProcessBookViewModel : ReactiveObject
 	}
 
 	public ProcessBookViewModel AddDownloadPdf() => AddProcessable<DownloadPdf>();
-	public ProcessBookViewModel AddDownloadDecryptBook() => AddProcessable<DownloadDecryptBook>();
+	public ProcessBookViewModel AddDownloadDecryptBook()
+	{
+		IncludesBookDownload = true;
+		return AddProcessable<DownloadDecryptBook>();
+	}
 	public ProcessBookViewModel AddConvertToMp3() => AddProcessable<ConvertToMp3>();
 	public ProcessBookViewModel AddUploadToAudiobookshelf() => AddProcessable<UploadToAudiobookshelf>();
 	public ProcessBookViewModel AddSimulateBadBookFailure() => AddProcessable<SimulateBadBookFailure>();

--- a/Source/LibationUiBase/ProcessQueue/ProcessQueueViewModel.cs
+++ b/Source/LibationUiBase/ProcessQueue/ProcessQueueViewModel.cs
@@ -104,8 +104,7 @@ public class ProcessQueueViewModel : ReactiveObject
 		RaisePropertyChanged(nameof(Progress));
 	}
 
-	private void ProcessBook_LogWritten(object? sender, string logMessage)
-		=> Invoke(() => LogEntries.Add(new(DateTime.Now, logMessage.Trim())));
+	private void ProcessBook_LogWritten(object? sender, string logMessage) => AddQueueLogEntry(logMessage);
 
 	private void AddQueueLogEntry(string logMessage)
 		=> Invoke(() => LogEntries.Add(new(DateTime.Now, logMessage.Trim())));
@@ -357,6 +356,10 @@ public class ProcessQueueViewModel : ReactiveObject
 
 	private void AddToQueue(IList<ProcessBookViewModel> pbook)
 	{
+		// Queueing more work withdraws an earlier Cancel All, which may still be settling on the book it
+		// cancelled. Otherwise these new books would inherit that cancellation at the daily-limit gate.
+		cancelAllRequested = false;
+
 		foreach (var book in pbook)
 			book.LogWritten += ProcessBook_LogWritten;
 

--- a/Source/LibationUiBase/ProcessQueue/ProcessQueueViewModel.cs
+++ b/Source/LibationUiBase/ProcessQueue/ProcessQueueViewModel.cs
@@ -19,11 +19,21 @@ public record LogEntry(DateTime LogDate, string LogMessage)
 
 public class ProcessQueueViewModel : ReactiveObject
 {
+	/// <summary>
+	/// How often a queue paused on the daily download limit re-checks. Short and fixed: never a delay computed
+	/// from when capacity is expected, so a change of setting or the window rolling over is picked up promptly.
+	/// </summary>
+	private static readonly TimeSpan DailyLimitPollInterval = TimeSpan.FromSeconds(15);
+
 	public ObservableCollection<LogEntry> LogEntries { get; } = new();
 	public TrackedQueue<ProcessBookViewModel> Queue { get; } = new();
 	private readonly BadBookSessionContext _badBookSession = new();
 	public Task? QueueRunner { get; private set; }
 	public bool Running => !QueueRunner?.IsCompleted ?? false;
+
+	/// <summary>Set by <see cref="CancelAllAsync"/>; watched by the daily download limit wait loop.</summary>
+	private volatile bool cancelAllRequested;
+	private bool dailyLimitMessageShownThisRun;
 
 	public ProcessQueueViewModel()
 	{
@@ -96,6 +106,21 @@ public class ProcessQueueViewModel : ReactiveObject
 
 	private void ProcessBook_LogWritten(object? sender, string logMessage)
 		=> Invoke(() => LogEntries.Add(new(DateTime.Now, logMessage.Trim())));
+
+	private void AddQueueLogEntry(string logMessage)
+		=> Invoke(() => LogEntries.Add(new(DateTime.Now, logMessage.Trim())));
+
+	/// <summary>
+	/// Clears the queue and cancels the book being processed. Also ends a pause on the daily download limit,
+	/// which is why both UIs call this instead of manipulating the queue directly.
+	/// </summary>
+	public async Task CancelAllAsync()
+	{
+		cancelAllRequested = true;
+		Queue.ClearQueue();
+		if (Queue.Current is ProcessBookViewModel current)
+			await current.CancelAsync();
+	}
 
 	#region Add Books to Queue
 
@@ -341,6 +366,125 @@ public class ProcessQueueViewModel : ReactiveObject
 	}
 
 	#endregion
+
+	#region Daily download limit
+
+	private enum DailyLimitGate
+	{
+		/// <summary>The limit does not stop this book right now.</summary>
+		Proceed,
+		/// <summary>This book is limited but something else in the queue is not; try it later.</summary>
+		Defer,
+		/// <summary>The user cancelled the queue while it was waiting.</summary>
+		Cancelled
+	}
+
+	/// <summary>
+	/// Runs immediately before a book downloads, never at queueing time, so the queue keeps its contents and a
+	/// user can raise or turn off the limit mid-run. Every iteration re-reads the setting, re-queries the
+	/// history and re-reads the clock: a queue left alone for days must resume by itself as its oldest
+	/// downloads age out of the rolling window.
+	/// </summary>
+	/// <param name="deferralsSoFar">
+	/// How many books this queue run has already moved to the back for the limit. Compared against the live
+	/// queued count so the rotation cannot continue indefinitely.
+	/// </param>
+	private async Task<DailyLimitGate> WaitForDailyLimitAsync(ProcessBookViewModel nextBook, int deferralsSoFar)
+	{
+		if (!nextBook.IncludesBookDownload)
+			return DailyLimitGate.Proceed;
+
+		var paused = false;
+
+		while (true)
+		{
+			if (cancelAllRequested)
+			{
+				nextBook.StatusOverride = null;
+				return DailyLimitGate.Cancelled;
+			}
+
+			var now = DateTimeOffset.Now;
+			var allowance = DailyDownloadLimit.Evaluate(Configuration.Instance, DownloadHistoryStore.GetCurrentWindow(now), now);
+
+			if (!allowance.Blocks(nextBook.LibraryBook.IsAudiblePlus))
+			{
+				nextBook.StatusOverride = null;
+				if (paused)
+				{
+					var resumed = $"Daily download limit: capacity is available again. Resuming with {nextBook.LibraryBook.Book.TitleWithSubtitle}.";
+					Serilog.Log.Logger.Information("Daily download limit no longer blocks {libraryBook}. Resuming the queue.", nextBook.LibraryBook.LogFriendly());
+					AddQueueLogEntry(resumed);
+				}
+				return DailyLimitGate.Proceed;
+			}
+
+			// Under "Plus titles only" a mixed queue can keep going; do not stall owned titles behind a Plus title.
+			if (deferralsSoFar < QueuedCount && AnyOtherQueuedBookAllowed(nextBook, allowance))
+			{
+				nextBook.StatusOverride = null;
+				Serilog.Log.Logger.Information(
+					"Daily download limit blocks {libraryBook}. Moving it to the end of the queue and continuing with titles the limit does not cover.",
+					nextBook.LibraryBook.LogFriendly());
+				AddQueueLogEntry(DailyDownloadLimitUserMessage.BuildDeferredLogEntry(allowance, nextBook.LibraryBook.Book.TitleWithSubtitle));
+				return DailyLimitGate.Defer;
+			}
+
+			if (!paused)
+			{
+				paused = true;
+				Serilog.Log.Logger.Information(
+					"Daily download limit reached; pausing the queue before {libraryBook}. {@DebugInfo}",
+					nextBook.LibraryBook.LogFriendly(),
+					new { allowance.Scope, allowance.Unit, allowance.Quantity, allowance.UsedBooks, allowance.UsedBytes, allowance.NextCapacityAt });
+				AddQueueLogEntry(DailyDownloadLimitUserMessage.BuildQueueLogEntry(allowance, nextBook.LibraryBook.Book.TitleWithSubtitle));
+				ShowDailyLimitMessageOncePerRun(allowance, nextBook.LibraryBook.Book.TitleWithSubtitle);
+			}
+
+			nextBook.StatusOverride = DailyDownloadLimitUserMessage.BuildWaitingStatus(allowance);
+
+			await Task.Delay(DailyLimitPollInterval);
+		}
+	}
+
+	/// <summary>Moves the book being held back to the end of the queue without counting it as completed.</summary>
+	private void RequeueLast(ProcessBookViewModel book)
+	{
+		Queue.ClearCurrent();
+		Queue.Enqueue([book]);
+	}
+
+	private bool AnyOtherQueuedBookAllowed(ProcessBookViewModel nextBook, DailyDownloadLimit.Allowance allowance)
+		=> Queue.Any(b =>
+			b is not null
+			&& !ReferenceEquals(b, nextBook)
+			&& b.Status is ProcessBookStatus.Queued
+			&& (!b.IncludesBookDownload || !allowance.Blocks(b.LibraryBook.IsAudiblePlus)));
+
+	/// <summary>
+	/// Deliberately not awaited. This dialog only completes when the user dismisses it, and a queue that is
+	/// waiting must be free to resume by itself hours later with nobody at the keyboard. Shown once per queue
+	/// run so a multi-day drip-feed does not stack up a dialog per day; later pauses use the log and status.
+	/// </summary>
+	private void ShowDailyLimitMessageOncePerRun(DailyDownloadLimit.Allowance allowance, string bookTitleWithSubtitle)
+	{
+		if (dailyLimitMessageShownThisRun)
+			return;
+
+		dailyLimitMessageShownThisRun = true;
+
+		_ = MessageBoxBase.Show(
+			DailyDownloadLimitUserMessage.BuildQueuePausedBody(allowance, bookTitleWithSubtitle),
+			DailyDownloadLimitUserMessage.DialogCaption,
+			MessageBoxButtons.OK,
+			MessageBoxIcon.Information)
+			.ContinueWith(
+				t => Serilog.Log.Logger.Error(t.Exception, "Failed to show the daily download limit message"),
+				TaskContinuationOptions.OnlyOnFaulted);
+	}
+
+	#endregion
+
 	public event EventHandler<ProcessBookViewModel>? ProcessStart;
 	public event EventHandler<ProcessBookViewModel>? ProcessEnd;
 	private async Task QueueLoop()
@@ -350,12 +494,16 @@ public class ProcessQueueViewModel : ReactiveObject
 			Serilog.Log.Logger.Information("Begin processing queue");
 
 			_badBookSession.Reset();
+			cancelAllRequested = false;
+			dailyLimitMessageShownThisRun = false;
 			RunningTime = string.Empty;
 			ProgressBarVisible = true;
 			var startingTime = DateTime.Now;
 			bool shownLicenseGuidanceMessage = false;
 			bool shownWidevineGuidanceMessage = false;
 			bool shownDiskFullMessage = false;
+			// Bounds the daily-limit deferral rotation, so a book can never be shuffled to the back forever.
+			int consecutiveDeferrals = 0;
 
 			using var counterTimer = new System.Threading.Timer(_ => RunningTime = timeToStr(DateTime.Now - startingTime), null, 0, 500);
 
@@ -364,6 +512,27 @@ public class ProcessQueueViewModel : ReactiveObject
 				if (Queue.Current is not ProcessBookViewModel nextBook)
 				{
 					Serilog.Log.Logger.Information("Current queue item is empty.");
+					continue;
+				}
+
+				// Checked here rather than at queueing time so the queue keeps its contents and the user can
+				// change the limit mid-run. Deferral keeps a mixed queue moving under "Plus titles only".
+				var gate = await WaitForDailyLimitAsync(nextBook, consecutiveDeferrals);
+
+				if (gate is DailyLimitGate.Defer)
+				{
+					consecutiveDeferrals++;
+					RequeueLast(nextBook);
+					continue;
+				}
+
+				consecutiveDeferrals = 0;
+
+				if (gate is DailyLimitGate.Cancelled)
+				{
+					Serilog.Log.Logger.Information("Queue was cancelled while waiting on the daily download limit.");
+					nextBook.Result = ProcessBookResult.Cancelled;
+					nextBook.Status = ProcessBookStatus.Cancelled;
 					continue;
 				}
 

--- a/Source/LibationWinForms/Dialogs/SettingsDialog.Designer.cs
+++ b/Source/LibationWinForms/Dialogs/SettingsDialog.Designer.cs
@@ -35,6 +35,13 @@
 			importEpisodesCb = new System.Windows.Forms.CheckBox();
 			downloadEpisodesCb = new System.Windows.Forms.CheckBox();
 			badBookGb = new System.Windows.Forms.GroupBox();
+			dailyDownloadLimitGb = new System.Windows.Forms.GroupBox();
+			dailyDownloadLimitDescLbl = new System.Windows.Forms.Label();
+			dailyDownloadLimitScopeCb = new System.Windows.Forms.ComboBox();
+			dailyDownloadLimitQtyLbl = new System.Windows.Forms.Label();
+			dailyDownloadLimitQtyNud = new System.Windows.Forms.NumericUpDown();
+			dailyDownloadLimitUnitCb = new System.Windows.Forms.ComboBox();
+			dailyDownloadLimitApproxLbl = new System.Windows.Forms.Label();
 			badBookIgnoreRb = new System.Windows.Forms.RadioButton();
 			badBookRetryRb = new System.Windows.Forms.RadioButton();
 			badBookAbortRb = new System.Windows.Forms.RadioButton();
@@ -162,6 +169,8 @@
 			downloadCoverArtCbox = new System.Windows.Forms.CheckBox();
 			createCueSheetCbox = new System.Windows.Forms.CheckBox();
 			badBookGb.SuspendLayout();
+			dailyDownloadLimitGb.SuspendLayout();
+			((System.ComponentModel.ISupportInitialize)dailyDownloadLimitQtyNud).BeginInit();
 			tabControl.SuspendLayout();
 			tab1ImportantSettings.SuspendLayout();
 			groupBox1.SuspendLayout();
@@ -258,7 +267,7 @@
 			badBookGb.Controls.Add(badBookRetryRb);
 			badBookGb.Controls.Add(badBookAbortRb);
 			badBookGb.Controls.Add(badBookAskRb);
-			badBookGb.Location = new System.Drawing.Point(7, 6);
+			badBookGb.Location = new System.Drawing.Point(7, 122);
 			badBookGb.Name = "badBookGb";
 			badBookGb.Size = new System.Drawing.Size(841, 76);
 			badBookGb.TabIndex = 13;
@@ -747,6 +756,77 @@
 			useWebViewCb.Text = "[use webview desc]";
 			useWebViewCb.UseVisualStyleBackColor = true;
 			// 
+			// dailyDownloadLimitGb
+			// 
+			dailyDownloadLimitGb.Anchor = System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right;
+			dailyDownloadLimitGb.Controls.Add(dailyDownloadLimitApproxLbl);
+			dailyDownloadLimitGb.Controls.Add(dailyDownloadLimitUnitCb);
+			dailyDownloadLimitGb.Controls.Add(dailyDownloadLimitQtyNud);
+			dailyDownloadLimitGb.Controls.Add(dailyDownloadLimitQtyLbl);
+			dailyDownloadLimitGb.Controls.Add(dailyDownloadLimitScopeCb);
+			dailyDownloadLimitGb.Controls.Add(dailyDownloadLimitDescLbl);
+			dailyDownloadLimitGb.Location = new System.Drawing.Point(7, 6);
+			dailyDownloadLimitGb.Name = "dailyDownloadLimitGb";
+			dailyDownloadLimitGb.Size = new System.Drawing.Size(842, 110);
+			dailyDownloadLimitGb.TabIndex = 23;
+			dailyDownloadLimitGb.TabStop = false;
+			dailyDownloadLimitGb.Text = "[daily download limit desc]";
+			// 
+			// dailyDownloadLimitDescLbl
+			// 
+			dailyDownloadLimitDescLbl.Location = new System.Drawing.Point(7, 19);
+			dailyDownloadLimitDescLbl.Name = "dailyDownloadLimitDescLbl";
+			dailyDownloadLimitDescLbl.Size = new System.Drawing.Size(828, 32);
+			dailyDownloadLimitDescLbl.TabIndex = 1;
+			dailyDownloadLimitDescLbl.Text = "[daily download limit long desc]";
+			// 
+			// dailyDownloadLimitScopeCb
+			// 
+			dailyDownloadLimitScopeCb.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+			dailyDownloadLimitScopeCb.FormattingEnabled = true;
+			dailyDownloadLimitScopeCb.Location = new System.Drawing.Point(7, 57);
+			dailyDownloadLimitScopeCb.Name = "dailyDownloadLimitScopeCb";
+			dailyDownloadLimitScopeCb.Size = new System.Drawing.Size(200, 23);
+			dailyDownloadLimitScopeCb.TabIndex = 2;
+			dailyDownloadLimitScopeCb.SelectedIndexChanged += dailyDownloadLimitScopeCb_SelectedIndexChanged;
+			// 
+			// dailyDownloadLimitQtyLbl
+			// 
+			dailyDownloadLimitQtyLbl.AutoSize = true;
+			dailyDownloadLimitQtyLbl.Location = new System.Drawing.Point(220, 61);
+			dailyDownloadLimitQtyLbl.Name = "dailyDownloadLimitQtyLbl";
+			dailyDownloadLimitQtyLbl.Size = new System.Drawing.Size(38, 15);
+			dailyDownloadLimitQtyLbl.TabIndex = 3;
+			dailyDownloadLimitQtyLbl.Text = "[qty]";
+			// 
+			// dailyDownloadLimitQtyNud
+			// 
+			dailyDownloadLimitQtyNud.Location = new System.Drawing.Point(264, 57);
+			dailyDownloadLimitQtyNud.Maximum = new decimal(new int[] { int.MaxValue, 0, 0, 0 });
+			dailyDownloadLimitQtyNud.Minimum = new decimal(new int[] { 1, 0, 0, 0 });
+			dailyDownloadLimitQtyNud.Name = "dailyDownloadLimitQtyNud";
+			dailyDownloadLimitQtyNud.Size = new System.Drawing.Size(110, 23);
+			dailyDownloadLimitQtyNud.TabIndex = 4;
+			dailyDownloadLimitQtyNud.Value = new decimal(new int[] { 50, 0, 0, 0 });
+			// 
+			// dailyDownloadLimitUnitCb
+			// 
+			dailyDownloadLimitUnitCb.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+			dailyDownloadLimitUnitCb.FormattingEnabled = true;
+			dailyDownloadLimitUnitCb.Location = new System.Drawing.Point(383, 57);
+			dailyDownloadLimitUnitCb.Name = "dailyDownloadLimitUnitCb";
+			dailyDownloadLimitUnitCb.Size = new System.Drawing.Size(90, 23);
+			dailyDownloadLimitUnitCb.TabIndex = 5;
+			dailyDownloadLimitUnitCb.SelectedIndexChanged += dailyDownloadLimitUnitCb_SelectedIndexChanged;
+			// 
+			// dailyDownloadLimitApproxLbl
+			// 
+			dailyDownloadLimitApproxLbl.Location = new System.Drawing.Point(485, 53);
+			dailyDownloadLimitApproxLbl.Name = "dailyDownloadLimitApproxLbl";
+			dailyDownloadLimitApproxLbl.Size = new System.Drawing.Size(350, 45);
+			dailyDownloadLimitApproxLbl.TabIndex = 6;
+			dailyDownloadLimitApproxLbl.Text = "[mb/gb approximate note]";
+			// 
 			// tab3DownloadDecrypt
 			// 
 			tab3DownloadDecrypt.AutoScroll = true;
@@ -756,6 +836,7 @@
 			tab3DownloadDecrypt.Controls.Add(inProgressFilesGb);
 			tab3DownloadDecrypt.Controls.Add(customFileNamingGb);
 			tab3DownloadDecrypt.Controls.Add(badBookGb);
+			tab3DownloadDecrypt.Controls.Add(dailyDownloadLimitGb);
 			tab3DownloadDecrypt.Location = new System.Drawing.Point(4, 24);
 			tab3DownloadDecrypt.Name = "tab3DownloadDecrypt";
 			tab3DownloadDecrypt.Padding = new System.Windows.Forms.Padding(3);
@@ -765,9 +846,9 @@
 			// 
 			// saveMetadataToFileCbox
 			// 
-			saveMetadataToFileCbox.Anchor = System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right;
+			saveMetadataToFileCbox.Anchor = System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right;
 			saveMetadataToFileCbox.AutoSize = true;
-			saveMetadataToFileCbox.Location = new System.Drawing.Point(481, 435);
+			saveMetadataToFileCbox.Location = new System.Drawing.Point(481, 551);
 			saveMetadataToFileCbox.Name = "saveMetadataToFileCbox";
 			saveMetadataToFileCbox.Size = new System.Drawing.Size(166, 19);
 			saveMetadataToFileCbox.TabIndex = 22;
@@ -776,9 +857,9 @@
 			// 
 			// useCoverAsFolderIconCb
 			// 
-			useCoverAsFolderIconCb.Anchor = System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left;
+			useCoverAsFolderIconCb.Anchor = System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left;
 			useCoverAsFolderIconCb.AutoSize = true;
-			useCoverAsFolderIconCb.Location = new System.Drawing.Point(6, 435);
+			useCoverAsFolderIconCb.Location = new System.Drawing.Point(6, 551);
 			useCoverAsFolderIconCb.Name = "useCoverAsFolderIconCb";
 			useCoverAsFolderIconCb.Size = new System.Drawing.Size(180, 19);
 			useCoverAsFolderIconCb.TabIndex = 22;
@@ -787,10 +868,10 @@
 			// 
 			// inProgressFilesGb
 			// 
-			inProgressFilesGb.Anchor = System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right;
+			inProgressFilesGb.Anchor = System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right;
 			inProgressFilesGb.Controls.Add(inProgressSelectControl);
 			inProgressFilesGb.Controls.Add(inProgressDescLbl);
-			inProgressFilesGb.Location = new System.Drawing.Point(6, 281);
+			inProgressFilesGb.Location = new System.Drawing.Point(6, 397);
 			inProgressFilesGb.Name = "inProgressFilesGb";
 			inProgressFilesGb.Size = new System.Drawing.Size(842, 148);
 			inProgressFilesGb.TabIndex = 21;
@@ -799,7 +880,7 @@
 			// 
 			// inProgressSelectControl
 			// 
-			inProgressSelectControl.Anchor = System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right;
+			inProgressSelectControl.Anchor = System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right;
 			inProgressSelectControl.Location = new System.Drawing.Point(6, 65);
 			inProgressSelectControl.Name = "inProgressSelectControl";
 			inProgressSelectControl.Size = new System.Drawing.Size(830, 80);
@@ -818,7 +899,7 @@
 			customFileNamingGb.Controls.Add(folderTemplateBtn);
 			customFileNamingGb.Controls.Add(folderTemplateTb);
 			customFileNamingGb.Controls.Add(folderTemplateLbl);
-			customFileNamingGb.Location = new System.Drawing.Point(7, 88);
+			customFileNamingGb.Location = new System.Drawing.Point(7, 204);
 			customFileNamingGb.Name = "customFileNamingGb";
 			customFileNamingGb.Size = new System.Drawing.Size(842, 187);
 			customFileNamingGb.TabIndex = 20;
@@ -1715,6 +1796,9 @@
 			Load += SettingsDialog_Load;
 			badBookGb.ResumeLayout(false);
 			badBookGb.PerformLayout();
+			dailyDownloadLimitGb.ResumeLayout(false);
+			dailyDownloadLimitGb.PerformLayout();
+			((System.ComponentModel.ISupportInitialize)dailyDownloadLimitQtyNud).EndInit();
 			tabControl.ResumeLayout(false);
 			tab1ImportantSettings.ResumeLayout(false);
 			tab1ImportantSettings.PerformLayout();
@@ -1768,6 +1852,13 @@
 		private System.Windows.Forms.Label loggingLevelLbl;
 		private System.Windows.Forms.ComboBox loggingLevelCb;
 		private System.Windows.Forms.GroupBox badBookGb;
+		private System.Windows.Forms.GroupBox dailyDownloadLimitGb;
+		private System.Windows.Forms.Label dailyDownloadLimitDescLbl;
+		private System.Windows.Forms.ComboBox dailyDownloadLimitScopeCb;
+		private System.Windows.Forms.Label dailyDownloadLimitQtyLbl;
+		private System.Windows.Forms.NumericUpDown dailyDownloadLimitQtyNud;
+		private System.Windows.Forms.ComboBox dailyDownloadLimitUnitCb;
+		private System.Windows.Forms.Label dailyDownloadLimitApproxLbl;
 		private System.Windows.Forms.RadioButton badBookRetryRb;
 		private System.Windows.Forms.RadioButton badBookAbortRb;
 		private System.Windows.Forms.RadioButton badBookAskRb;

--- a/Source/LibationWinForms/Dialogs/SettingsDialog.DownloadDecrypt.cs
+++ b/Source/LibationWinForms/Dialogs/SettingsDialog.DownloadDecrypt.cs
@@ -1,8 +1,10 @@
 ﻿using Dinah.Core;
 using LibationFileManager;
 using LibationFileManager.Templates;
+using LibationUiBase;
 using System;
 using System.IO;
+using System.Linq;
 
 namespace LibationWinForms.Dialogs;
 
@@ -24,6 +26,8 @@ public partial class SettingsDialog
 
 	private void Load_DownloadDecrypt(Configuration config)
 	{
+		Load_DailyDownloadLimit(config);
+
 		inProgressDescLbl.Text = desc(nameof(config.InProgress));
 		editCharreplacementBtn.Text = desc(nameof(config.ReplacementCharacters));
 
@@ -66,8 +70,81 @@ public partial class SettingsDialog
 		saveMetadataToFileCbox.Checked = config.SaveMetadataToFile;
 	}
 
+	#region daily download limit
+
+	private void Load_DailyDownloadLimit(Configuration config)
+	{
+		dailyDownloadLimitGb.Text = desc(nameof(config.DailyDownloadLimit));
+		dailyDownloadLimitDescLbl.Text
+			= "Rolling 24 hours, not a calendar day. Only downloads Libation completes are counted; books you download from the Audible app or website are not.";
+		dailyDownloadLimitQtyLbl.Text = desc(nameof(config.DailyDownloadLimitQuantity));
+		dailyDownloadLimitApproxLbl.Text
+			= "MB and GB are approximate: Libation does not know precisely how large an audiobook is before downloading it, so it assumes about 400 MB per book.";
+
+		var scopeTip = Configuration.GetHelpText(nameof(config.DailyDownloadLimit));
+		toolTip.SetToolTip(dailyDownloadLimitScopeCb, scopeTip);
+		toolTip.SetToolTip(dailyDownloadLimitDescLbl, scopeTip);
+		toolTip.SetToolTip(dailyDownloadLimitUnitCb, Configuration.GetHelpText(nameof(config.DailyDownloadLimitUnit)));
+
+		dailyDownloadLimitScopeCb.Items.Clear();
+		dailyDownloadLimitScopeCb.Items.AddRange(
+			Enum.GetValues<Configuration.DailyLimitScope>()
+			.Select(v => (object)new EnumDisplay<Configuration.DailyLimitScope>(v))
+			.ToArray());
+		dailyDownloadLimitScopeCb.SelectedIndex
+			= Array.IndexOf(Enum.GetValues<Configuration.DailyLimitScope>(), config.DailyDownloadLimit);
+
+		dailyDownloadLimitUnitCb.Items.Clear();
+		dailyDownloadLimitUnitCb.Items.AddRange(
+			Enum.GetValues<Configuration.DailyLimitUnit>()
+			.Select(v => (object)new EnumDisplay<Configuration.DailyLimitUnit>(v))
+			.ToArray());
+		dailyDownloadLimitUnitCb.SelectedIndex
+			= Array.IndexOf(Enum.GetValues<Configuration.DailyLimitUnit>(), config.DailyDownloadLimitUnit);
+
+		dailyDownloadLimitQtyNud.Value = Math.Clamp(config.DailyDownloadLimitQuantity, dailyDownloadLimitQtyNud.Minimum, dailyDownloadLimitQtyNud.Maximum);
+
+		UpdateDailyDownloadLimitEnabled();
+	}
+
+	private void dailyDownloadLimitScopeCb_SelectedIndexChanged(object sender, EventArgs e) => UpdateDailyDownloadLimitEnabled();
+
+	private void dailyDownloadLimitUnitCb_SelectedIndexChanged(object sender, EventArgs e) => UpdateDailyDownloadLimitEnabled();
+
+	/// <summary>The quantity and unit only mean anything once a scope other than "No limit" is chosen.</summary>
+	private void UpdateDailyDownloadLimitEnabled()
+	{
+		var limited = SelectedDailyLimitScope() is not Configuration.DailyLimitScope.NoLimit;
+
+		dailyDownloadLimitQtyLbl.Visible = limited;
+		dailyDownloadLimitQtyNud.Visible = limited;
+		dailyDownloadLimitUnitCb.Visible = limited;
+		dailyDownloadLimitApproxLbl.Visible = limited && SelectedDailyLimitUnit() is not Configuration.DailyLimitUnit.Books;
+	}
+
+	private Configuration.DailyLimitScope SelectedDailyLimitScope()
+		=> dailyDownloadLimitScopeCb.SelectedItem is EnumDisplay<Configuration.DailyLimitScope> selected
+		? selected.Value
+		: Configuration.DailyLimitScope.NoLimit;
+
+	private Configuration.DailyLimitUnit SelectedDailyLimitUnit()
+		=> dailyDownloadLimitUnitCb.SelectedItem is EnumDisplay<Configuration.DailyLimitUnit> selected
+		? selected.Value
+		: Configuration.DailyLimitUnit.Books;
+
+	private void Save_DailyDownloadLimit(Configuration config)
+	{
+		config.DailyDownloadLimit = SelectedDailyLimitScope();
+		config.DailyDownloadLimitQuantity = (int)dailyDownloadLimitQtyNud.Value;
+		config.DailyDownloadLimitUnit = SelectedDailyLimitUnit();
+	}
+
+	#endregion
+
 	private void Save_DownloadDecrypt(Configuration config)
 	{
+		Save_DailyDownloadLimit(config);
+
 		config.InProgress = inProgressSelectControl.SelectedDirectory;
 
 		config.BadBook

--- a/Source/LibationWinForms/ProcessQueue/ProcessQueueControl.cs
+++ b/Source/LibationWinForms/ProcessQueue/ProcessQueueControl.cs
@@ -67,11 +67,7 @@ internal partial class ProcessQueueControl : UserControl
 	}
 
 	private async void cancelAllBtn_Click(object? sender, EventArgs e)
-	{
-		ViewModel.Queue.ClearQueue();
-		if (ViewModel.Queue.Current is not null)
-			await ViewModel.Queue.Current.CancelAsync();
-	}
+		=> await ViewModel.CancelAllAsync();
 
 	private void btnClearFinished_Click(object? sender, EventArgs e)
 	{

--- a/Source/_Tests/ApplicationServices.Tests/DownloadHistoryStoreTests.cs
+++ b/Source/_Tests/ApplicationServices.Tests/DownloadHistoryStoreTests.cs
@@ -1,0 +1,127 @@
+using ApplicationServices;
+using AssertionHelper;
+using LibationFileManager;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.IO;
+using System.Linq;
+
+namespace DownloadHistoryStoreTests;
+
+/// <summary>
+/// Exercises the download history against a real SQLite database in a temp directory, which also proves the
+/// new migration applies to a fresh database and that the store's queries work on the shipping provider.
+/// </summary>
+[TestClass]
+[DoNotParallelize]
+public class DownloadHistoryStoreTests
+{
+	private string tempLibationFiles = string.Empty;
+
+	[TestInitialize]
+	public void Initialize()
+	{
+		tempLibationFiles = Path.Combine(Path.GetTempPath(), $"libation-download-history-tests-{Guid.NewGuid():N}");
+		Directory.CreateDirectory(tempLibationFiles);
+
+		// A fresh Configuration resolves LibationFiles from this variable, so the database lands in the temp dir.
+		Environment.SetEnvironmentVariable(LibationFiles.LIBATION_FILES_DIR, tempLibationFiles);
+		Configuration.CreateMockInstance();
+	}
+
+	[TestCleanup]
+	public void Cleanup()
+	{
+		Configuration.RestoreSingletonInstance();
+		Environment.SetEnvironmentVariable(LibationFiles.LIBATION_FILES_DIR, null);
+
+		try
+		{
+			Directory.Delete(tempLibationFiles, recursive: true);
+		}
+		catch (IOException)
+		{
+			// A leftover temp directory is not worth failing a test over.
+		}
+	}
+
+	[TestMethod]
+	public void Round_trips_a_recorded_download_through_a_real_database()
+	{
+		var completedAt = DateTimeOffset.Now.AddHours(-2);
+
+		DownloadHistoryStore.Record("B004V3LWLM", isAudiblePlus: true, bytes: 123_456_789, completedAt: completedAt);
+
+		var entries = DownloadHistoryStore.GetCurrentWindow(DateTimeOffset.Now);
+
+		entries.Count.Should().Be(1);
+		entries[0].AudibleProductId.Should().Be("B004V3LWLM");
+		entries[0].IsAudiblePlus.Should().BeTrue();
+		entries[0].Bytes.Should().Be(123_456_789);
+		// Round-tripped through UTC ticks, so this is exact rather than approximate.
+		Assert.AreEqual(completedAt.UtcTicks, entries[0].CompletedAt.UtcTicks);
+	}
+
+	[TestMethod]
+	public void Creates_the_database_file_and_applies_the_new_migration()
+	{
+		DownloadHistoryStore.Record("ASIN1", isAudiblePlus: false, bytes: 1);
+
+		File.Exists(Path.Combine(tempLibationFiles, "LibationContext.db")).Should().BeTrue();
+		DownloadHistoryStore.GetSince(DateTimeOffset.Now.AddMinutes(-1)).Count.Should().Be(1);
+	}
+
+	[TestMethod]
+	public void GetSince_excludes_downloads_before_the_cutoff()
+	{
+		var now = DateTimeOffset.Now;
+		DownloadHistoryStore.Record("OLD", isAudiblePlus: true, bytes: 1, completedAt: now.AddHours(-23));
+		DownloadHistoryStore.Record("NEW", isAudiblePlus: true, bytes: 1, completedAt: now.AddHours(-1));
+
+		var lastTwoHours = DownloadHistoryStore.GetSince(now.AddHours(-2));
+
+		lastTwoHours.Count.Should().Be(1);
+		lastTwoHours[0].AudibleProductId.Should().Be("NEW");
+
+		// Both are inside the rolling window the limit uses.
+		DownloadHistoryStore.GetCurrentWindow(now).Count.Should().Be(2);
+	}
+
+	[TestMethod]
+	public void Recording_prunes_rows_older_than_the_retention_period()
+	{
+		var now = DateTimeOffset.Now;
+		DownloadHistoryStore.Record("ANCIENT", isAudiblePlus: true, bytes: 1, completedAt: now.AddDays(-4));
+		DownloadHistoryStore.Record("YESTERDAY", isAudiblePlus: true, bytes: 1, completedAt: now.AddHours(-20));
+
+		var asins = DownloadHistoryStore.GetSince(DateTimeOffset.MinValue).Select(e => e.AudibleProductId).ToList();
+
+		asins.Contains("ANCIENT").Should().BeFalse();
+		asins.Contains("YESTERDAY").Should().BeTrue();
+	}
+
+	[TestMethod]
+	public void Entries_are_returned_oldest_first()
+	{
+		var now = DateTimeOffset.Now;
+		DownloadHistoryStore.Record("SECOND", isAudiblePlus: true, bytes: 1, completedAt: now.AddHours(-2));
+		DownloadHistoryStore.Record("FIRST", isAudiblePlus: true, bytes: 1, completedAt: now.AddHours(-5));
+
+		var entries = DownloadHistoryStore.GetCurrentWindow(now);
+
+		entries.Select(e => e.AudibleProductId).Should().BeEquivalentTo(["FIRST", "SECOND"]);
+	}
+
+	[TestMethod]
+	public void A_broken_database_cannot_fail_a_finished_download()
+	{
+		// Recording runs after a download has already succeeded, so a database problem must not throw.
+		Configuration.Instance.PostgresqlConnectionString
+			= "Host=127.0.0.1;Port=1;Database=nope;Username=nobody;Password=nothing;Timeout=1;Command Timeout=1";
+
+		DownloadHistoryStore.Record("ASIN1", isAudiblePlus: true, bytes: 1);
+
+		// And a failed read reports an empty window rather than blocking downloads.
+		DownloadHistoryStore.GetCurrentWindow(DateTimeOffset.Now).Count.Should().Be(0);
+	}
+}

--- a/Source/_Tests/LibationFileManager.Tests/DailyDownloadLimitTests.cs
+++ b/Source/_Tests/LibationFileManager.Tests/DailyDownloadLimitTests.cs
@@ -364,15 +364,17 @@ public class DailyDownloadLimitTests
 	}
 
 	[TestMethod]
-	public void Waiting_status_names_the_resume_time()
+	public void Waiting_status_names_the_resume_time_and_stays_short()
 	{
 		var config = Config(Configuration.DailyLimitScope.AllBooks, quantity: 1);
 		var allowance = DailyDownloadLimit.Evaluate(config, Downloads(1, Now.AddHours(-3), isPlus: false), Now);
 
 		var status = DailyDownloadLimitUserMessage.BuildWaitingStatus(allowance);
 
-		StringAssert.Contains(status, "Daily limit reached");
+		StringAssert.Contains(status, "Daily limit");
 		StringAssert.Contains(status, allowance.NextCapacityAt!.Value.ToLocalTime().ToString("t"));
+		// The process queue column clips instead of wrapping, so this has to stay short enough to read.
+		Assert.IsTrue(status.Length <= 34, $"Waiting status is too long for the queue column: '{status}'");
 	}
 
 	[TestMethod]

--- a/Source/_Tests/LibationFileManager.Tests/DailyDownloadLimitTests.cs
+++ b/Source/_Tests/LibationFileManager.Tests/DailyDownloadLimitTests.cs
@@ -1,0 +1,392 @@
+using AssertionHelper;
+using LibationFileManager;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace DailyDownloadLimitTests;
+
+[TestClass]
+[DoNotParallelize]
+public class DailyDownloadLimitTests
+{
+	private static readonly DateTimeOffset Now = new(2026, 3, 14, 21, 0, 0, TimeSpan.FromHours(-4));
+
+	private const long EstimatedBookBytes = DiskSpaceHelper.EstimatedBytesPerAudiobookBackup;
+
+	[TestCleanup]
+	public void Cleanup() => Configuration.RestoreSingletonInstance();
+
+	private static Configuration Config(
+		Configuration.DailyLimitScope scope,
+		int quantity = 50,
+		Configuration.DailyLimitUnit unit = Configuration.DailyLimitUnit.Books)
+	{
+		var config = Configuration.CreateMockInstance();
+		config.DailyDownloadLimit = scope;
+		config.DailyDownloadLimitQuantity = quantity;
+		config.DailyDownloadLimitUnit = unit;
+		return config;
+	}
+
+	private static List<DownloadHistoryEntry> Downloads(int count, DateTimeOffset at, bool isPlus = true, long bytes = 300_000_000)
+		=> Enumerable.Range(0, count)
+		.Select(i => new DownloadHistoryEntry(at.AddSeconds(i), $"ASIN{i}", isPlus, bytes))
+		.ToList();
+
+	#region defaults
+
+	[TestMethod]
+	public void Defaults_are_off_and_write_nothing()
+	{
+		var config = Configuration.CreateMockInstance();
+
+		config.Exists(nameof(Configuration.DailyDownloadLimit)).Should().BeFalse();
+		config.Exists(nameof(Configuration.DailyDownloadLimitQuantity)).Should().BeFalse();
+		config.Exists(nameof(Configuration.DailyDownloadLimitUnit)).Should().BeFalse();
+
+		Assert.AreEqual(Configuration.DailyLimitScope.NoLimit, config.DailyDownloadLimit);
+		Assert.AreEqual(50, config.DailyDownloadLimitQuantity);
+		Assert.AreEqual(Configuration.DailyLimitUnit.Books, config.DailyDownloadLimitUnit);
+	}
+
+	[TestMethod]
+	public void Quantity_of_zero_or_negative_is_clamped_to_one()
+	{
+		var config = Configuration.CreateMockInstance();
+
+		config.DailyDownloadLimitQuantity = 0;
+		Assert.AreEqual(1, config.DailyDownloadLimitQuantity);
+
+		config.DailyDownloadLimitQuantity = -7;
+		Assert.AreEqual(1, config.DailyDownloadLimitQuantity);
+	}
+
+	[TestMethod]
+	public void NoLimit_never_blocks_anything()
+	{
+		var config = Config(Configuration.DailyLimitScope.NoLimit);
+		var history = Downloads(500, Now.AddHours(-1));
+
+		var allowance = DailyDownloadLimit.Evaluate(config, history, Now);
+
+		allowance.IsLimited.Should().BeFalse();
+		allowance.AllowsAnother.Should().BeTrue();
+		allowance.Blocks(isPlus: true).Should().BeFalse();
+		allowance.Blocks(isPlus: false).Should().BeFalse();
+		Assert.IsNull(allowance.RemainingBooks);
+		Assert.IsNull(allowance.NextCapacityAt);
+	}
+
+	#endregion
+
+	#region rolling window
+
+	[TestMethod]
+	public void Fifty_downloads_at_eleven_pm_still_blocks_two_hours_later()
+	{
+		var config = Config(Configuration.DailyLimitScope.AllBooks, quantity: 50);
+		var elevenPm = Now.AddHours(2);
+		var history = Downloads(50, elevenPm);
+
+		var oneAmNextDay = elevenPm.AddHours(2);
+		var allowance = DailyDownloadLimit.Evaluate(config, history, oneAmNextDay);
+
+		allowance.Blocks(isPlus: false).Should().BeTrue();
+		allowance.UsedBooks.Should().Be(50);
+		Assert.AreEqual(0, allowance.RemainingBooks!.Value);
+	}
+
+	[TestMethod]
+	public void Capacity_returns_twenty_four_hours_after_the_download_not_at_midnight()
+	{
+		var config = Config(Configuration.DailyLimitScope.AllBooks, quantity: 50);
+		var elevenPm = Now.AddHours(2);
+		var history = Downloads(50, elevenPm);
+
+		// One second before the oldest download ages out.
+		DailyDownloadLimit
+			.Evaluate(config, history, elevenPm.AddHours(24).AddSeconds(-1))
+			.Blocks(isPlus: false)
+			.Should().BeTrue();
+
+		// And just after.
+		DailyDownloadLimit
+			.Evaluate(config, history, elevenPm.AddHours(24).AddSeconds(1))
+			.Blocks(isPlus: false)
+			.Should().BeFalse();
+	}
+
+	[TestMethod]
+	public void NextCapacityAt_is_twenty_four_hours_after_the_oldest_counted_download()
+	{
+		var config = Config(Configuration.DailyLimitScope.AllBooks, quantity: 2);
+		var oldest = Now.AddHours(-5);
+		var history = new List<DownloadHistoryEntry>
+		{
+			new(Now.AddHours(-1), "NEWER", false, 1),
+			new(oldest, "OLDEST", false, 1),
+		};
+
+		var allowance = DailyDownloadLimit.Evaluate(config, history, Now);
+
+		allowance.Blocks(isPlus: false).Should().BeTrue();
+		Assert.AreEqual(oldest.AddHours(24), allowance.NextCapacityAt);
+	}
+
+	[TestMethod]
+	public void Partial_expiry_frees_capacity_a_few_at_a_time()
+	{
+		// What a multi-day queue relies on: an evening of downloads frees up over the following evening.
+		var config = Config(Configuration.DailyLimitScope.AllBooks, quantity: 10);
+		var evening = Now;
+		var history = new List<DownloadHistoryEntry>();
+		for (var i = 0; i < 10; i++)
+			history.Add(new DownloadHistoryEntry(evening.AddMinutes(i * 30), $"ASIN{i}", false, 1));
+
+		// A day later, the first three have aged out, so three slots are free and no more.
+		var nextEvening = evening.AddHours(24).AddMinutes(75);
+		var allowance = DailyDownloadLimit.Evaluate(config, history, nextEvening);
+
+		allowance.UsedBooks.Should().Be(7);
+		Assert.AreEqual(3, allowance.RemainingBooks!.Value);
+		allowance.AllowsAnother.Should().BeTrue();
+
+		// Filling those three blocks again until the next one ages out.
+		history.AddRange(Downloads(3, nextEvening, isPlus: false, bytes: 1));
+		var refilled = DailyDownloadLimit.Evaluate(config, history, nextEvening.AddMinutes(1));
+
+		refilled.UsedBooks.Should().Be(10);
+		refilled.Blocks(isPlus: false).Should().BeTrue();
+		Assert.AreEqual(evening.AddMinutes(90).AddHours(24), refilled.NextCapacityAt);
+	}
+
+	[TestMethod]
+	public void Downloads_older_than_the_window_are_ignored()
+	{
+		var config = Config(Configuration.DailyLimitScope.AllBooks, quantity: 5);
+		var history = Downloads(50, Now.AddHours(-30), isPlus: false);
+
+		var allowance = DailyDownloadLimit.Evaluate(config, history, Now);
+
+		allowance.UsedBooks.Should().Be(0);
+		allowance.Blocks(isPlus: false).Should().BeFalse();
+	}
+
+	#endregion
+
+	#region scope
+
+	[TestMethod]
+	public void PlusOnly_counts_and_blocks_only_plus_titles()
+	{
+		var config = Config(Configuration.DailyLimitScope.PlusOnly, quantity: 3);
+		var history = Downloads(3, Now.AddHours(-2), isPlus: true)
+			.Concat(Downloads(9, Now.AddHours(-1), isPlus: false))
+			.ToList();
+
+		var allowance = DailyDownloadLimit.Evaluate(config, history, Now);
+
+		allowance.UsedBooks.Should().Be(3);
+		allowance.Blocks(isPlus: true).Should().BeTrue();
+		allowance.Blocks(isPlus: false).Should().BeFalse();
+
+		DailyDownloadLimit.AppliesTo(isPlus: true, config).Should().BeTrue();
+		DailyDownloadLimit.AppliesTo(isPlus: false, config).Should().BeFalse();
+	}
+
+	[TestMethod]
+	public void AllBooks_counts_owned_and_plus_together()
+	{
+		var config = Config(Configuration.DailyLimitScope.AllBooks, quantity: 5);
+		var history = Downloads(3, Now.AddHours(-2), isPlus: true)
+			.Concat(Downloads(2, Now.AddHours(-1), isPlus: false))
+			.ToList();
+
+		var allowance = DailyDownloadLimit.Evaluate(config, history, Now);
+
+		allowance.UsedBooks.Should().Be(5);
+		allowance.Blocks(isPlus: true).Should().BeTrue();
+		allowance.Blocks(isPlus: false).Should().BeTrue();
+	}
+
+	#endregion
+
+	#region MB and GB
+
+	[TestMethod]
+	public void Byte_limit_blocks_when_another_estimated_book_would_not_fit()
+	{
+		// 1 GB limit, 800 MB already used: a further ~400 MB book would exceed it.
+		var config = Config(Configuration.DailyLimitScope.AllBooks, quantity: 1, unit: Configuration.DailyLimitUnit.GB);
+		var history = Downloads(2, Now.AddHours(-1), isPlus: false, bytes: 400_000_000);
+
+		var allowance = DailyDownloadLimit.Evaluate(config, history, Now);
+
+		allowance.UsedBytes.Should().Be(800_000_000);
+		allowance.Blocks(isPlus: false).Should().BeTrue();
+		Assert.AreEqual(1024L * 1024 * 1024, allowance.LimitBytes);
+	}
+
+	[TestMethod]
+	public void Byte_limit_allows_when_another_estimated_book_fits()
+	{
+		var config = Config(Configuration.DailyLimitScope.AllBooks, quantity: 2, unit: Configuration.DailyLimitUnit.GB);
+		var history = Downloads(2, Now.AddHours(-1), isPlus: false, bytes: 400_000_000);
+
+		var allowance = DailyDownloadLimit.Evaluate(config, history, Now);
+
+		allowance.Blocks(isPlus: false).Should().BeFalse();
+		Assert.AreEqual((int)((2L * 1024 * 1024 * 1024 - 800_000_000) / EstimatedBookBytes), allowance.RemainingBooks!.Value);
+	}
+
+	[TestMethod]
+	public void MB_and_GB_use_the_same_scale_as_the_rest_of_Libation()
+	{
+		var mb = Config(Configuration.DailyLimitScope.AllBooks, quantity: 1024, unit: Configuration.DailyLimitUnit.MB);
+		var gb = Config(Configuration.DailyLimitScope.AllBooks, quantity: 1, unit: Configuration.DailyLimitUnit.GB);
+
+		Assert.AreEqual(
+			DailyDownloadLimit.Evaluate(gb, [], Now).LimitBytes,
+			DailyDownloadLimit.Evaluate(mb, [], Now).LimitBytes);
+	}
+
+	[TestMethod]
+	public void An_empty_window_always_allows_one_download_even_below_the_estimate()
+	{
+		// Without this rule a 1 MB limit would block downloading forever and report "limit reached"
+		// to a user who had downloaded nothing.
+		var config = Config(Configuration.DailyLimitScope.AllBooks, quantity: 1, unit: Configuration.DailyLimitUnit.MB);
+
+		var allowance = DailyDownloadLimit.Evaluate(config, [], Now);
+
+		allowance.AllowsAnother.Should().BeTrue();
+		allowance.Blocks(isPlus: false).Should().BeFalse();
+		Assert.AreEqual(1, allowance.RemainingBooks!.Value);
+
+		// But only one: after that download the limit holds.
+		var afterOne = DailyDownloadLimit.Evaluate(config, Downloads(1, Now, isPlus: false, bytes: 300_000_000), Now.AddMinutes(1));
+		afterOne.Blocks(isPlus: false).Should().BeTrue();
+	}
+
+	[TestMethod]
+	public void Byte_limit_next_capacity_waits_for_enough_bytes_to_age_out()
+	{
+		// 1 GB limit; three 400 MB downloads. Losing only the oldest still leaves 800 MB used,
+		// which cannot fit another estimated book, so capacity returns with the second.
+		var config = Config(Configuration.DailyLimitScope.AllBooks, quantity: 1, unit: Configuration.DailyLimitUnit.GB);
+		var first = Now.AddHours(-6);
+		var second = Now.AddHours(-5);
+		var history = new List<DownloadHistoryEntry>
+		{
+			new(first, "A", false, 400_000_000),
+			new(second, "B", false, 400_000_000),
+			new(Now.AddHours(-4), "C", false, 400_000_000),
+		};
+
+		var allowance = DailyDownloadLimit.Evaluate(config, history, Now);
+
+		allowance.Blocks(isPlus: false).Should().BeTrue();
+		Assert.AreEqual(second.AddHours(24), allowance.NextCapacityAt);
+	}
+
+	#endregion
+
+	#region throttling suggestion
+
+	[TestMethod]
+	public void Suggestion_is_silent_below_the_threshold()
+	{
+		var config = Config(Configuration.DailyLimitScope.NoLimit);
+		var history = Downloads(DailyDownloadLimit.SuggestionMinimumRecentDownloads - 1, Now.AddHours(-1));
+
+		DailyDownloadLimitUserMessage.BuildSuggestionParagraph(config, history, Now).Should().BeNull();
+	}
+
+	[TestMethod]
+	public void Suggestion_is_silent_when_a_limit_is_already_configured()
+	{
+		var config = Config(Configuration.DailyLimitScope.PlusOnly);
+		var history = Downloads(60, Now.AddHours(-1));
+
+		DailyDownloadLimitUserMessage.BuildSuggestionParagraph(config, history, Now).Should().BeNull();
+	}
+
+	[TestMethod]
+	public void Suggestion_quotes_the_real_recent_counts()
+	{
+		var config = Config(Configuration.DailyLimitScope.NoLimit);
+		var history = Downloads(58, Now.AddHours(-3), isPlus: true)
+			.Concat(Downloads(5, Now.AddHours(-2), isPlus: false))
+			.Concat(Downloads(99, Now.AddHours(-40), isPlus: true))
+			.ToList();
+
+		var suggestion = DailyDownloadLimitUserMessage.BuildSuggestionParagraph(config, history, Now);
+
+		Assert.IsNotNull(suggestion);
+		StringAssert.Contains(suggestion, "63 titles");
+		StringAssert.Contains(suggestion, "58 of them from the Plus catalog");
+		StringAssert.Contains(suggestion, "Daily download limit");
+	}
+
+	[TestMethod]
+	public void Recent_summary_ignores_downloads_outside_the_window()
+	{
+		var history = Downloads(4, Now.AddHours(-2), isPlus: true, bytes: 10)
+			.Concat(Downloads(3, Now.AddHours(-1), isPlus: false, bytes: 10))
+			.Concat(Downloads(99, Now.AddHours(-25), isPlus: true, bytes: 10))
+			.ToList();
+
+		var recent = DailyDownloadLimit.SummarizeRecent(history, Now);
+
+		recent.TotalDownloads.Should().Be(7);
+		recent.PlusDownloads.Should().Be(4);
+		recent.TotalBytes.Should().Be(70);
+	}
+
+	#endregion
+
+	#region user-facing copy
+
+	[TestMethod]
+	public void Paused_message_says_how_to_change_the_limit_and_when_it_resumes()
+	{
+		var config = Config(Configuration.DailyLimitScope.PlusOnly, quantity: 50);
+		var allowance = DailyDownloadLimit.Evaluate(config, Downloads(50, Now.AddHours(-3)), Now);
+
+		var body = DailyDownloadLimitUserMessage.BuildQueuePausedBody(allowance, "A Wrinkle in Time");
+
+		StringAssert.Contains(body, "A Wrinkle in Time");
+		StringAssert.Contains(body, "Settings > Download/Decrypt > Daily download limit");
+		StringAssert.Contains(body, "still queued");
+		StringAssert.Contains(body, "Cancel All");
+	}
+
+	[TestMethod]
+	public void Waiting_status_names_the_resume_time()
+	{
+		var config = Config(Configuration.DailyLimitScope.AllBooks, quantity: 1);
+		var allowance = DailyDownloadLimit.Evaluate(config, Downloads(1, Now.AddHours(-3), isPlus: false), Now);
+
+		var status = DailyDownloadLimitUserMessage.BuildWaitingStatus(allowance);
+
+		StringAssert.Contains(status, "Daily limit reached");
+		StringAssert.Contains(status, allowance.NextCapacityAt!.Value.ToLocalTime().ToString("t"));
+	}
+
+	[TestMethod]
+	public void Cli_lines_point_at_Settings_json()
+	{
+		var config = Config(Configuration.DailyLimitScope.AllBooks, quantity: 10);
+		var allowance = DailyDownloadLimit.Evaluate(config, Downloads(10, Now.AddHours(-1), isPlus: false), Now);
+
+		var lines = string.Join("\n", DailyDownloadLimitUserMessage.BuildCliSkippedLines(allowance));
+
+		StringAssert.Contains(lines, "Daily download limit reached");
+		StringAssert.Contains(lines, "Settings.json");
+		StringAssert.Contains(lines, nameof(Configuration.DailyDownloadLimit));
+	}
+
+	#endregion
+}

--- a/docs/development/testing.md
+++ b/docs/development/testing.md
@@ -93,3 +93,28 @@ Two of the Liberate icons are not stored in the database at all, which is worth 
 - **Green and Error are database-only.** `AudioExists` is defined as `BookStatus is Liberated or Error`, so neither needs an audio file to exist. Creating one changes nothing.
 
 One more trap, in the grid rather than the database: a podcast's series is identified by the **parent book's own ASIN**, not by an arbitrary series id, and `SeriesEntry.GetAllSeriesEntriesAsync` discards any series whose children it cannot match. Point the episodes at a different series id and the parent row disappears from the grid with no error.
+
+### seed-download-history.cs
+
+Fills the `DownloadHistory` table with fake completed downloads, so the [daily download limit](/docs/features/daily-download-limit) can be tested without downloading anything. Start Libation once first so the table exists.
+
+Reach a limit of 50 Audible Plus titles and stay there:
+
+```bash
+dotnet run Scripts/seed-download-history.cs -- --count 50 --age-seconds 7200
+```
+
+The limit uses a rolling 24 hour window, and `--age-seconds` is how long ago each fake download finished, so it also controls when the window frees up. Dating the rows just under 24 hours old turns a multi-day wait into a one minute wait, which is how the pause-and-resume behavior is checked:
+
+```bash
+# a paused queue resumes on its own about a minute from now
+dotnet run Scripts/seed-download-history.cs -- --count 50 --age-seconds 86325
+```
+
+Other flags: `--owned` seeds purchased titles instead of Plus ones (useful for checking that a Plus-only limit ignores them), `--mb` sets the size of each fake download for testing MB and GB limits, and `--clean` deletes every row.
+
+Libation may be running while you seed. Each check re-queries the database, so a running queue picks up the new rows within seconds without a restart.
+
+::: tip
+The limit is off by default. Set **Settings > Download/Decrypt > Daily download limit** before expecting seeded rows to block anything.
+:::

--- a/docs/features/daily-download-limit.md
+++ b/docs/features/daily-download-limit.md
@@ -1,0 +1,67 @@
+# Daily download limit
+
+Libation can pace itself, downloading only so much in any 24 hour period. The limit is **off by default**: nothing changes until you turn it on.
+
+Two different reasons to use it:
+
+- **Audible throttling.** Downloading a lot of Audible Plus titles in a short time can lead Audible to deny content licenses for a day or two ("license denied"). That limit is Audible's, not Libation's, and Audible does not publish a number, but community reports put it in the dozens of titles. Capping your Plus downloads avoids provoking it.
+- **Disk space.** A large library can fill a drive. A limit in MB or GB stops a long run before your disk does.
+
+## Turning it on
+
+Settings > Download/Decrypt > **Daily download limit**.
+
+| Option | Effect |
+|--------|--------|
+| No limit | The default. Libation downloads as fast as it can. |
+| Plus titles only | Limits Audible Plus titles (the ones with an orange plus badge). Titles you own are unaffected. |
+| All books | Limits everything Libation downloads. |
+
+Choosing either limit shows a quantity and a unit: **books**, **MB** or **GB**. 50 books per day is a reasonable starting point for Plus titles.
+
+## Rolling 24 hours, not a calendar day
+
+The window always looks back 24 hours from right now. Capacity comes back 24 hours after each individual download, not at midnight. Downloading 50 titles at 11pm does not let you download 50 more at 1am; you get one back at 11pm the following night, and so on.
+
+## What counts
+
+Only downloads Libation itself completed successfully. That means:
+
+- Failed and cancelled downloads do not count.
+- PDF-only downloads and mp3 conversions never count, and are never blocked.
+- Books you download in the Audible app or on Audible's website are invisible to Libation and cannot be counted.
+- Re-downloading a title counts again, because it is another download.
+
+Libation records your downloads whether or not a limit is set, so if you turn the limit on after a heavy session, it already knows what you have done today.
+
+## About MB and GB
+
+Libation does not know how large an audiobook is until it has downloaded it, so a size limit is necessarily approximate. When deciding whether there is room for another book, Libation assumes about 400 MB for it — the same estimate it uses to warn about low disk space. Sizes already recorded are exact; only the next book is a guess.
+
+Because of that estimate, one download is always allowed when your window is empty. Otherwise a limit smaller than one book would stop downloading entirely and report "limit reached" to someone who had downloaded nothing.
+
+## What happens when the limit is reached
+
+The limit is checked immediately before each book downloads, not when you queue them, so your queue keeps its contents and you can change your mind at any time.
+
+**In the app:** the queue pauses instead of emptying. You get one notice, the waiting title shows when it expects to resume, and Libation continues on its own once capacity returns — including days later, if you leave it running with a long queue. Raise or turn off the limit in Settings and the queue picks that up within a few seconds, with nothing to requeue. Cancel All stops it instead.
+
+Under "Plus titles only" a queue holding both kinds keeps going: Plus titles move to the back and your owned titles download in the meantime.
+
+**On the command line:** `libationcli liberate` does not wait, since a scripted or scheduled run should not sit idle for hours. It skips the titles the limit covers, says so, and reports how many it skipped. Those titles remain un-liberated and are picked up by the next run.
+
+## Docker and the command line
+
+Containers have no settings dialog, so add the keys to the `Settings.json` you mount at `/config`:
+
+```json
+{
+  "DailyDownloadLimit": "PlusOnly",
+  "DailyDownloadLimitQuantity": 50,
+  "DailyDownloadLimitUnit": "Books"
+}
+```
+
+`DailyDownloadLimit` accepts `NoLimit`, `PlusOnly` or `AllBooks`, and `DailyDownloadLimitUnit` accepts `Books`, `MB` or `GB`. Download counts are kept in Libation's database, so they survive container restarts as long as your database is on a mounted volume, as it is in the standard setup.
+
+A container that liberates on a schedule combines well with a limit: each run downloads what it may and stops, and the next run continues where it left off.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -101,6 +101,10 @@ The stoplights will tell you a title's status:
 
 Or hover over the button to see the status.
 
+::: tip Downloading a big Plus library
+Audible may temporarily deny licenses if you download a lot of Audible Plus titles at once. If that describes your library, consider a [daily download limit](/docs/features/daily-download-limit) before you start.
+:::
+
 ![Liberate book step 1](images/LiberateBook1.png)
 
 Select Liberate > Begin Book Backups

--- a/docs/index.md
+++ b/docs/index.md
@@ -21,6 +21,7 @@ Learn about Libation's powerful features:
 
 - **[Audio File Formats](/docs/features/audio-file-formats)** - Supported audio formats and conversion options
 - **[Audiobookshelf Auto-Upload](/docs/features/audiobookshelf)** - Optionally upload liberated books to Audiobookshelf
+- **[Daily Download Limit](/docs/features/daily-download-limit)** - Optionally pace your downloads over a rolling 24 hours
 - **[Naming Templates](/docs/features/naming-templates)** - Customize how your audiobook files are named
 - **[Searching & Filtering](/docs/features/searching-and-filtering)** - Find and organize your audiobooks
 - **[Easy guide to searching](/docs/features/lucene)** - Tutorial for search queries

--- a/docs/installation/docker.md
+++ b/docs/installation/docker.md
@@ -37,6 +37,10 @@ The docker image is provided as-is. We hope it can be useful to you but it is no
 >
 > **Solution:** Configure custom replacement characters in `Settings.json` to replace colons with compatible characters. See [Command Line Interface - Set custom replacement characters](/docs/advanced/command-line-interface#set-custom-replacement-characters) for configuration examples.
 
+> [!TIP] Pacing downloads
+>
+> To stop a scheduled container from downloading your whole library at once, see [Daily download limit](/docs/features/daily-download-limit#docker-and-the-command-line). It is off unless you add the keys to your mounted `Settings.json`. Download counts live in Libation's database, so they survive container restarts when that database is on a volume.
+
 Configuration in Libation is handled by two files, `AccountsSettings.json` and `Settings.json`. These files can usually be found in the Libation folder in your user's home directory. The easiest way to configure these is to run the desktop version of Libation and then copy them into a folder, such as `/opt/libation/config`, that you'll volume mount into the image. `Settings.json` is technically optional, and, if not provided, Libation will run using the default settings. Additionally, the `Books` and `InProgress` settings in `Settings.json` will be ignored and the image will instead substitute it's own values. If tokens in that file are encrypted on the desktop, also copy the exported `libation-master.key` (see the encrypted-tokens warning above).
 
 ### Adding Audible accounts without the GUI


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Implements the daily download limit from #1920.

Off by default. Nothing is written to `Settings.json` and no migration touches existing settings, so an install that never opts in behaves exactly as before apart from recording its own downloads.

## Behavior

- Rolling 24 hours ending at the current local time, not a calendar day. 50 downloads at 11pm does not free up 50 more at 1am.
- Only successful downloads Libation performed are counted. PDF-only downloads and mp3 conversions are never counted or blocked.
- Scope: `PlusOnly` counts and blocks only Audible Plus titles, so owned titles keep flowing; `AllBooks` covers everything; `NoLimit` disables it.
- Units: `Books` compares a count. `MB`/`GB` compare recorded bytes and use the existing `DiskSpaceHelper.EstimatedBytesPerAudiobookBackup` (400 MB) to judge whether another book would exceed the limit. When nothing has been recorded in the window one download is always allowed, so a limit below 400 MB cannot wedge downloading entirely.

## Settings

New group at the top of the Download/Decrypt tab in both dialogs. Quantity has a minimum of 1 and no practical maximum (`int.MaxValue`, so a typed value cannot overflow the `int` setting); the WinForms spinner sets both bounds explicitly because its defaults are 0 and 100.

[Daily download limit set to Plus titles only, 50 books](https://cursor.com/agents/bc-442918c2-8e16-484c-be4a-b5fcdab0245f/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fsettings_daily_limit_plus_50_books.webp)

The MB/GB note appears only for those units:

[Approximation note shown when the unit is GB](https://cursor.com/agents/bc-442918c2-8e16-484c-be4a-b5fcdab0245f/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fsettings_daily_limit_gb_approximate_note.webp)

## Where the check happens

Immediately before each book downloads, never at queueing time, so a full queue stays full and raising or turning off the limit takes effect on the very next book with no requeueing.

When the next book is blocked but something else in the queue is not (a mixed queue under Plus-only), the blocked title moves to the end and the queue carries on. When nothing can proceed the queue pauses rather than draining: one dialog, a queue-log line, a per-book waiting status, and a re-check every 15 seconds.

[daily_limit_blocks_download_and_pauses_queue.mp4](https://cursor.com/agents/bc-442918c2-8e16-484c-be4a-b5fcdab0245f/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdaily_limit_blocks_download_and_pauses_queue.mp4)

A queue left running for days must drip-feed itself, so every re-check recomputes from scratch: fresh clock, fresh history query, settings read from `Configuration.Instance` rather than the config captured at enqueue. The dialog is deliberately not awaited, because `MessageBoxBase.Show` only completes when dismissed and an unattended queue must be able to resume behind it.

Filmed by dating the recorded downloads just under 24 hours old, so they age out of the window a minute later. Nothing is clicked between the pause and the resume:

[paused_queue_resumes_itself_when_window_rolls.mp4](https://cursor.com/agents/bc-442918c2-8e16-484c-be4a-b5fcdab0245f/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fpaused_queue_resumes_itself_when_window_rolls.mp4)

Mixed queue under Plus-only: the blocked Plus title goes to the back, owned titles are attempted, and the queue settles into a wait instead of rotating forever (6 deferrals for 8 Plus titles, then one pause).

[Queue log showing a Plus title moved to the end of the queue](https://cursor.com/agents/bc-442918c2-8e16-484c-be4a-b5fcdab0245f/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fqueue_log_plus_title_deferred_owned_titles_continue.webp)

The CLI never waits: it skips covered titles, prints why once, reports a skipped count, and exits 0. That keeps the Docker entrypoint's sleep loop working.

[cli_daily_limit_output.log](https://cursor.com/agents/bc-442918c2-8e16-484c-be4a-b5fcdab0245f/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fcli_daily_limit_output.log)

## Where the history lives

In the library database, as a new additive `DownloadHistory` table with migrations for SQLite and PostgreSQL. A file under `LibationFiles` would have been silently discarded in Docker, where `LibationFiles` is `/config-internal` inside the image and only the database is on a volume. No change to `Docker/liberate.sh` or the Dockerfile.

Verified by replicating that layout (ephemeral directory, `appsettings.json` redirect, database symlinked to the mounted volume) and destroying the ephemeral directory the way a container restart does. The counts survive; a file written under `LibationFiles` does not:

[docker_layout_history_survives_restart.log](https://cursor.com/agents/bc-442918c2-8e16-484c-be4a-b5fcdab0245f/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdocker_layout_history_survives_restart.log)

Timestamps are stored as UTC ticks so range queries mean the same thing on both providers and a window spanning a DST change stays exactly 24 hours.

## Suggesting the feature

Audible reports no throttling reason (`RejectionReason` has only `ContentEligibility`, `RequesterEligibility`, `GenericError`), so Libation already infers it. With downloads now always recorded, a license denial can cite real numbers: "Libation successfully downloaded 63 titles in the last 24 hours, 58 of them from the Plus catalog". The suggestion stays silent when a limit is already configured or when too few recent downloads make throttling implausible.

## Verification

- 1,221 tests pass, including the rolling window and partial-expiry math, scopes, MB/GB math, the always-allow-one rule, the suggestion rules, and a store round-trip against a real SQLite database.
- **Upgrade path:** the migration was applied to a populated pre-change database (27 books). All books intact, index created, and `Settings.json` byte-for-byte unchanged afterwards, confirming the feature is invisible until opted into.
- All CI jobs pass, including Windows Classic (WinForms) and the Docker image build.

Not exercised here, and worth a reviewer's eye: the **WinForms layout**. It compiles (locally with `-p:EnableWindowsTargeting=true`, and in CI), but no Windows desktop was available to look at it. The new group is placed at the top of the Download/Decrypt tab, which pushed the existing groups down past the tab's height; that tab already has `AutoScroll`, and the three controls that previously stretched or anchored to the bottom are now top-anchored so nothing can overlap the new group when the dialog is resized.

The **PostgreSQL migration** is generated by the same tooling as the SQLite one and reviewed, but not applied to a live PostgreSQL server: there is no Docker daemon in this environment to run one.


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-442918c2-8e16-484c-be4a-b5fcdab0245f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-442918c2-8e16-484c-be4a-b5fcdab0245f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

