### PR TITLE
fix(queue): explain a multi-book download that queues nothing (#1940)

### DIFF
--- a/Source/LibationAvalonia/ViewModels/MainVM.BackupCounts.cs
+++ b/Source/LibationAvalonia/ViewModels/MainVM.BackupCounts.cs
@@ -90,7 +90,7 @@ partial class MainVM
 			&& stats.PendingBooks + stats.pdfsNotDownloaded > 0)
 		{
 			// RunWorkerCompleted has no SynchronizationContext; queue items require the UI thread.
-			await Dispatcher.UIThread.InvokeAsync(async () => await BackupAllBooksAsync(stats.LibraryBooks));
+			await Dispatcher.UIThread.InvokeAsync(async () => await BackupAllBooksAsync(stats.LibraryBooks, notifyIfNothingQueued: false));
 		}
 	}
 }

--- a/Source/LibationAvalonia/ViewModels/MainVM.Liberate.cs
+++ b/Source/LibationAvalonia/ViewModels/MainVM.Liberate.cs
@@ -21,13 +21,14 @@ partial class MainVM
 		await BackupAllBooksAsync(books);
 	}
 
-	private async Task BackupAllBooksAsync(IEnumerable<LibraryBook> books)
+	/// <param name="notifyIfNothingQueued">False for the automatic post-scan download, which runs unattended.</param>
+	private async Task BackupAllBooksAsync(IEnumerable<LibraryBook> books, bool notifyIfNothingQueued = true)
 	{
 		try
 		{
 			var unliberated = books.UnLiberated().ToArray();
 
-			if (await ProcessQueue.QueueDownloadDecryptAsync(unliberated))
+			if (await ProcessQueue.QueueDownloadDecryptAsync(unliberated, notifyIfNothingQueued: notifyIfNothingQueued))
 				setQueueCollapseState(false);
 		}
 		catch (Exception ex)

--- a/Source/LibationAvalonia/ViewModels/MainVM.ProcessQueue.cs
+++ b/Source/LibationAvalonia/ViewModels/MainVM.ProcessQueue.cs
@@ -59,7 +59,10 @@ partial class MainVM
 		{
 			Serilog.Log.Logger.Information("Begin backing up all {series} episodes", series.LibraryBook);
 
-			if (await ProcessQueue.QueueDownloadDecryptAsync(series.Children.Select(c => c.LibraryBook).UnLiberated().ToArray()))
+			// Every episode, not just the ones that can be queued: the menu item is enabled from the grid's
+			// display status, so it can be clicked for episodes the queue will reject, and only the queue
+			// knows why it rejected them.
+			if (await ProcessQueue.QueueDownloadDecryptAsync(series.Children.Select(c => c.LibraryBook).ToArray()))
 				setQueueCollapseState(false);
 		}
 		catch (Exception ex)

--- a/Source/LibationUiBase/ProcessQueue/BackupRequest.cs
+++ b/Source/LibationUiBase/ProcessQueue/BackupRequest.cs
@@ -6,15 +6,6 @@ using System.Text;
 
 namespace LibationUiBase.ProcessQueue;
 
-/// <summary>Why a title in a backup request cannot be queued for download.</summary>
-internal enum BackupSkipReason
-{
-	AlreadyDownloaded,
-	PreviousError,
-	AbsentFromLastScan,
-	NoAudioOfItsOwn
-}
-
 /// <summary>
 /// Splits a multi-book backup request into the titles that can be queued and the reason each of the rest
 /// was left out, so a request Libation understands and declines can be explained instead of ignored.
@@ -23,39 +14,42 @@ internal sealed class BackupRequest
 {
 	public const string NothingQueuedCaption = "Download not queued";
 
-	/// <summary>Reasons are reported in this order, which runs from the most to the least common.</summary>
-	private static readonly BackupSkipReason[] ReasonOrder =
-	[
-		BackupSkipReason.AlreadyDownloaded,
-		BackupSkipReason.PreviousError,
-		BackupSkipReason.AbsentFromLastScan,
-		BackupSkipReason.NoAudioOfItsOwn
-	];
+	/// <summary>Why a title cannot be queued. Reported in declaration order.</summary>
+	internal sealed record SkipReason(string Label, string Advice = "")
+	{
+		public static readonly SkipReason AlreadyDownloaded = new("Already downloaded");
+		public static readonly SkipReason PreviousError = new("Previously failed to download", "set the download status to 'Not Downloaded' to try again");
+		public static readonly SkipReason AbsentFromLastScan = new("Absent from your last library scan", "run Scan, or `libationcli scan`, then try again");
+
+		public static readonly SkipReason[] All = [AlreadyDownloaded, PreviousError, AbsentFromLastScan];
+	}
 
 	/// <summary>The titles the caller asked to back up, including the ones that cannot be queued.</summary>
 	public int RequestedCount { get; }
 	public LibraryBook[] Queueable { get; }
-	public IReadOnlyDictionary<BackupSkipReason, int> SkippedByReason { get; }
 	public int SkippedCount => RequestedCount - Queueable.Length;
+	public int Skipped(SkipReason reason) => skipped.GetValueOrDefault(reason);
 
-	private BackupRequest(int requestedCount, LibraryBook[] queueable, IReadOnlyDictionary<BackupSkipReason, int> skippedByReason)
+	private readonly Dictionary<SkipReason, int> skipped;
+
+	private BackupRequest(int requestedCount, LibraryBook[] queueable, Dictionary<SkipReason, int> skipped)
 	{
 		RequestedCount = requestedCount;
 		Queueable = queueable;
-		SkippedByReason = skippedByReason;
+		this.skipped = skipped;
 	}
 
 	public static BackupRequest Create(IEnumerable<LibraryBook> libraryBooks)
 	{
 		var requestedCount = 0;
 		var queueable = new List<LibraryBook>();
-		var skipped = new Dictionary<BackupSkipReason, int>();
+		var skipped = new Dictionary<SkipReason, int>();
 
 		foreach (var libraryBook in libraryBooks)
 		{
 			requestedCount++;
 
-			if (GetSkipReason(libraryBook) is not BackupSkipReason reason)
+			if (GetSkipReason(libraryBook) is not SkipReason reason)
 				queueable.Add(libraryBook);
 			else
 				skipped[reason] = skipped.GetValueOrDefault(reason) + 1;
@@ -64,22 +58,18 @@ internal sealed class BackupRequest
 		return new BackupRequest(requestedCount, [.. queueable], skipped);
 	}
 
-	/// <summary>
-	/// Null when the title can be queued. The order of the checks mirrors LibraryBook.Downloadable: a title
-	/// absent from the last scan is reported as such no matter what its download status says.
-	/// </summary>
-	private static BackupSkipReason? GetSkipReason(LibraryBook libraryBook)
+	/// <summary>Null when the title can be queued. Absent outranks status: Downloadable is false either way.</summary>
+	private static SkipReason? GetSkipReason(LibraryBook libraryBook)
 		=> libraryBook.NeedsBookDownload || libraryBook.NeedsPdfDownload ? null
-		: libraryBook.AbsentFromLastScan ? BackupSkipReason.AbsentFromLastScan
-		: libraryBook.Book.ContentType is not (ContentType.Product or ContentType.Episode) ? BackupSkipReason.NoAudioOfItsOwn
-		: libraryBook.Book.UserDefinedItem.BookStatus is LiberatedStatus.Error ? BackupSkipReason.PreviousError
-		: BackupSkipReason.AlreadyDownloaded;
+		: libraryBook.AbsentFromLastScan ? SkipReason.AbsentFromLastScan
+		: libraryBook.Book.UserDefinedItem.BookStatus is LiberatedStatus.Error ? SkipReason.PreviousError
+		: SkipReason.AlreadyDownloaded;
 
-	/// <summary>A compact breakdown for the log, eg: "already downloaded: 3, absent from last scan: 1".</summary>
+	/// <summary>A compact breakdown for the log, eg: "already downloaded: 3, absent from your last library scan: 1".</summary>
 	public string BuildSkippedLogSummary()
 		=> SkippedCount == 0
 		? "none"
-		: string.Join(", ", OrderedReasons().Select(r => $"{LogName(r.Reason)}: {r.Count}"));
+		: string.Join(", ", Breakdown().Select(b => $"{b.Reason.Label.ToLowerInvariant()}: {b.Count}"));
 
 	/// <summary>The dialog body shown when a backup request produced nothing to queue.</summary>
 	public string BuildNothingQueuedBody()
@@ -95,42 +85,13 @@ internal sealed class BackupRequest
 		sb.AppendLine($"None of the {"title".PluralizeWithCount(RequestedCount)} could be queued for download.");
 		sb.AppendLine();
 
-		foreach (var (reason, count) in OrderedReasons())
-			sb.AppendLine($"{Label(reason)}: {count}{Hint(reason)}");
+		//the count comes before the advice so the numbers stay scannable
+		foreach (var (reason, count) in Breakdown())
+			sb.AppendLine($"{reason.Label}: {count}{(reason.Advice is "" ? "" : $"  ({reason.Advice})")}");
 
 		return sb.ToString().TrimEnd();
 	}
 
-	private IEnumerable<(BackupSkipReason Reason, int Count)> OrderedReasons()
-		=> ReasonOrder
-		.Where(SkippedByReason.ContainsKey)
-		.Select(reason => (reason, SkippedByReason[reason]));
-
-	private static string LogName(BackupSkipReason reason)
-		=> reason switch
-		{
-			BackupSkipReason.AlreadyDownloaded => "already downloaded",
-			BackupSkipReason.PreviousError => "previous error",
-			BackupSkipReason.AbsentFromLastScan => "absent from last scan",
-			_ => "no audio of its own"
-		};
-
-	private static string Label(BackupSkipReason reason)
-		=> reason switch
-		{
-			BackupSkipReason.AlreadyDownloaded => "Already downloaded",
-			BackupSkipReason.PreviousError => "Previously failed to download",
-			BackupSkipReason.AbsentFromLastScan => "Absent from your last library scan",
-			_ => "Series or podcast parent"
-		};
-
-	/// <summary>What to do about it, if there is anything to do. Follows the count so the numbers stay scannable.</summary>
-	private static string Hint(BackupSkipReason reason)
-		=> reason switch
-		{
-			BackupSkipReason.PreviousError => "  (set the download status to 'Not Downloaded' to try again)",
-			BackupSkipReason.AbsentFromLastScan => "  (run Scan, or `libationcli scan`, then try again)",
-			BackupSkipReason.NoAudioOfItsOwn => "  (no audio of its own)",
-			_ => ""
-		};
+	private IEnumerable<(SkipReason Reason, int Count)> Breakdown()
+		=> SkipReason.All.Where(skipped.ContainsKey).Select(reason => (reason, skipped[reason]));
 }

--- a/Source/LibationUiBase/ProcessQueue/BackupRequest.cs
+++ b/Source/LibationUiBase/ProcessQueue/BackupRequest.cs
@@ -1,0 +1,126 @@
+using DataLayer;
+using Dinah.Core;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace LibationUiBase.ProcessQueue;
+
+/// <summary>Why a title in a backup request cannot be queued for download.</summary>
+internal enum BackupSkipReason
+{
+	AlreadyDownloaded,
+	PreviousError,
+	AbsentFromLastScan,
+	NoAudioOfItsOwn
+}
+
+/// <summary>
+/// Splits a multi-book backup request into the titles that can be queued and the reason each of the rest
+/// was left out, so a request Libation understands and declines can be explained instead of ignored.
+/// </summary>
+internal sealed class BackupRequest
+{
+	public const string NothingQueuedCaption = "Download not queued";
+
+	/// <summary>Reasons are reported in this order, which runs from the most to the least common.</summary>
+	private static readonly BackupSkipReason[] ReasonOrder =
+	[
+		BackupSkipReason.AlreadyDownloaded,
+		BackupSkipReason.PreviousError,
+		BackupSkipReason.AbsentFromLastScan,
+		BackupSkipReason.NoAudioOfItsOwn
+	];
+
+	/// <summary>The titles the caller asked to back up, including the ones that cannot be queued.</summary>
+	public int RequestedCount { get; }
+	public LibraryBook[] Queueable { get; }
+	public IReadOnlyDictionary<BackupSkipReason, int> SkippedByReason { get; }
+	public int SkippedCount => RequestedCount - Queueable.Length;
+
+	private BackupRequest(int requestedCount, LibraryBook[] queueable, IReadOnlyDictionary<BackupSkipReason, int> skippedByReason)
+	{
+		RequestedCount = requestedCount;
+		Queueable = queueable;
+		SkippedByReason = skippedByReason;
+	}
+
+	public static BackupRequest Create(IEnumerable<LibraryBook> libraryBooks)
+	{
+		var requestedCount = 0;
+		var queueable = new List<LibraryBook>();
+		var skipped = new Dictionary<BackupSkipReason, int>();
+
+		foreach (var libraryBook in libraryBooks)
+		{
+			requestedCount++;
+
+			if (GetSkipReason(libraryBook) is not BackupSkipReason reason)
+				queueable.Add(libraryBook);
+			else
+				skipped[reason] = skipped.GetValueOrDefault(reason) + 1;
+		}
+
+		return new BackupRequest(requestedCount, [.. queueable], skipped);
+	}
+
+	/// <summary>
+	/// Null when the title can be queued. The order of the checks mirrors LibraryBook.Downloadable: a title
+	/// absent from the last scan is reported as such no matter what its download status says.
+	/// </summary>
+	private static BackupSkipReason? GetSkipReason(LibraryBook libraryBook)
+		=> libraryBook.NeedsBookDownload || libraryBook.NeedsPdfDownload ? null
+		: libraryBook.AbsentFromLastScan ? BackupSkipReason.AbsentFromLastScan
+		: libraryBook.Book.ContentType is not (ContentType.Product or ContentType.Episode) ? BackupSkipReason.NoAudioOfItsOwn
+		: libraryBook.Book.UserDefinedItem.BookStatus is LiberatedStatus.Error ? BackupSkipReason.PreviousError
+		: BackupSkipReason.AlreadyDownloaded;
+
+	/// <summary>A compact breakdown for the log, eg: "already downloaded: 3, absent from last scan: 1".</summary>
+	public string BuildSkippedLogSummary()
+		=> SkippedCount == 0
+		? "none"
+		: string.Join(", ", OrderedReasons().Select(r => $"{LogName(r.Reason)}: {r.Count}"));
+
+	/// <summary>The dialog body shown when a backup request produced nothing to queue.</summary>
+	public string BuildNothingQueuedBody()
+	{
+		if (RequestedCount == 0)
+			return """
+				Libation found no titles that need downloading.
+
+				Titles that are already downloaded, and titles that were absent from your last library scan, are not queued.
+				""";
+
+		var sb = new StringBuilder();
+		sb.AppendLine($"None of the {"title".PluralizeWithCount(RequestedCount)} could be queued for download.");
+		sb.AppendLine();
+
+		foreach (var (reason, count) in OrderedReasons())
+			sb.AppendLine($"{Describe(reason)}: {count}");
+
+		return sb.ToString().TrimEnd();
+	}
+
+	private IEnumerable<(BackupSkipReason Reason, int Count)> OrderedReasons()
+		=> ReasonOrder
+		.Where(SkippedByReason.ContainsKey)
+		.Select(reason => (reason, SkippedByReason[reason]));
+
+	private static string LogName(BackupSkipReason reason)
+		=> reason switch
+		{
+			BackupSkipReason.AlreadyDownloaded => "already downloaded",
+			BackupSkipReason.PreviousError => "previous error",
+			BackupSkipReason.AbsentFromLastScan => "absent from last scan",
+			_ => "no audio of its own"
+		};
+
+	private static string Describe(BackupSkipReason reason)
+		=> reason switch
+		{
+			BackupSkipReason.AlreadyDownloaded => "Already downloaded",
+			BackupSkipReason.PreviousError => "Previously failed to download (set the download status to 'Not Downloaded' to try again)",
+			BackupSkipReason.AbsentFromLastScan => "Absent from your last library scan (run Scan, or `libationcli scan`, then try again)",
+			_ => "Series or podcast parent, which has no audio of its own"
+		};
+}

--- a/Source/LibationUiBase/ProcessQueue/BackupRequest.cs
+++ b/Source/LibationUiBase/ProcessQueue/BackupRequest.cs
@@ -96,7 +96,7 @@ internal sealed class BackupRequest
 		sb.AppendLine();
 
 		foreach (var (reason, count) in OrderedReasons())
-			sb.AppendLine($"{Describe(reason)}: {count}");
+			sb.AppendLine($"{Label(reason)}: {count}{Hint(reason)}");
 
 		return sb.ToString().TrimEnd();
 	}
@@ -115,12 +115,22 @@ internal sealed class BackupRequest
 			_ => "no audio of its own"
 		};
 
-	private static string Describe(BackupSkipReason reason)
+	private static string Label(BackupSkipReason reason)
 		=> reason switch
 		{
 			BackupSkipReason.AlreadyDownloaded => "Already downloaded",
-			BackupSkipReason.PreviousError => "Previously failed to download (set the download status to 'Not Downloaded' to try again)",
-			BackupSkipReason.AbsentFromLastScan => "Absent from your last library scan (run Scan, or `libationcli scan`, then try again)",
-			_ => "Series or podcast parent, which has no audio of its own"
+			BackupSkipReason.PreviousError => "Previously failed to download",
+			BackupSkipReason.AbsentFromLastScan => "Absent from your last library scan",
+			_ => "Series or podcast parent"
+		};
+
+	/// <summary>What to do about it, if there is anything to do. Follows the count so the numbers stay scannable.</summary>
+	private static string Hint(BackupSkipReason reason)
+		=> reason switch
+		{
+			BackupSkipReason.PreviousError => "  (set the download status to 'Not Downloaded' to try again)",
+			BackupSkipReason.AbsentFromLastScan => "  (run Scan, or `libationcli scan`, then try again)",
+			BackupSkipReason.NoAudioOfItsOwn => "  (no audio of its own)",
+			_ => ""
 		};
 }

--- a/Source/LibationUiBase/ProcessQueue/ProcessQueueViewModel.cs
+++ b/Source/LibationUiBase/ProcessQueue/ProcessQueueViewModel.cs
@@ -186,7 +186,11 @@ public class ProcessQueueViewModel : ReactiveObject
 		AddToQueue(procs);
 	}
 
-	public async Task<bool> QueueDownloadDecryptAsync(IList<LibraryBook> libraryBooks, Configuration? config = null)
+	/// <param name="notifyIfNothingQueued">
+	/// Whether to tell the user when a multi-book request queued nothing. Always logged either way. Automated
+	/// callers (auto-download after a scan) pass false so a routine no-op cannot put a dialog on screen.
+	/// </param>
+	public async Task<bool> QueueDownloadDecryptAsync(IList<LibraryBook> libraryBooks, Configuration? config = null, bool notifyIfNothingQueued = true)
 	{
 		config ??= Configuration.Instance;
 		if (!await IsBooksDirectoryValidAsync(config))
@@ -237,20 +241,42 @@ public class ProcessQueueViewModel : ReactiveObject
 		}
 		else
 		{
-			var toLiberate = libraryBooks.UnLiberated().ToArray();
+			var request = BackupRequest.Create(libraryBooks);
 
-			if (toLiberate.Length > 0)
+			if (request.Queueable.Length == 0)
 			{
-				// May no-op when free space is unknown (common on UNC); see DiskSpaceBackupPreflight.
-				if (!await DiskSpaceBackupPreflight.ConfirmBulkBackupAsync(toLiberate.Length, config, backupQueueAlreadyRunning: Running))
-					return false;
+				// This branch used to return with no log entry and no message, so a request Libation had
+				// understood and declined was indistinguishable from a dead button.
+				Serilog.Log.Logger.Information(
+					"Download not queued: none of the {requested} requested titles need downloading. Skipped: {skipped}",
+					request.RequestedCount,
+					request.BuildSkippedLogSummary());
 
-				Serilog.Log.Logger.Information("Begin backup of {count} library books", toLiberate.Length);
-				AddDownloadDecrypt(toLiberate, config);
-				return true;
+				if (notifyIfNothingQueued)
+					await MessageBoxBase.Show(
+						request.BuildNothingQueuedBody(),
+						BackupRequest.NothingQueuedCaption,
+						MessageBoxButtons.OK,
+						MessageBoxIcon.Information);
+
+				return false;
 			}
+
+			if (request.SkippedCount > 0)
+				Serilog.Log.Logger.Information(
+					"Skipping {skippedCount} of {requested} requested titles. Skipped: {skipped}",
+					request.SkippedCount,
+					request.RequestedCount,
+					request.BuildSkippedLogSummary());
+
+			// May no-op when free space is unknown (common on UNC); see DiskSpaceBackupPreflight.
+			if (!await DiskSpaceBackupPreflight.ConfirmBulkBackupAsync(request.Queueable.Length, config, backupQueueAlreadyRunning: Running))
+				return false;
+
+			Serilog.Log.Logger.Information("Begin backup of {count} library books", request.Queueable.Length);
+			AddDownloadDecrypt(request.Queueable, config);
+			return true;
 		}
-		return false;
 	}
 
 	private async Task<bool> IsBooksDirectoryValidAsync(Configuration config)
@@ -334,7 +360,9 @@ public class ProcessQueueViewModel : ReactiveObject
 	private void addDownloadDecryptCore(IList<LibraryBook> entries, Configuration config)
 	{
 		var procs = entries.Where(e => !IsBookInQueue(e)).Select(Create).ToArray();
-		Serilog.Log.Logger.Information("Queueing {count} books ofr download/decrypt", procs.Length);
+		Serilog.Log.Logger.Information("Queueing {count} books for download/decrypt", procs.Length);
+		if (procs.Length < entries.Count)
+			Serilog.Log.Logger.Information("{count} of the requested books are already in the queue and were not added again", entries.Count - procs.Length);
 		AddToQueue(procs);
 
 		ProcessBookViewModel Create(LibraryBook entry)

--- a/Source/LibationWinForms/Form1.Liberate.cs
+++ b/Source/LibationWinForms/Form1.Liberate.cs
@@ -19,12 +19,13 @@ public partial class Form1
 		await BackupAllBooksAsync(library);
 	}
 
-	private async Task BackupAllBooksAsync(IEnumerable<LibraryBook> books)
+	/// <param name="notifyIfNothingQueued">False for the automatic post-scan download, which runs unattended.</param>
+	private async Task BackupAllBooksAsync(IEnumerable<LibraryBook> books, bool notifyIfNothingQueued = true)
 	{
 		try
 		{
 			var unliberated = books.UnLiberated().ToArray();
-			if (await processBookQueue1.ViewModel.QueueDownloadDecryptAsync(unliberated))
+			if (await processBookQueue1.ViewModel.QueueDownloadDecryptAsync(unliberated, notifyIfNothingQueued: notifyIfNothingQueued))
 				SetQueueCollapseState(false);
 		}
 		catch (Exception ex)

--- a/Source/LibationWinForms/Form1.ProcessQueue.cs
+++ b/Source/LibationWinForms/Form1.ProcessQueue.cs
@@ -52,7 +52,10 @@ public partial class Form1
 		{
 			Serilog.Log.Logger.Information("Begin backing up all {series} episodes", series.LibraryBook);
 
-			if (await processBookQueue1.ViewModel.QueueDownloadDecryptAsync(series.Children.Select(c => c.LibraryBook).UnLiberated().ToArray()))
+			// Every episode, not just the ones that can be queued: the menu item is enabled from the grid's
+			// display status, so it can be clicked for episodes the queue will reject, and only the queue
+			// knows why it rejected them.
+			if (await processBookQueue1.ViewModel.QueueDownloadDecryptAsync(series.Children.Select(c => c.LibraryBook).ToArray()))
 				SetQueueCollapseState(false);
 		}
 		catch (Exception ex)

--- a/Source/LibationWinForms/Form1._NonUI.cs
+++ b/Source/LibationWinForms/Form1._NonUI.cs
@@ -44,7 +44,7 @@ public partial class Form1
 			return;
 
 		// RunWorkerCompleted has no SynchronizationContext; queue items require the UI thread.
-		this.UIThreadAsync(() => _ = BackupAllBooksAsync(libraryStats.LibraryBooks));
+		this.UIThreadAsync(() => _ = BackupAllBooksAsync(libraryStats.LibraryBooks, notifyIfNothingQueued: false));
 	}
 
 	private void AudibleApiStorage_LoadError(object? sender, AccountSettingsLoadErrorEventArgs e)

--- a/Source/_Tests/LibationUiBase.Tests/BackupRequestTests.cs
+++ b/Source/_Tests/LibationUiBase.Tests/BackupRequestTests.cs
@@ -1,0 +1,120 @@
+using DataLayer;
+using LibationUiBase.ProcessQueue;
+
+namespace LibationUiBase.Tests;
+
+[TestClass]
+public class BackupRequestTests
+{
+	private static LibraryBook LibraryBook(
+		string asin,
+		LiberatedStatus bookStatus = LiberatedStatus.NotLiberated,
+		ContentType contentType = ContentType.Product,
+		bool absentFromLastScan = false)
+	{
+		var contributor = Contributor.GetEmpty();
+		var book = new Book(
+			new AudibleProductId(asin),
+			asin,
+			null,
+			null,
+			1,
+			contentType,
+			[contributor],
+			[contributor],
+			"us");
+
+		book.UserDefinedItem.BookStatus = bookStatus;
+
+		return new LibraryBook(book, new DateTime(2026, 8, 10), "account") { AbsentFromLastScan = absentFromLastScan };
+	}
+
+	[TestMethod]
+	public void books_that_need_downloading_are_queueable()
+	{
+		var request = BackupRequest.Create([
+			LibraryBook("NEW"),
+			LibraryBook("DONE", LiberatedStatus.Liberated)]);
+
+		CollectionAssert.AreEqual(new[] { "NEW" }, request.Queueable.Select(lb => lb.Book.AudibleProductId).ToList());
+		Assert.AreEqual(2, request.RequestedCount);
+		Assert.AreEqual(1, request.SkippedCount);
+	}
+
+	[TestMethod]
+	public void liberated_books_are_skipped_as_already_downloaded()
+	{
+		var request = BackupRequest.Create([
+			LibraryBook("DONE1", LiberatedStatus.Liberated),
+			LibraryBook("DONE2", LiberatedStatus.Liberated)]);
+
+		Assert.AreEqual(0, request.Queueable.Length);
+		Assert.AreEqual(2, request.SkippedByReason[BackupSkipReason.AlreadyDownloaded]);
+	}
+
+	[TestMethod]
+	public void errored_books_are_reported_apart_from_downloaded_ones()
+	{
+		var request = BackupRequest.Create([LibraryBook("BAD", LiberatedStatus.Error)]);
+
+		Assert.AreEqual(1, request.SkippedByReason[BackupSkipReason.PreviousError]);
+	}
+
+	[TestMethod]
+	public void absent_from_last_scan_outranks_the_download_status()
+	{
+		//Downloadable is false while a book is absent, so its NotLiberated status cannot be acted on
+		var request = BackupRequest.Create([LibraryBook("GONE", absentFromLastScan: true)]);
+
+		Assert.AreEqual(0, request.Queueable.Length);
+		Assert.AreEqual(1, request.SkippedByReason[BackupSkipReason.AbsentFromLastScan]);
+	}
+
+	[TestMethod]
+	public void series_parents_have_no_audio_of_their_own()
+	{
+		var request = BackupRequest.Create([LibraryBook("SHOW", contentType: ContentType.Parent)]);
+
+		Assert.AreEqual(1, request.SkippedByReason[BackupSkipReason.NoAudioOfItsOwn]);
+	}
+
+	[TestMethod]
+	public void empty_request_says_nothing_needs_downloading()
+	{
+		var request = BackupRequest.Create([]);
+
+		Assert.AreEqual(0, request.RequestedCount);
+		Assert.AreEqual(0, request.SkippedCount);
+		StringAssert.Contains(request.BuildNothingQueuedBody(), "no titles that need downloading");
+		Assert.AreEqual("none", request.BuildSkippedLogSummary());
+	}
+
+	[TestMethod]
+	public void nothing_queued_body_counts_every_reason()
+	{
+		var request = BackupRequest.Create([
+			LibraryBook("DONE1", LiberatedStatus.Liberated),
+			LibraryBook("DONE2", LiberatedStatus.Liberated),
+			LibraryBook("DONE3", LiberatedStatus.Liberated),
+			LibraryBook("BAD", LiberatedStatus.Error),
+			LibraryBook("GONE", absentFromLastScan: true)]);
+
+		var body = request.BuildNothingQueuedBody();
+
+		StringAssert.Contains(body, "None of the 5 titles could be queued for download.");
+		StringAssert.Contains(body, "Already downloaded: 3");
+		StringAssert.Contains(body, "Previously failed to download");
+		StringAssert.Contains(body, "Absent from your last library scan");
+	}
+
+	[TestMethod]
+	public void log_summary_is_a_compact_breakdown()
+	{
+		var request = BackupRequest.Create([
+			LibraryBook("DONE1", LiberatedStatus.Liberated),
+			LibraryBook("DONE2", LiberatedStatus.Liberated),
+			LibraryBook("GONE", absentFromLastScan: true)]);
+
+		Assert.AreEqual("already downloaded: 2, absent from last scan: 1", request.BuildSkippedLogSummary());
+	}
+}

--- a/Source/_Tests/LibationUiBase.Tests/BackupRequestTests.cs
+++ b/Source/_Tests/LibationUiBase.Tests/BackupRequestTests.cs
@@ -103,8 +103,10 @@ public class BackupRequestTests
 
 		StringAssert.Contains(body, "None of the 5 titles could be queued for download.");
 		StringAssert.Contains(body, "Already downloaded: 3");
-		StringAssert.Contains(body, "Previously failed to download");
-		StringAssert.Contains(body, "Absent from your last library scan");
+		StringAssert.Contains(body, "Previously failed to download: 1");
+		StringAssert.Contains(body, "Absent from your last library scan: 1");
+		//the guidance follows the count so the numbers stay scannable
+		StringAssert.Contains(body, "1  (run Scan, or `libationcli scan`, then try again)");
 	}
 
 	[TestMethod]

--- a/Source/_Tests/LibationUiBase.Tests/BackupRequestTests.cs
+++ b/Source/_Tests/LibationUiBase.Tests/BackupRequestTests.cs
@@ -9,7 +9,6 @@ public class BackupRequestTests
 	private static LibraryBook LibraryBook(
 		string asin,
 		LiberatedStatus bookStatus = LiberatedStatus.NotLiberated,
-		ContentType contentType = ContentType.Product,
 		bool absentFromLastScan = false)
 	{
 		var contributor = Contributor.GetEmpty();
@@ -19,7 +18,7 @@ public class BackupRequestTests
 			null,
 			null,
 			1,
-			contentType,
+			ContentType.Product,
 			[contributor],
 			[contributor],
 			"us");
@@ -49,7 +48,7 @@ public class BackupRequestTests
 			LibraryBook("DONE2", LiberatedStatus.Liberated)]);
 
 		Assert.AreEqual(0, request.Queueable.Length);
-		Assert.AreEqual(2, request.SkippedByReason[BackupSkipReason.AlreadyDownloaded]);
+		Assert.AreEqual(2, request.Skipped(BackupRequest.SkipReason.AlreadyDownloaded));
 	}
 
 	[TestMethod]
@@ -57,7 +56,7 @@ public class BackupRequestTests
 	{
 		var request = BackupRequest.Create([LibraryBook("BAD", LiberatedStatus.Error)]);
 
-		Assert.AreEqual(1, request.SkippedByReason[BackupSkipReason.PreviousError]);
+		Assert.AreEqual(1, request.Skipped(BackupRequest.SkipReason.PreviousError));
 	}
 
 	[TestMethod]
@@ -67,15 +66,7 @@ public class BackupRequestTests
 		var request = BackupRequest.Create([LibraryBook("GONE", absentFromLastScan: true)]);
 
 		Assert.AreEqual(0, request.Queueable.Length);
-		Assert.AreEqual(1, request.SkippedByReason[BackupSkipReason.AbsentFromLastScan]);
-	}
-
-	[TestMethod]
-	public void series_parents_have_no_audio_of_their_own()
-	{
-		var request = BackupRequest.Create([LibraryBook("SHOW", contentType: ContentType.Parent)]);
-
-		Assert.AreEqual(1, request.SkippedByReason[BackupSkipReason.NoAudioOfItsOwn]);
+		Assert.AreEqual(1, request.Skipped(BackupRequest.SkipReason.AbsentFromLastScan));
 	}
 
 	[TestMethod]
@@ -117,6 +108,6 @@ public class BackupRequestTests
 			LibraryBook("DONE2", LiberatedStatus.Liberated),
 			LibraryBook("GONE", absentFromLastScan: true)]);
 
-		Assert.AreEqual("already downloaded: 2, absent from last scan: 1", request.BuildSkippedLogSummary());
+		Assert.AreEqual("already downloaded: 2, absent from your last library scan: 1", request.BuildSkippedLogSummary());
 	}
 }

--- a/Source/_Tests/LibationUiBase.Tests/QueueDownloadDecryptTests.cs
+++ b/Source/_Tests/LibationUiBase.Tests/QueueDownloadDecryptTests.cs
@@ -1,0 +1,93 @@
+using DataLayer;
+using LibationFileManager;
+using LibationUiBase.Forms;
+using LibationUiBase.ProcessQueue;
+
+namespace LibationUiBase.Tests;
+
+/// <summary>
+/// Covers what a multi-book backup request does when it cannot queue anything. These tests never queue a
+/// book: doing so starts the queue loop, which downloads for real.
+/// </summary>
+[TestClass]
+[DoNotParallelize]
+public class QueueDownloadDecryptTests
+{
+	private string tempDir = "";
+	private List<(string Message, string Caption)> Dialogs { get; } = [];
+
+	[TestInitialize]
+	public void Initialize()
+	{
+		//ProcessQueueViewModel raises property changes through the current SynchronizationContext
+		SynchronizationContext.SetSynchronizationContext(new SynchronizationContext());
+
+		tempDir = Path.Combine(Path.GetTempPath(), "LibationQueueDownloadDecryptTests", Path.GetRandomFileName());
+
+		var config = Configuration.CreateMockInstance();
+		config.Books = Path.Combine(tempDir, "Books");
+		config.InProgress = Path.Combine(tempDir, "InProgress");
+
+		MessageBoxBase.ShowAsyncImpl = (_, message, caption, _, _, _, _) =>
+		{
+			Dialogs.Add((message, caption));
+			return Task.FromResult(DialogResult.OK);
+		};
+	}
+
+	[TestCleanup]
+	public void Cleanup()
+	{
+		//null restores MessageBoxBase's own no-op implementation
+		MessageBoxBase.ShowAsyncImpl = null!;
+		Configuration.RestoreSingletonInstance();
+
+		if (Directory.Exists(tempDir))
+			Directory.Delete(tempDir, recursive: true);
+	}
+
+	private static LibraryBook Liberated(string asin)
+	{
+		var contributor = Contributor.GetEmpty();
+		var book = new Book(new AudibleProductId(asin), asin, null, null, 1, ContentType.Product, [contributor], [contributor], "us");
+		book.UserDefinedItem.BookStatus = LiberatedStatus.Liberated;
+		return new LibraryBook(book, new DateTime(2026, 8, 10), "account");
+	}
+
+	[TestMethod]
+	public async Task selecting_several_downloaded_books_says_why_nothing_was_queued()
+	{
+		var queue = new ProcessQueueViewModel();
+
+		var queued = await queue.QueueDownloadDecryptAsync([Liberated("DONE1"), Liberated("DONE2")]);
+
+		Assert.IsFalse(queued);
+		Assert.AreEqual(0, queue.Queue.Count);
+		Assert.AreEqual(1, Dialogs.Count);
+		Assert.AreEqual("Download not queued", Dialogs[0].Caption);
+		StringAssert.Contains(Dialogs[0].Message, "Already downloaded: 2");
+	}
+
+	[TestMethod]
+	public async Task a_request_the_caller_already_filtered_to_nothing_is_still_acknowledged()
+	{
+		var queue = new ProcessQueueViewModel();
+
+		var queued = await queue.QueueDownloadDecryptAsync([]);
+
+		Assert.IsFalse(queued);
+		Assert.AreEqual(1, Dialogs.Count);
+		StringAssert.Contains(Dialogs[0].Message, "no titles that need downloading");
+	}
+
+	[TestMethod]
+	public async Task automated_callers_are_not_interrupted_by_a_dialog()
+	{
+		var queue = new ProcessQueueViewModel();
+
+		var queued = await queue.QueueDownloadDecryptAsync([Liberated("DONE1"), Liberated("DONE2")], notifyIfNothingQueued: false);
+
+		Assert.IsFalse(queued);
+		Assert.AreEqual(0, Dialogs.Count);
+	}
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## The bug

`QueueDownloadDecryptAsync` splits on `libraryBooks.Count == 1`. The single-book branch is chatty: it logs a warning and shows a dialog when it cannot queue. The multi-book branch computed `libraryBooks.UnLiberated()` and, when that came back empty, fell through to `return false` with no log entry and no message. Callers then do nothing, because their only fallback (open the file in Explorer) is guarded on `Count == 1`. Reported as [#1940](https://github.com/rmcrackan/Libation/issues/1940).

Several callers pre-filter with `.UnLiberated()` before calling - "Begin Book and PDF Backups", "Liberate Visible Books", "Liberate All Episodes" - so a library with nothing to fetch reaches this branch with an **empty** list, and `Count == 0` is not `Count == 1`. WinForms' multi-select "Download split by chapters" also reaches it with a non-empty list whose titles are all absent from the last scan, since `Downloadable` rejects those regardless of status.

## The fix

`BackupRequest` classifies every title in a backup request as queueable or skipped for one of three reasons: already downloaded, previously failed, or absent from the last library scan. The multi-book branch then:

- always logs, including a compact breakdown (`already downloaded: 2, absent from your last library scan: 1`),
- shows a "Download not queued" dialog with that breakdown when nothing could be queued,
- logs the skipped titles when a mixed selection queues some and drops others, which previously vanished without a trace.

"Liberate All Episodes" now hands the queue every episode instead of pre-filtering them. Its menu item is enabled from the grid's display status, so it can be clicked for episodes the queue will reject, and pre-filtering threw away the reason before anything could report it. This is what makes the screenshot below say "Absent from your last library scan: 2" rather than a generic line.

`notifyIfNothingQueued` defaults to true and is passed `false` by the automatic post-scan download in both GUIs. That path fires on every scan when "auto download" is on, and its pending-book count is computed from the file system while `UnLiberated()` reads stored status, so the two can legitimately disagree and hand this method an empty list. It still logs; it just never puts a dialog on an unattended screen.

Also fixed the `"Queueing {count} books ofr download/decrypt"` typo, and added a line for books dropped because they were already in the queue.

152 lines of production code across 8 files, 95 of them the new `BackupRequest`.

### Note on the literal repro in the issue

Right-clicking several already-downloaded books and choosing "Download selected audiobooks" leaves that item **greyed out** in both GUIs, because `DownloadBookEnabled` uses the same predicate the queue does. That is unchanged here, and it is why the reported silence actually arrives through the neighbouring paths above. Enabling the item so it could explain itself instead of greying out is a UX call I left alone; happy to change it if you would prefer that.

## Testing

`BackupRequestTests` covers the classification and both message forms. `QueueDownloadDecryptTests` drives `QueueDownloadDecryptAsync` itself with a mocked `MessageBoxBase` and asserts the dialog for a multi-select of downloaded books, the acknowledgement for a caller-filtered empty request, and the silence for automated callers. Those tests deliberately never queue a book, since queueing starts the real download loop.

Full suite from `Source/`: 1231 tests, 0 failed, 23 pre-existing platform/opt-in skips.

Verified by hand in the Avalonia GUI against a seeded demo library.

"Begin Book and PDF Backups" with every title already downloaded - previously did nothing at all:

[begin_backups_now_explains_nothing_to_download.mp4](https://cursor.com/agents/bc-ddd35e89-7710-413a-b447-c8390f4b657d/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fbegin_backups_now_explains_nothing_to_download.mp4)

"Liberate All Episodes" on a series whose episodes are absent from the last scan - an enabled menu item that previously did nothing at all:

[liberate_all_episodes_explains_skipped_titles.mp4](https://cursor.com/agents/bc-ddd35e89-7710-413a-b447-c8390f4b657d/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fliberate_all_episodes_explains_skipped_titles.mp4)

[Download not queued dialog listing the skip reason and count](https://cursor.com/agents/bc-ddd35e89-7710-413a-b447-c8390f4b657d/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdialog_explains_skipped_titles.webp)

Both interactions now leave a trace in `Log202608.log`, which is what the issue asked for at minimum:

```
Download not queued: none of the 0 requested titles need downloading. Skipped: none
Download not queued: none of the 2 requested titles need downloading. Skipped: absent from your last library scan: 2
```


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ddd35e89-7710-413a-b447-c8390f4b657d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ddd35e89-7710-413a-b447-c8390f4b657d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

