### PR TITLE
feat(cli): per-run download limit for liberate

### DIFF
--- a/Source/LibationCli/Options/LiberateOptions.cs
+++ b/Source/LibationCli/Options/LiberateOptions.cs
@@ -15,7 +15,8 @@ namespace LibationCli;
 
 [Verb("liberate", HelpText = "Liberate: book and pdf backups. Default: download and decrypt all un-liberated titles and download pdfs.\n"
 	+ "Optional: specify product id(s) via --id or positional ASIN(s) to liberate those book(s), including re-download if already liberated.\n"
-	+ "Optional: reads a license file from standard input.")]
+	+ "Optional: reads a license file from standard input.\n"
+	+ "Optional: stop this run early with --limit-books, --limit-mb or --limit-gb.")]
 public class LiberateOptions : ProcessableOptionsBase
 {
 	[Option(shortName: 'p', longName: "pdf", Required = false, Default = false, HelpText = "Flag to only download pdfs")]
@@ -28,8 +29,35 @@ public class LiberateOptions : ProcessableOptionsBase
 	[Option(shortName: 'l', longName: "license", Required = false, Default = null, HelpText = "A license file from the get-license command. Either a file path or dash ('-') to read from standard input.")]
 	public string? LicenseInput { get; set; }
 
+	#region per-run limit
+	// Distinct SetName values make these three mutually exclusive. See ExportOptions for the same pattern.
+
+	[Option(longName: "limit-books", Required = false, Default = null, SetName = "limit-books",
+		HelpText = "Stop this run after downloading this many books. A daily download limit, if set, still applies.")]
+	public int? LimitBooks { get; set; }
+
+	[Option(longName: "limit-mb", Required = false, Default = null, SetName = "limit-mb",
+		HelpText = "Stop this run after downloading about this many MB. Approximate: a title's size is unknown until it is downloaded.")]
+	public int? LimitMB { get; set; }
+
+	[Option(longName: "limit-gb", Required = false, Default = null, SetName = "limit-gb",
+		HelpText = "Stop this run after downloading about this many GB. Approximate: a title's size is unknown until it is downloaded.")]
+	public int? LimitGB { get; set; }
+
+	private RunDownloadLimit? runLimit;
+	protected override RunDownloadLimit? RunLimit => runLimit;
+
+	#endregion
+
 	protected override async Task ProcessAsync()
 	{
+		if (!RunDownloadLimit.TryCreate(LimitBooks, LimitMB, LimitGB, PdfOnly, out runLimit, out var limitError))
+		{
+			PrintVerbUsage("ERROR", "=====", limitError);
+			Environment.ExitCode = (int)ExitCode.RunTimeError;
+			return;
+		}
+
 		if (AudibleFileStorage.BooksDirectory is null)
 		{
 			Console.Error.WriteLine("Error: Books directory is not set. Please configure the 'Books' setting in Settings.json.");

--- a/Source/LibationCli/Options/_ProcessableOptionsBase.cs
+++ b/Source/LibationCli/Options/_ProcessableOptionsBase.cs
@@ -100,7 +100,7 @@ public abstract class ProcessableOptionsBase : OptionsBase
 			{
 				if (DbContexts.GetLibraryBook_Flat_NoTracking(asin, caseSensative: false) is LibraryBook lb)
 				{
-					if (!await TryProcessAsync(lb, true))
+					if (!await ProcessOrStopAsync(lb, true))
 						break;
 				}
 				else
@@ -117,7 +117,7 @@ public abstract class ProcessableOptionsBase : OptionsBase
 			var libraryBooks = DbContexts.GetLibrary_Flat_NoTracking();
 			foreach (var lb in Processable.GetValidLibraryBooks(libraryBooks))
 			{
-				if (!await TryProcessAsync(lb, false))
+				if (!await ProcessOrStopAsync(lb, false))
 					break;
 			}
 		}
@@ -137,7 +137,7 @@ public abstract class ProcessableOptionsBase : OptionsBase
 
 		// False ends the run. The limit is checked here rather than at the top of the run so that a run whose
 		// books happen to end exactly at the limit says nothing: nothing was cut short.
-		async Task<bool> TryProcessAsync(LibraryBook libraryBook, bool validate)
+		async Task<bool> ProcessOrStopAsync(LibraryBook libraryBook, bool validate)
 		{
 			if (runLimit is not null && runLimit.TryStop(out var stopMessage))
 			{

--- a/Source/LibationCli/Options/_ProcessableOptionsBase.cs
+++ b/Source/LibationCli/Options/_ProcessableOptionsBase.cs
@@ -81,9 +81,17 @@ public abstract class ProcessableOptionsBase : OptionsBase
 		return strProc;
 	}
 
+	/// <summary>How much this run may download before it stops, or null for a verb without a per-run limit.</summary>
+	protected virtual RunDownloadLimit? RunLimit => null;
+
 	protected async Task RunAsync(Processable Processable, Action<LibraryBook>? config = null, Action<string>? notFound = null)
 	{
 		var skippedForDailyLimit = 0;
+		var runLimitReached = false;
+
+		// Needs no guard against pdf or convert runs, unlike the daily limit below: the tracker counts only
+		// audiobook downloads this run recorded, and those verbs record none.
+		var runLimit = RunLimit is RunDownloadLimit limit ? new RunLimitTracker(limit, DateTimeOffset.Now) : null;
 
 		var productIds = GetProductIds().ToArray();
 		if (productIds.Length > 0)
@@ -92,19 +100,16 @@ public abstract class ProcessableOptionsBase : OptionsBase
 			{
 				if (DbContexts.GetLibraryBook_Flat_NoTracking(asin, caseSensative: false) is LibraryBook lb)
 				{
-					config?.Invoke(lb);
-					if (IsSkippedByDailyLimit(Processable, lb))
-						skippedForDailyLimit++;
-					else
-						await ProcessOneAsync(Processable, lb, true);
+					if (!await TryProcessAsync(lb, true))
+						break;
 				}
-			else
-			{
+				else
+				{
 					var msg = $"Book with ASIN '{asin}' not found in library. Skipping.";
 					Console.Error.WriteLine(msg);
 					Serilog.Log.Logger.Error(msg);
 					notFound?.Invoke(asin);
-			}
+				}
 			}
 		}
 		else
@@ -112,11 +117,8 @@ public abstract class ProcessableOptionsBase : OptionsBase
 			var libraryBooks = DbContexts.GetLibrary_Flat_NoTracking();
 			foreach (var lb in Processable.GetValidLibraryBooks(libraryBooks))
 			{
-				config?.Invoke(lb);
-				if (IsSkippedByDailyLimit(Processable, lb))
-					skippedForDailyLimit++;
-				else
-					await ProcessOneAsync(Processable, lb, false);
+				if (!await TryProcessAsync(lb, false))
+					break;
 			}
 		}
 
@@ -127,9 +129,36 @@ public abstract class ProcessableOptionsBase : OptionsBase
 			Serilog.Log.Logger.Information(summary);
 		}
 
-		var done = "Done. All books have been processed";
+		var done = runLimitReached
+			? "Done. Stopped early: this run's download limit was reached."
+			: "Done. All books have been processed";
 		Console.WriteLine(done);
 		Serilog.Log.Logger.Information(done);
+
+		// False ends the run. The limit is checked here rather than at the top of the run so that a run whose
+		// books happen to end exactly at the limit says nothing: nothing was cut short.
+		async Task<bool> TryProcessAsync(LibraryBook libraryBook, bool validate)
+		{
+			if (runLimit is not null && runLimit.TryStop(out var stopMessage))
+			{
+				runLimitReached = true;
+				Console.WriteLine(stopMessage);
+				Serilog.Log.Logger.Information(stopMessage);
+				return false;
+			}
+
+			config?.Invoke(libraryBook);
+
+			if (IsSkippedByDailyLimit(Processable, libraryBook))
+			{
+				skippedForDailyLimit++;
+				return true;
+			}
+
+			runLimit?.Attempting(libraryBook.Book.AudibleProductId);
+			await ProcessOneAsync(Processable, libraryBook, validate);
+			return true;
+		}
 	}
 
 	protected bool announcedDailyLimit;

--- a/Source/LibationCli/RunDownloadLimit.cs
+++ b/Source/LibationCli/RunDownloadLimit.cs
@@ -1,0 +1,140 @@
+using ApplicationServices;
+using LibationFileManager;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+
+namespace LibationCli;
+
+/// <summary>
+/// How much a single <c>liberate</c> run may download, from the mutually exclusive <c>--limit-books</c>,
+/// <c>--limit-mb</c> and <c>--limit-gb</c> options. Distinct from the daily download limit, which is a setting
+/// spanning a rolling 24 hours and keeps applying on top of this one.
+/// </summary>
+public readonly record struct RunDownloadLimit(Configuration.DailyLimitUnit Unit, int Quantity)
+{
+	public string Describe()
+		=> Unit is Configuration.DailyLimitUnit.Books ? $"{Quantity} book(s)" : $"{Quantity} {Unit}";
+
+	public static string OptionName(Configuration.DailyLimitUnit unit)
+		=> unit switch
+		{
+			Configuration.DailyLimitUnit.MB => "--limit-mb",
+			Configuration.DailyLimitUnit.GB => "--limit-gb",
+			_ => "--limit-books"
+		};
+
+	/// <summary>
+	/// Builds the limit from the three options, at most one of which the parser lets through. Passing none is
+	/// success with a null <paramref name="limit"/>: an unlimited run is the default, not an error.
+	/// </summary>
+	public static bool TryCreate(
+		int? books,
+		int? megabytes,
+		int? gigabytes,
+		bool pdfOnly,
+		out RunDownloadLimit? limit,
+		[NotNullWhen(false)] out string? error)
+	{
+		limit = null;
+		error = null;
+
+		(Configuration.DailyLimitUnit Unit, int Quantity)? specified
+			= books is int b ? (Configuration.DailyLimitUnit.Books, b)
+			: megabytes is int mb ? (Configuration.DailyLimitUnit.MB, mb)
+			: gigabytes is int gb ? (Configuration.DailyLimitUnit.GB, gb)
+			: null;
+
+		if (specified is null)
+			return true;
+
+		var (unit, quantity) = specified.Value;
+
+		if (quantity < 1)
+		{
+			error = $"{OptionName(unit)} must be at least 1.";
+			return false;
+		}
+
+		// Pdf downloads are never recorded, so a limit combined with --pdf would silently never stop the run.
+		if (pdfOnly)
+		{
+			error = $"{OptionName(unit)} cannot be used with --pdf. The limit counts audiobook downloads, and --pdf downloads no audiobooks.";
+			return false;
+		}
+
+		limit = new RunDownloadLimit(unit, quantity);
+		return true;
+	}
+}
+
+/// <summary>
+/// Tracks how much one run has downloaded and decides when it has had enough.
+/// <para>
+/// Counts the same downloads the daily limit counts, by reading the history rows written when a download
+/// succeeds, so failed, cancelled and pdf-only work is never counted and the two limits cannot disagree about
+/// what a book or a byte is worth. Only titles this run attempted are counted, so a Libation window or a second
+/// container downloading at the same time does not consume this run's allowance.
+/// </para>
+/// </summary>
+internal sealed class RunLimitTracker
+{
+	private const string StopSuffix = "Remaining titles are still un-liberated and will be tried on the next run.";
+
+	private readonly RunDownloadLimit limit;
+	private readonly DateTimeOffset runStart;
+	private readonly Func<DateTimeOffset, IReadOnlyList<DownloadHistoryEntry>> readHistory;
+	private readonly HashSet<string> attempted = new(StringComparer.OrdinalIgnoreCase);
+
+	public RunLimitTracker(
+		RunDownloadLimit limit,
+		DateTimeOffset runStart,
+		Func<DateTimeOffset, IReadOnlyList<DownloadHistoryEntry>>? readHistory = null)
+	{
+		this.limit = limit;
+		this.runStart = runStart;
+		this.readHistory = readHistory ?? DownloadHistoryStore.GetSince;
+	}
+
+	/// <summary>Call for every title handed to the processable, whether or not it ends up downloading.</summary>
+	public void Attempting(string? audibleProductId)
+	{
+		if (!string.IsNullOrWhiteSpace(audibleProductId))
+			attempted.Add(audibleProductId);
+	}
+
+	/// <summary>
+	/// True when the run has downloaded all it may. Re-reads history on every call, so it reflects whatever the
+	/// last title turned out to weigh rather than an estimate.
+	/// </summary>
+	public bool TryStop([NotNullWhen(true)] out string? message)
+	{
+		var (books, bytes) = Downloaded();
+
+		// One download is always allowed: a limit smaller than a single estimated book would otherwise end the
+		// run immediately and report a limit reached to someone who had downloaded nothing.
+		if (books == 0 || DailyDownloadLimit.FitsAnother(limit.Unit, limit.Quantity, books, bytes))
+		{
+			message = null;
+			return false;
+		}
+
+		message = limit.Unit is Configuration.DailyLimitUnit.Books
+			? $"Reached this run's limit of {limit.Describe()}. Downloaded {books} title(s); stopping. {StopSuffix}"
+			: $"Reached this run's limit of {limit.Describe()}. Downloaded about {DiskSpaceHelper.FormatBytes(bytes)} across {books} title(s); stopping. {StopSuffix}";
+		return true;
+	}
+
+	private (int Books, long Bytes) Downloaded()
+	{
+		if (attempted.Count == 0)
+			return (0, 0);
+
+		var mine = readHistory(runStart)
+			.Where(e => e.AudibleProductId is string id && attempted.Contains(id))
+			.ToList();
+
+		return (mine.Count, mine.Sum(e => e.Bytes));
+	}
+}

--- a/Source/LibationFileManager/DailyDownloadLimit.cs
+++ b/Source/LibationFileManager/DailyDownloadLimit.cs
@@ -69,13 +69,25 @@ public static class DailyDownloadLimit
 			_ => false
 		};
 
-	private static long ToBytes(int quantity, Configuration.DailyLimitUnit unit)
+	/// <summary>The limit expressed in bytes. Zero for a book count, which is not a size at all.</summary>
+	public static long ToBytes(int quantity, Configuration.DailyLimitUnit unit)
 		=> unit switch
 		{
 			Configuration.DailyLimitUnit.MB => quantity * BytesPerMB,
 			Configuration.DailyLimitUnit.GB => quantity * BytesPerGB,
 			_ => 0
 		};
+
+	/// <summary>
+	/// Whether one more download stays within <paramref name="quantity"/> of <paramref name="unit"/>, given what
+	/// has been downloaded already. Shared with the CLI's per-run limit so the two cannot disagree about what a
+	/// book or a byte is worth. In MB/GB mode the answer is necessarily an estimate: a title's size is unknown
+	/// until it has been downloaded.
+	/// </summary>
+	public static bool FitsAnother(Configuration.DailyLimitUnit unit, int quantity, int usedBooks, long usedBytes)
+		=> unit is Configuration.DailyLimitUnit.Books
+		? usedBooks < quantity
+		: usedBytes + DiskSpaceHelper.EstimatedBytesPerAudiobookBackup <= ToBytes(quantity, unit);
 
 	public static Allowance Evaluate(Configuration config, IReadOnlyList<DownloadHistoryEntry> history, DateTimeOffset now)
 	{
@@ -109,10 +121,7 @@ public static class DailyDownloadLimit
 			RemainingBooks: RemainingBooks(usedBytes, usedBooks, allowsAnother),
 			NextCapacityAt: allowsAnother ? null : NextCapacityAt(counted, usedBytes));
 
-		bool WouldFit(long bytes, int books)
-			=> unit is Configuration.DailyLimitUnit.Books
-			? books < quantity
-			: bytes + DiskSpaceHelper.EstimatedBytesPerAudiobookBackup <= ToBytes(quantity, unit);
+		bool WouldFit(long bytes, int books) => FitsAnother(unit, quantity, books, bytes);
 
 		int RemainingBooks(long bytes, int books, bool allows)
 		{

--- a/Source/_Tests/LibationCli.Tests/RunDownloadLimitTests.cs
+++ b/Source/_Tests/LibationCli.Tests/RunDownloadLimitTests.cs
@@ -1,0 +1,239 @@
+using AssertionHelper;
+using LibationFileManager;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+
+namespace LibationCli.Tests;
+
+/// <summary>
+/// The per-run limit options on <c>liberate</c>, and the decision to stop a run. Everything here is pure: the
+/// history a run has produced is supplied directly, so no database or downloading is involved.
+/// </summary>
+[TestClass]
+public class RunDownloadLimitTests
+{
+	private static readonly DateTimeOffset RunStart = new(2026, 8, 14, 19, 0, 0, TimeSpan.FromHours(-4));
+
+	private const long ThreeHundredMB = 300L * 1024 * 1024;
+
+	private static LiberateOptions? Parse(params string[] args)
+	{
+		using var error = new StringWriter();
+		return Program.ParseInvocation(args, error).Result?.Value as LiberateOptions;
+	}
+
+	private static DownloadHistoryEntry Entry(string asin, long bytes = ThreeHundredMB)
+		=> new(RunStart.AddMinutes(1), asin, IsAudiblePlus: true, bytes);
+
+	#region parsing
+
+	[TestMethod]
+	[DataRow("--limit-books", 10, Configuration.DailyLimitUnit.Books)]
+	[DataRow("--limit-mb", 500, Configuration.DailyLimitUnit.MB)]
+	[DataRow("--limit-gb", 5, Configuration.DailyLimitUnit.GB)]
+	public void Each_option_maps_to_its_own_unit(string option, int quantity, Configuration.DailyLimitUnit expectedUnit)
+	{
+		var options = Parse("liberate", option, quantity.ToString());
+		Assert.IsNotNull(options);
+
+		Assert.IsTrue(RunDownloadLimit.TryCreate(options.LimitBooks, options.LimitMB, options.LimitGB, options.PdfOnly, out var limit, out var error));
+		Assert.IsNull(error);
+		Assert.IsNotNull(limit);
+		Assert.AreEqual(expectedUnit, limit.Value.Unit);
+		limit.Value.Quantity.Should().Be(quantity);
+	}
+
+	[TestMethod]
+	[DataRow("--limit-books", "10", "--limit-mb", "500")]
+	[DataRow("--limit-books", "10", "--limit-gb", "5")]
+	[DataRow("--limit-mb", "500", "--limit-gb", "5")]
+	public void Two_limit_options_cannot_be_used_together(params string[] limitArgs)
+	{
+		using var error = new StringWriter();
+
+		var outcome = Program.ParseInvocation(["liberate", .. limitArgs], error);
+
+		Assert.AreEqual(ExitCode.ParseError, outcome.ExitCode);
+		StringAssert.Contains(error.ToString(), "is not compatible with");
+	}
+
+	[TestMethod]
+	public void A_limit_combines_with_the_other_liberate_options()
+	{
+		var options = Parse("liberate", "--force", "--limit-books", "3", "B017V4IM1G");
+
+		Assert.IsNotNull(options);
+		options.Force.Should().BeTrue();
+		Assert.AreEqual(3, options.LimitBooks);
+		CollectionAssert.AreEqual(new[] { "B017V4IM1G" }, options.Asins!.ToArray());
+	}
+
+	[TestMethod]
+	public void No_limit_option_is_an_unlimited_run_rather_than_an_error()
+	{
+		var options = Parse("liberate");
+		Assert.IsNotNull(options);
+
+		Assert.IsTrue(RunDownloadLimit.TryCreate(options.LimitBooks, options.LimitMB, options.LimitGB, options.PdfOnly, out var limit, out var error));
+		Assert.IsNull(limit);
+		Assert.IsNull(error);
+	}
+
+	#endregion
+
+	#region validation
+
+	[TestMethod]
+	[DataRow(0)]
+	[DataRow(-7)]
+	public void A_quantity_below_one_is_rejected(int quantity)
+	{
+		Assert.IsFalse(RunDownloadLimit.TryCreate(quantity, null, null, pdfOnly: false, out var limit, out var error));
+
+		Assert.IsNull(limit);
+		StringAssert.Contains(error!, "--limit-books");
+		StringAssert.Contains(error!, "at least 1");
+	}
+
+	[TestMethod]
+	public void The_rejection_names_the_option_the_user_actually_typed()
+	{
+		Assert.IsFalse(RunDownloadLimit.TryCreate(null, null, 0, pdfOnly: false, out _, out var error));
+
+		StringAssert.Contains(error!, "--limit-gb");
+	}
+
+	[TestMethod]
+	public void A_limit_is_rejected_with_pdf_only_rather_than_silently_never_stopping()
+	{
+		Assert.IsFalse(RunDownloadLimit.TryCreate(null, 500, null, pdfOnly: true, out var limit, out var error));
+
+		Assert.IsNull(limit);
+		StringAssert.Contains(error!, "--limit-mb");
+		StringAssert.Contains(error!, "--pdf");
+	}
+
+	#endregion
+
+	#region stopping a run
+
+	[TestMethod]
+	public void A_book_limit_stops_the_run_once_that_many_have_downloaded()
+	{
+		var history = new List<DownloadHistoryEntry>();
+		var tracker = new RunLimitTracker(new(Configuration.DailyLimitUnit.Books, 2), RunStart, _ => history);
+
+		tracker.TryStop(out _).Should().BeFalse();
+
+		Download(tracker, history, "ASIN1");
+		tracker.TryStop(out _).Should().BeFalse();
+
+		Download(tracker, history, "ASIN2");
+		tracker.TryStop(out var message).Should().BeTrue();
+
+		StringAssert.Contains(message!, "2 book(s)");
+		StringAssert.Contains(message!, "Downloaded 2 title(s)");
+		StringAssert.Contains(message!, "tried on the next run");
+	}
+
+	[TestMethod]
+	public void A_size_limit_stops_when_another_book_would_not_fit()
+	{
+		// 300 MB each against a 1 GB limit: a fourth would be assumed to need another 400 MB, over the limit.
+		var history = new List<DownloadHistoryEntry>();
+		var tracker = new RunLimitTracker(new(Configuration.DailyLimitUnit.GB, 1), RunStart, _ => history);
+
+		Download(tracker, history, "ASIN1");
+		Download(tracker, history, "ASIN2");
+		tracker.TryStop(out _).Should().BeFalse();
+
+		Download(tracker, history, "ASIN3");
+		tracker.TryStop(out var message).Should().BeTrue();
+
+		StringAssert.Contains(message!, "1 GB");
+		StringAssert.Contains(message!, "900 MB");
+		StringAssert.Contains(message!, "across 3 title(s)");
+	}
+
+	[TestMethod]
+	public void One_download_is_allowed_even_when_the_limit_is_smaller_than_a_book()
+	{
+		var history = new List<DownloadHistoryEntry>();
+		var tracker = new RunLimitTracker(new(Configuration.DailyLimitUnit.MB, 1), RunStart, _ => history);
+
+		// Otherwise a run would end immediately and report a limit reached to someone who downloaded nothing.
+		tracker.TryStop(out _).Should().BeFalse();
+
+		Download(tracker, history, "ASIN1");
+		tracker.TryStop(out _).Should().BeTrue();
+	}
+
+	[TestMethod]
+	public void Downloads_this_run_did_not_perform_are_not_counted()
+	{
+		// A Libation window or a second container downloading at the same time writes to the same history.
+		var history = new List<DownloadHistoryEntry>
+		{
+			Entry("SOMEONE_ELSE1"),
+			Entry("SOMEONE_ELSE2"),
+			Entry("SOMEONE_ELSE3")
+		};
+		var tracker = new RunLimitTracker(new(Configuration.DailyLimitUnit.Books, 2), RunStart, _ => history);
+
+		Download(tracker, history, "ASIN1");
+
+		tracker.TryStop(out _).Should().BeFalse();
+	}
+
+	[TestMethod]
+	public void Titles_attempted_but_not_downloaded_are_not_counted()
+	{
+		// A title that failed, or that the daily limit skipped, writes no history row.
+		var history = new List<DownloadHistoryEntry>();
+		var tracker = new RunLimitTracker(new(Configuration.DailyLimitUnit.Books, 1), RunStart, _ => history);
+
+		tracker.Attempting("FAILED1");
+		tracker.Attempting("FAILED2");
+
+		tracker.TryStop(out _).Should().BeFalse();
+	}
+
+	[TestMethod]
+	public void Product_ids_are_matched_without_regard_to_case()
+	{
+		var history = new List<DownloadHistoryEntry> { Entry("b0test0001") };
+		var tracker = new RunLimitTracker(new(Configuration.DailyLimitUnit.Books, 1), RunStart, _ => history);
+
+		tracker.Attempting("B0TEST0001");
+
+		tracker.TryStop(out _).Should().BeTrue();
+	}
+
+	[TestMethod]
+	public void History_is_read_afresh_from_the_start_of_the_run()
+	{
+		// Re-reading is what lets the limit reflect what the last title actually weighed.
+		var reads = new List<DateTimeOffset>();
+		var tracker = new RunLimitTracker(
+			new(Configuration.DailyLimitUnit.Books, 5),
+			RunStart,
+			since => { reads.Add(since); return []; });
+
+		tracker.Attempting("ASIN1");
+		tracker.TryStop(out _);
+		tracker.TryStop(out _);
+
+		CollectionAssert.AreEqual(new[] { RunStart, RunStart }, reads);
+	}
+
+	private static void Download(RunLimitTracker tracker, List<DownloadHistoryEntry> history, string asin)
+	{
+		tracker.Attempting(asin);
+		history.Add(Entry(asin));
+	}
+
+	#endregion
+}

--- a/Source/_Tests/LibationCli.Tests/RunLimitLoopTests.cs
+++ b/Source/_Tests/LibationCli.Tests/RunLimitLoopTests.cs
@@ -66,8 +66,11 @@ public class RunLimitLoopTests
 		await new LimitedRun(new(Configuration.DailyLimitUnit.Books, 2)).Go(processable);
 
 		processable.Downloaded.Should().HaveCount(2);
-		StringAssert.Contains(Output, "Reached this run's limit of 2 book(s)");
-		StringAssert.Contains(Output, "Done. Stopped early");
+		StringAssert.Contains(
+			Output,
+			"Reached this run's limit of 2 book(s). Downloaded 2 title(s); stopping. "
+			+ "Remaining titles are still un-liberated and will be tried on the next run.");
+		StringAssert.Contains(Output, "Done. Stopped early: this run's download limit was reached.");
 	}
 
 	[TestMethod]
@@ -80,7 +83,10 @@ public class RunLimitLoopTests
 
 		// A fourth 300 MB title would be assumed to need another 400 MB, past the 1 GB limit.
 		processable.Downloaded.Should().HaveCount(3);
-		StringAssert.Contains(Output, "Reached this run's limit of 1 GB");
+		StringAssert.Contains(
+			Output,
+			"Reached this run's limit of 1 GB. Downloaded about 900 MB across 3 title(s); stopping. "
+			+ "Remaining titles are still un-liberated and will be tried on the next run.");
 	}
 
 	[TestMethod]

--- a/Source/_Tests/LibationCli.Tests/RunLimitLoopTests.cs
+++ b/Source/_Tests/LibationCli.Tests/RunLimitLoopTests.cs
@@ -1,0 +1,201 @@
+using ApplicationServices;
+using AssertionHelper;
+using DataLayer;
+using Dinah.Core.ErrorHandling;
+using FileLiberator;
+using LibationFileManager;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Threading.Tasks;
+
+namespace LibationCli.Tests;
+
+/// <summary>
+/// Drives the real <c>liberate</c> run loop against a real library database and a processable that records
+/// downloads the way <see cref="DownloadDecryptBook"/> does, which is as close to a limited run as is possible
+/// without an Audible account.
+/// </summary>
+[TestClass]
+[DoNotParallelize]
+public class RunLimitLoopTests
+{
+	private string tempLibationFiles = string.Empty;
+	private TextWriter originalOut = Console.Out;
+	private StringWriter capturedOut = new();
+
+	[TestInitialize]
+	public void Initialize()
+	{
+		tempLibationFiles = Path.Combine(Path.GetTempPath(), $"libation-run-limit-tests-{Guid.NewGuid():N}");
+		Directory.CreateDirectory(tempLibationFiles);
+
+		// A fresh Configuration resolves LibationFiles from this variable, so the database lands in the temp dir.
+		Environment.SetEnvironmentVariable(LibationFiles.LIBATION_FILES_DIR, tempLibationFiles);
+		Configuration.CreateMockInstance();
+
+		originalOut = Console.Out;
+		capturedOut = new StringWriter();
+		Console.SetOut(capturedOut);
+	}
+
+	[TestCleanup]
+	public void Cleanup()
+	{
+		Console.SetOut(originalOut);
+		Configuration.RestoreSingletonInstance();
+		Environment.SetEnvironmentVariable(LibationFiles.LIBATION_FILES_DIR, null);
+
+		try
+		{
+			Directory.Delete(tempLibationFiles, recursive: true);
+		}
+		catch (IOException)
+		{
+			// A leftover temp directory is not worth failing a test over.
+		}
+	}
+
+	[TestMethod]
+	public async Task A_book_limit_leaves_the_rest_of_the_library_for_the_next_run()
+	{
+		SeedLibrary(5);
+		var processable = NewProcessable();
+
+		await new LimitedRun(new(Configuration.DailyLimitUnit.Books, 2)).Go(processable);
+
+		processable.Downloaded.Should().HaveCount(2);
+		StringAssert.Contains(Output, "Reached this run's limit of 2 book(s)");
+		StringAssert.Contains(Output, "Done. Stopped early");
+	}
+
+	[TestMethod]
+	public async Task A_size_limit_stops_once_another_book_would_not_fit()
+	{
+		SeedLibrary(10);
+		var processable = NewProcessable(bytesPerBook: 300L * 1024 * 1024);
+
+		await new LimitedRun(new(Configuration.DailyLimitUnit.GB, 1)).Go(processable);
+
+		// A fourth 300 MB title would be assumed to need another 400 MB, past the 1 GB limit.
+		processable.Downloaded.Should().HaveCount(3);
+		StringAssert.Contains(Output, "Reached this run's limit of 1 GB");
+	}
+
+	[TestMethod]
+	public async Task A_run_that_fits_inside_its_limit_says_nothing_about_it()
+	{
+		SeedLibrary(3);
+		var processable = NewProcessable();
+
+		await new LimitedRun(new(Configuration.DailyLimitUnit.Books, 10)).Go(processable);
+
+		processable.Downloaded.Should().HaveCount(3);
+		Output.Contains("Reached this run's limit").Should().BeFalse();
+		StringAssert.Contains(Output, "Done. All books have been processed");
+	}
+
+	[TestMethod]
+	public async Task A_run_ending_exactly_at_its_limit_says_nothing_either()
+	{
+		// Nothing was cut short, so reporting a limit reached would be misleading.
+		SeedLibrary(2);
+		var processable = NewProcessable();
+
+		await new LimitedRun(new(Configuration.DailyLimitUnit.Books, 2)).Go(processable);
+
+		processable.Downloaded.Should().HaveCount(2);
+		Output.Contains("Reached this run's limit").Should().BeFalse();
+		StringAssert.Contains(Output, "Done. All books have been processed");
+	}
+
+	[TestMethod]
+	public async Task Without_a_limit_the_whole_library_is_processed()
+	{
+		SeedLibrary(6);
+		var processable = NewProcessable();
+
+		await new LimitedRun(null).Go(processable);
+
+		processable.Downloaded.Should().HaveCount(6);
+		StringAssert.Contains(Output, "Done. All books have been processed");
+	}
+
+	[TestMethod]
+	public async Task Downloads_from_an_earlier_run_do_not_count_against_this_one()
+	{
+		SeedLibrary(4);
+		var processable = NewProcessable();
+
+		// The same titles, downloaded moments ago by a different run: inside the daily window, outside this run.
+		for (var i = 0; i < 4; i++)
+			DownloadHistoryStore.Record(ProductId(i), isAudiblePlus: true, bytes: 1, completedAt: DateTimeOffset.Now.AddHours(-1));
+
+		await new LimitedRun(new(Configuration.DailyLimitUnit.Books, 3)).Go(processable);
+
+		processable.Downloaded.Should().HaveCount(3);
+	}
+
+	private string Output => capturedOut.ToString();
+
+	private static string ProductId(int index) => $"B0RUNLIMIT{index:0000}";
+
+	private static RecordingProcessable NewProcessable(long bytesPerBook = 1024 * 1024)
+		=> new() { Configuration = Configuration.Instance, BytesPerBook = bytesPerBook };
+
+	private static void SeedLibrary(int count)
+	{
+		// Shared instances: a contributor is one row no matter how many books credit it.
+		var author = new Contributor("Test Author");
+		var narrator = new Contributor("Test Narrator");
+
+		using var context = DbContexts.GetContext();
+
+		for (var i = 0; i < count; i++)
+		{
+			var book = new Book(
+				new AudibleProductId(ProductId(i)),
+				$"Test Title {i}",
+				"",
+				"",
+				600,
+				ContentType.Product,
+				[author],
+				[narrator],
+				"us");
+
+			context.LibraryBooks.Add(new LibraryBook(book, new DateTime(2026, 1, 1).AddMinutes(i), "test-account"));
+		}
+
+		context.SaveChanges();
+	}
+
+	/// <summary>Stands in for <see cref="DownloadDecryptBook"/>: succeeds, and records what it "downloaded".</summary>
+	private sealed class RecordingProcessable : Processable
+	{
+		public required long BytesPerBook { get; init; }
+		public List<string> Downloaded { get; } = [];
+
+		public override string Name => nameof(RecordingProcessable);
+
+		public override bool Validate(LibraryBook libraryBook) => true;
+
+		public override Task<StatusHandler> ProcessAsync(LibraryBook libraryBook)
+		{
+			Downloaded.Add(libraryBook.Book.AudibleProductId);
+			DownloadHistoryStore.Record(libraryBook.Book.AudibleProductId, libraryBook.IsAudiblePlus, BytesPerBook);
+			return Task.FromResult(new StatusHandler());
+		}
+	}
+
+	/// <summary>Exposes the run loop, which is otherwise reachable only through a verb.</summary>
+	private sealed class LimitedRun(RunDownloadLimit? limit) : ProcessableOptionsBase
+	{
+		protected override RunDownloadLimit? RunLimit => limit;
+
+		protected override Task ProcessAsync() => Task.CompletedTask;
+
+		public Task Go(Processable processable) => RunAsync(processable);
+	}
+}

--- a/docs/advanced/command-line-interface.md
+++ b/docs/advanced/command-line-interface.md
@@ -206,6 +206,24 @@ libationcli liberate --force
 libationcli liberate -f
 ```
 
+## Limit How Much One Run Downloads
+
+A large library can take a long time and a lot of disk to liberate in one go. These options stop a run once it has downloaded a given amount, leaving the rest for the next run:
+
+```console
+libationcli liberate --limit-books 10
+libationcli liberate --limit-mb 500
+libationcli liberate --limit-gb 20
+```
+
+The three are mutually exclusive; using two together is an error. Each applies to a single invocation, so a scheduled or scripted run downloads what it may, stops, and the next run continues where it left off.
+
+Only successful audiobook downloads count. Failed titles do not, and PDFs are neither counted nor limited, so a limit cannot be combined with `--pdf`. Titles the limit stopped Libation from reaching remain un-liberated and are picked up next time. Reaching the limit is not a failure: the command still exits **0**.
+
+MB and GB are approximate, because Libation does not know how large a title is until it has downloaded it. When deciding whether there is room for another book it assumes about 400 MB for it, the same estimate it uses to warn about low disk space. One download is always allowed, so a limit smaller than a single book downloads one book rather than nothing.
+
+This is a per-run limit, separate from the [daily download limit](/docs/features/daily-download-limit) setting. Both apply if both are set.
+
 ## Liberate using a license file from the `get-license` command
 
 ```console

--- a/docs/features/daily-download-limit.md
+++ b/docs/features/daily-download-limit.md
@@ -50,6 +50,12 @@ Under "Plus titles only" a queue holding both kinds keeps going: Plus titles mov
 
 **On the command line:** `libationcli liberate` does not wait, since a scripted or scheduled run should not sit idle for hours. It skips the titles the limit covers, says so, and reports how many it skipped. Those titles remain un-liberated and are picked up by the next run.
 
+## A limit for one run
+
+The command line has a second, separate limit: `libationcli liberate --limit-books 10` (or `--limit-mb` / `--limit-gb`) stops that one run after downloading that much, whatever your daily limit says. It is useful for taking a large library a slice at a time, and both limits apply if both are set. See [Limit how much one run downloads](/docs/advanced/command-line-interface#limit-how-much-one-run-downloads).
+
+There is no equivalent in the app, where selecting rows in the grid and choosing **Download selected audiobooks** already says exactly which titles to download.
+
 ## Docker and the command line
 
 Containers have no settings dialog, so add the keys to the `Settings.json` you mount at `/config`:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds three mutually exclusive options to `libationcli liberate` that stop a single run once it has downloaded that much:

```console
libationcli liberate --limit-books 10
libationcli liberate --limit-mb 500
libationcli liberate --limit-gb 20
```

Requested by @wtanksleyjr in #1920: "I could also use a max per run, although that might be more interesting for command line use than for GUI." A scripted or scheduled run currently has no way to take only a slice of a large library, so users resort to feeding the CLI a handful of ASINs at a time.

CLI only. The GUI needs no equivalent: selecting rows and choosing **Download selected audiobooks** already says exactly which titles to download, and a live queue that accepts new work mid-run has no boundary a "per run" counter could reset on.

## Behavior

Counting reuses the daily limit's history rows rather than a private tally, so a book and a byte mean the same thing to both limits, and failed, cancelled and pdf-only work is never counted. Only titles this run attempted are counted, so a Libation window or a second container downloading at the same time does not consume this run's allowance.

The limit is checked before each title rather than at the top of the run, so a run whose books happen to end exactly at the limit reports nothing: nothing was cut short. Reaching the limit is not a failure and the command still exits 0. The daily download limit keeps applying on top, unchanged.

MB and GB are approximate, since a title's size is unknown until it has downloaded. Deciding whether there is room for another book uses the same 400 MB estimate as the low-disk-space warning, and one download is always allowed so a limit smaller than a single book downloads one book rather than nothing.

Rejected up front: two limits together (a parse error from `SetName`, exit 2), a quantity below 1, and any limit combined with `--pdf`, which would otherwise never stop because pdf downloads are not recorded.

## Verification

`liberate`'s option surface, exercised against the built CLI:

[cli_per_run_limit_transcript.txt](https://cursor.com/agents/bc-a8e8541d-332e-4e42-ba75-53e001429be6/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fcli_per_run_limit_transcript.txt)

25 new tests. The loop tests drive the real run loop against a real library database with a processable that records downloads the way `DownloadDecryptBook` does, which is as close to a limited run as is possible without an Audible account; they pin the exact counts and the exact message. A deliberate mutation (expecting 4 downloads instead of 2) was confirmed to fail before being reverted, so the counts are not vacuous.

[per_run_limit_tests.txt](https://cursor.com/agents/bc-a8e8541d-332e-4e42-ba75-53e001429be6/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fper_run_limit_tests.txt)

Full suite from `Source/`: 1223 passed, 23 skipped (the opt-in OS secret store tests), 0 failed. `LibationAvalonia` and `LibationCli` both build clean.

An end-to-end download cannot be demonstrated here, since the limit only counts successful downloads and those need real Audible credentials.

Closes part of #1920.

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a8e8541d-332e-4e42-ba75-53e001429be6?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a8e8541d-332e-4e42-ba75-53e001429be6&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

