### PR TITLE
docs(faq): add entry about Audible Standard

### DIFF
--- a/Source/LibationUiBase/LibationContributor.cs
+++ b/Source/LibationUiBase/LibationContributor.cs
@@ -55,6 +55,7 @@ public class LibationContributor
             GitHubUser("m-j-r"),
             GitHubUser("Demoniskk"),
             GitHubUser("oxivanisher"),
+			GitHubUser("tippfehlr"),
         ]);
 
 	private LibationContributor(string name, LibationContributorType type, Uri link)

--- a/docs/frequently-asked-questions.md
+++ b/docs/frequently-asked-questions.md
@@ -111,6 +111,6 @@ Libation no longer requests spatial/Atmos from Audible (see [Spatial Audio, Dolb
 
 For spatial files you already have, see [Playing spatial files you already have](./advanced/spatial-audio.md#playing-spatial-files-you-already-have) and [Supported Media Players](./features/audio-file-formats.md#supported-media-players).
 
-## Does Libation work with books from Audible Standard?
+### Does Libation work with books from Audible Standard?
 
-Yes, at least while the subscription is active. Not yet tested without a subscription.
+Yes, while the subscription is active. After the subscription becomes inactive, Libation cannot get a license and so does not download those books.

--- a/docs/frequently-asked-questions.md
+++ b/docs/frequently-asked-questions.md
@@ -110,3 +110,7 @@ No. **Use Widevine DRM** unlocks **Request xHE-AAC Codec** for higher-bitrate st
 Libation no longer requests spatial/Atmos from Audible (see [Spatial Audio, Dolby Atmos, and Widevine DRM](./advanced/spatial-audio.md)). Books you liberated before 13.1.3 may be E-AC-3 or AC-4; newer downloads are stereo unless you kept older files.
 
 For spatial files you already have, see [Playing spatial files you already have](./advanced/spatial-audio.md#playing-spatial-files-you-already-have) and [Supported Media Players](./features/audio-file-formats.md#supported-media-players).
+
+## Does Libation work with books from Audible Standard?
+
+Yes, at least while the subscription is active. Not yet tested without a subscription.


### PR DESCRIPTION
Just tested this after missing the entry. With audible.de, I can download books just fine, but haven’t tested it without the subscription.