### PR TITLE
Track the queue pop-out state explicitly (re: #1941, not a bug fix)

### DIFF
--- a/Source/LibationWinForms/Form1.ProcessQueue.cs
+++ b/Source/LibationWinForms/Form1.ProcessQueue.cs
@@ -12,6 +12,7 @@ namespace LibationWinForms;
 public partial class Form1
 {
 	int WidthChange = 0;
+	private bool queueIsPoppedOut;
 	private void Configure_ProcessQueue()
 	{
 		processBookQueue1.PopoutButton.Click += ProcessBookQueue1_PopOut;
@@ -85,7 +86,7 @@ public partial class Form1
 		}
 		else if (!collapsed && splitContainer1.Panel2Collapsed)
 		{
-			if (!processBookQueue1.PopoutButton.Visible)
+			if (queueIsPoppedOut)
 				//Queue is in popout mode. Do nothing.
 				return;
 
@@ -112,6 +113,7 @@ public partial class Form1
 		dockForm.FormClosing += DockForm_FormClosing;
 		splitContainer1.Panel2.Controls.Remove(processBookQueue1);
 		splitContainer1.Panel2Collapsed = true;
+		queueIsPoppedOut = true;
 		processBookQueue1.PopoutButton.Visible = false;
 		dockForm.PassControl(processBookQueue1);
 		dockForm.Show();
@@ -129,6 +131,7 @@ public partial class Form1
 			this.Width += dockForm.WidthChange;
 			splitContainer1.Panel2.Controls.Add(dockForm.RegainControl());
 			splitContainer1.Panel2Collapsed = false;
+			queueIsPoppedOut = false;
 			processBookQueue1.PopoutButton.Visible = true;
 			dockForm.SaveSizeAndLocation(Configuration.Instance);
 			this.Focus();


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## TL;DR

Issue #1941 does not reproduce, and the root cause it gives is wrong. This PR fixes no behavior. It only replaces the implicit pop-out check with a bool, so the next reader (human or LLM) does not misread it the same way. Close it if you would rather leave the code alone.

## Why #1941 is wrong

The issue says the reopen guard misfires because "in WinForms `Control.Visible` also returns false for a control with no parent", and the collapse path has just removed `processBookQueue1` from `Panel2`. Two problems:

1. `PopoutButton` is a `ToolStripButton`, so `Control.Visible` is not the getter being called. `ToolStripItem.Visible` is `(ParentInternal is not null) && (ParentInternal.Visible) && Available`, and `PopoutButton.Visible = false` sets `Available`. `Available` is false only between `ProcessBookQueue1_PopOut` and `DockForm_FormClosing`, which is exactly the state the guard wants to detect.
2. The claim is false for `Control` too. In `dotnet/winforms` `release/10.0`, the getter is `DesiredVisibility && (ParentInternal is null || ParentInternal.Visible)`, so a parentless (parked) control reports `Visible == true`. `Controls.Remove` only calls `SetParentHandle(default)` + `AssignParent(null)`; it never clears the visible bit, and `WmShowWindow` deliberately refuses to clear it when the control has no visible parent.

There is also a behavioral proof inside this repo. `Form1_FormClosing` calls `SetQueueCollapseState(true)`, so Classic always launches with the queue collapsed, and `SetQueueCollapseState(false)` is the only path that ever opens the panel. If that guard early-returned on a collapsed queue, the queue panel could never open at all - not from the toggle, not from Liberate, not from Download all. Separately, the pop-out window renders the queue after the same `Panel2.Controls.Remove(...)` + `Controls.Add(...)` with no `Visible = true` anywhere, which it could not do if removal cleared the visible bit.

The reporter's step 5 ("`Settings.json` shows `Panel2Collapsed: true` and never returns to `false`") is a real observation with a different cause: `Form1_FormClosing` collapses the queue on every exit on purpose, to keep `SaveSizeAndLocation` from recording an excessively wide form. So the value at rest is always `true`, which is by design, not evidence of a stuck toggle.

## What this PR changes

`SetQueueCollapseState` now checks a `queueIsPoppedOut` field set in `ProcessBookQueue1_PopOut` and cleared in `DockForm_FormClosing`, instead of inferring pop-out from `PopoutButton.Visible`.

Equivalent in every reachable path:

- Toggle click or a Liberate/Download action while merely collapsed: `Available` was true, so the old check passed; the flag is false, so the new check passes.
- Liberate/Download while popped out: `Available` was false; the flag is true. Still returns early.
- `Configure_ProcessQueue` at startup: cannot reach that branch, since the designer leaves `Panel2Collapsed` at its default `false`.

The one difference is in the branch that is currently unreachable: `ToolStripItem.Visible` walks up to `Form1`, so the old check also read false whenever the main form was not visible. A future "start hidden" feature, a designer default of `Panel2Collapsed = true`, or any pre-`Show` caller would have turned that into the exact bug #1941 describes, including the skipped config write. The flag has no such second meaning.

I left `processBookQueue1.PopoutButton.Visible = true` in the reopen branch alone, even though it is redundant, to keep the diff to the guard.

## Testing

I cannot run WinForms here (Linux, no `Microsoft.WindowsDesktop.App`), so this is compile plus source-level verification only:

- `dotnet build Source/LibationWinForms/LibationWinForms.csproj -p:EnableWindowsTargeting=true` - succeeds, 0 errors, same 29 pre-existing warnings as before the change.
- `dotnet test` from `Source/` - 1246 tests, 0 failed, 23 skipped (the opt-in OS secret store ones).

The `Visible` semantics above are quoted verbatim from `dotnet/winforms` `release/10.0`, the WinForms that ships with the `net10.0-windows7.0` target.

## Not changed

If you do want the panel's open/closed state to survive a restart (the one legitimate wish in #1941), that is a deliberate change to `Form1_FormClosing`: it would need to save the pre-collapse width so the restored form is not narrow with a 350px-min queue squeezing the grid. That is UI sizing logic I cannot test here, so I left it for you to decide. For reference, Chardonnay does persist its pane state - `MainWindow_Closing` does not force-collapse - which is the actual Classic/Chardonnay difference, and it is about persistence rather than a stuck toggle.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-88101f3b-4c39-41d4-b54e-d70c6fb9610d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-88101f3b-4c39-41d4-b54e-d70c6fb9610d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

