### PR TITLE
Recover from Lucene read-past-EOF and clarify auto-scan auth

### DIFF
--- a/Source/AudibleUtilities/AccountCredentialStatus.cs
+++ b/Source/AudibleUtilities/AccountCredentialStatus.cs
@@ -1,0 +1,34 @@
+namespace AudibleUtilities;
+
+/// <summary>Helpers for describing whether an account has usable stored Audible tokens.</summary>
+public static class AccountCredentialStatus
+{
+	/// <summary>
+	/// True when identity tokens are absent or have no refresh token, i.e. the account was never
+	/// fully logged in or credentials were cleared -- not merely an expired access token.
+	/// </summary>
+	public static bool LooksLikeMissingCredentials(Account? account)
+	{
+		var tokens = account?.IdentityTokens;
+		if (tokens is null)
+			return true;
+		if (tokens.IsValid)
+			return false;
+
+		return tokens.RefreshToken is null
+			|| string.IsNullOrWhiteSpace(tokens.RefreshToken.Value);
+	}
+
+	/// <summary>User-facing account label for dialogs and log messages.</summary>
+	public static string FormatAccountLabel(Account? account)
+	{
+		if (account is null)
+			return "an Audible account";
+
+		if (!string.IsNullOrWhiteSpace(account.AccountName)
+			&& !string.Equals(account.AccountName, account.AccountId, StringComparison.OrdinalIgnoreCase))
+			return $"'{account.AccountName}' ({account.AccountId})";
+
+		return $"'{account.AccountId}'";
+	}
+}

--- a/Source/AudibleUtilities/ApiExtended.cs
+++ b/Source/AudibleUtilities/ApiExtended.cs
@@ -59,19 +59,27 @@ public class ApiExtended
 		{
 			if (!allowInteractiveLogin || LoginChoiceFactory is null)
 			{
+				var missing = AccountCredentialStatus.LooksLikeMissingCredentials(account);
 				Serilog.Log.Logger.Error(ex,
-					"Stored credentials could not be used and interactive login is not available. {@DebugInfo}",
+					missing
+						? "Stored credentials are missing or incomplete and interactive login is not available. {@DebugInfo}"
+						: "Stored credentials could not be used and interactive login is not available. {@DebugInfo}",
 					new
 					{
 						Account = account.MaskedLogEntry ?? "[null]",
 						LocaleName = locale.Name,
 						AllowInteractiveLogin = allowInteractiveLogin,
-						LoginChoiceFactorySet = LoginChoiceFactory is not null
+						LoginChoiceFactorySet = LoginChoiceFactory is not null,
+						LooksLikeMissingCredentials = missing
 					});
+
+				var reason = missing
+					? $"Stored credentials for '{account.AccountId}' are missing or incomplete"
+					: $"Stored credentials for '{account.AccountId}' could not be used";
 
 				throw new AuthenticationRequiredException(
 					account,
-					message: $"Stored credentials for '{account.AccountId}' could not be used"
+					message: reason
 						+ (LoginChoiceFactory is null
 							? " and interactive login is not available in this context (CLI/Docker)."
 							: " and interactive login was not allowed.")

--- a/Source/AudibleUtilities/AuthenticationExceptionHelper.cs
+++ b/Source/AudibleUtilities/AuthenticationExceptionHelper.cs
@@ -24,4 +24,28 @@ public static class AuthenticationExceptionHelper
 
 		return false;
 	}
+
+	/// <summary>
+	/// Finds the first <see cref="AuthenticationRequiredException"/> in <paramref name="ex"/> or its inner chain.
+	/// </summary>
+	public static AuthenticationRequiredException? FindAuthenticationRequired(Exception ex)
+	{
+		if (ex is AggregateException aggregate)
+		{
+			foreach (var inner in aggregate.InnerExceptions)
+			{
+				var found = FindAuthenticationRequired(inner);
+				if (found is not null)
+					return found;
+			}
+		}
+
+		for (var current = ex; current is not null; current = current.InnerException)
+		{
+			if (current is AuthenticationRequiredException auth)
+				return auth;
+		}
+
+		return null;
+	}
 }

--- a/Source/LibationAvalonia/ViewModels/MainVM.Import.cs
+++ b/Source/LibationAvalonia/ViewModels/MainVM.Import.cs
@@ -240,6 +240,14 @@ public partial class MainVM
 					NonJsonResponseExceptionExtensions.LibraryScanFailedCaption,
 					htmlEx);
 			}
+			else if (SearchIndexRecovery.TryFindFailure(ex, out var indexEx) && indexEx is not null)
+			{
+				await MessageBox.ShowAdminAlert(
+					MainWindow,
+					SearchIndexRecovery.ManualRecoveryInstructions,
+					SearchIndexRecovery.Caption,
+					indexEx);
+			}
 			else
 			{
 				await MessageBox.ShowAdminAlert(

--- a/Source/LibationAvalonia/ViewModels/MainVM.ScanAuto.cs
+++ b/Source/LibationAvalonia/ViewModels/MainVM.ScanAuto.cs
@@ -34,13 +34,12 @@ partial class MainVM
 		Configuration.Instance.PropertyChanged += startAutoScan;
 	}
 
-	private async Task notifyAutoScanAuthRequiredAsync()
+	private async Task notifyAutoScanAuthRequiredAsync(AuthenticationRequiredException ex)
 	{
 		await MessageBox.Show(
 			MainWindow,
-			"Libation could not refresh your Audible library because your login session expired.\n\n"
-			+ "Background auto-scan has been paused. Use Import > Scan Library to log in again to resume periodic scans.",
-			"Auto-scan paused - login required",
+			AutoScanAuthPrompt.FormatBody(ex),
+			AutoScanAuthPrompt.Caption,
 			MessageBoxButtons.OK,
 			MessageBoxIcon.Warning);
 	}

--- a/Source/LibationSearchEngine/SearchEngine.cs
+++ b/Source/LibationSearchEngine/SearchEngine.cs
@@ -95,12 +95,23 @@ public class SearchEngine
 				createNewIndexCore(libraryList, overwrite);
 				return;
 			}
-			catch (Exception ex) when (IsRecoverableCorruptIndexException(ex) && corruptRebuildAttemptsRemaining > 0)
+			catch (Exception ex) when (IsRecoverableCorruptIndexException(ex))
 			{
-				corruptRebuildAttemptsRemaining--;
-				Serilog.Log.Logger.Warning(ex, "Lucene search index corrupt at {Path}. Clearing for rebuild.", SearchEngineDirectory);
-				deleteAllSearchIndexFiles(SearchEngineDirectory);
-				attempt--;
+				if (corruptRebuildAttemptsRemaining > 0)
+				{
+					corruptRebuildAttemptsRemaining--;
+					Serilog.Log.Logger.Warning(ex, "Lucene search index corrupt at {Path}. Clearing for rebuild.", SearchEngineDirectory);
+					deleteAllSearchIndexFiles(SearchEngineDirectory);
+					attempt--;
+					continue;
+				}
+
+				Serilog.Log.Logger.Error(ex,
+					"Lucene search index at {Path} remains unreadable after rebuild attempts. "
+					+ "Close Libation, delete the SearchEngine folder in your Libation files directory "
+					+ "(Settings > Open log folder), restart Libation, and scan again.",
+					SearchEngineDirectory);
+				throw;
 			}
 			catch (IOException ex) when (attempt < maxRetries - 1 && !IsRecoverableCorruptIndexException(ex))
 			{
@@ -117,6 +128,47 @@ public class SearchEngine
 				Thread.Sleep(delayMs);
 			}
 		}
+	}
+
+	/// <summary>
+	/// User-facing steps when automatic SearchEngine rebuild fails. Safe to show in message boxes.
+	/// </summary>
+	public const string ManualIndexRecoveryInstructions
+		= "Libation's search index appears corrupted and could not be rebuilt automatically.\n\n"
+		+ "1. Open Settings and click 'Open log folder'\n"
+		+ "2. Close Libation\n"
+		+ "3. Delete the SearchEngine folder in that directory\n"
+		+ "4. Restart Libation and scan again";
+
+	/// <summary>
+	/// True when <paramref name="ex"/> or an inner exception is a Lucene search-index failure that
+	/// may need the manual SearchEngine-folder recovery steps.
+	/// </summary>
+	public static bool TryFindSearchIndexFailure(Exception ex, out Exception? indexException)
+	{
+		for (var current = ex; current is not null; current = current.InnerException)
+		{
+			if (IsRecoverableCorruptIndexException(current)
+				|| (current is IOException
+					&& current.StackTrace is { } stack
+					&& stack.Contains("LibationSearchEngine", StringComparison.Ordinal)))
+			{
+				indexException = current;
+				return true;
+			}
+		}
+
+		if (ex is AggregateException aggregate)
+		{
+			foreach (var inner in aggregate.InnerExceptions)
+			{
+				if (TryFindSearchIndexFailure(inner, out indexException))
+					return true;
+			}
+		}
+
+		indexException = null;
+		return false;
 	}
 
 	/// <summary>

--- a/Source/LibationSearchEngine/SearchEngine.cs
+++ b/Source/LibationSearchEngine/SearchEngine.cs
@@ -83,7 +83,7 @@ public class SearchEngine
 		const int maxRetries = 5;
 		const int baseDelayMs = 400;
 		var libraryList = library.ToList();
-		// Corruption (e.g. checksum mismatch in segments) is not fixed by waiting; clear and rebuild immediately.
+		// Corruption (e.g. checksum mismatch / truncated segments) is not fixed by waiting; clear and rebuild immediately.
 		var corruptRebuildAttemptsRemaining = 2;
 
 		// Exponential backoff retry: 400 ms, 800 ms, 1600 ms, etc
@@ -95,13 +95,14 @@ public class SearchEngine
 				createNewIndexCore(libraryList, overwrite);
 				return;
 			}
-			catch (CorruptIndexException ex) when (corruptRebuildAttemptsRemaining-- > 0)
+			catch (Exception ex) when (IsRecoverableCorruptIndexException(ex) && corruptRebuildAttemptsRemaining > 0)
 			{
+				corruptRebuildAttemptsRemaining--;
 				Serilog.Log.Logger.Warning(ex, "Lucene search index corrupt at {Path}. Clearing for rebuild.", SearchEngineDirectory);
 				deleteAllSearchIndexFiles(SearchEngineDirectory);
 				attempt--;
 			}
-			catch (IOException ex) when (attempt < maxRetries - 1 && ex is not CorruptIndexException)
+			catch (IOException ex) when (attempt < maxRetries - 1 && !IsRecoverableCorruptIndexException(ex))
 			{
 				var delayMs = baseDelayMs * (1 << attempt);
 				// write.lock can be held by another process (e.g. second Libation instance, antivirus) or a prior writer that did not release. Retry after delay.
@@ -122,10 +123,14 @@ public class SearchEngine
 	/// Lucene 3 parses <c>segments_*</c> filenames in the index directory. Cloud sync (e.g. OneDrive) can leave debris
 	/// or conflict copies whose names break that parser, throwing <see cref="ArgumentException"/> with this message shape.
 	/// Actual error is likely to be something like: Invalid or unsupported character in number, hence this string check.
-	/// <see cref="CorruptIndexException"/> (e.g. checksum mismatch in segments) is also recoverable by deleting the index and rebuilding.
+	/// <see cref="CorruptIndexException"/> (e.g. checksum mismatch in segments) and truncated segment files
+	/// (<c>IOException: read past EOF</c>) are also recoverable by deleting the index and rebuilding.
 	/// </summary>
 	public static bool IsRecoverableCorruptIndexException(Exception ex)
 		=> ex is CorruptIndexException
+		|| (ex is IOException ioex
+			&& ioex is not CorruptIndexException
+			&& ioex.Message.Contains("read past EOF", StringComparison.OrdinalIgnoreCase))
 		|| (ex is ArgumentException aex && aex.Message.Contains("character in number", StringComparison.OrdinalIgnoreCase));
 
 	private static void deleteAllSearchIndexFiles(string searchEngineDirectory)

--- a/Source/LibationUiBase/AutoScanAuthPrompt.cs
+++ b/Source/LibationUiBase/AutoScanAuthPrompt.cs
@@ -1,0 +1,25 @@
+using System;
+using AudibleUtilities;
+
+namespace LibationUiBase;
+
+/// <summary>Shared copy for the auto-scan "login required" pause dialog.</summary>
+public static class AutoScanAuthPrompt
+{
+	public const string Caption = "Auto-scan paused - login required";
+
+	public static string FormatBody(AuthenticationRequiredException ex)
+	{
+		ArgumentNullException.ThrowIfNull(ex);
+
+		var label = AccountCredentialStatus.FormatAccountLabel(ex.Account);
+		if (AccountCredentialStatus.LooksLikeMissingCredentials(ex.Account))
+		{
+			return $"Libation could not refresh the Audible library for {label} because that account has not been logged in (or stored credentials are missing).\n\n"
+				+ "Background auto-scan has been paused. Use Import > Scan Library to log in for that account and resume periodic scans.";
+		}
+
+		return $"Libation could not refresh the Audible library for {label} because the stored login is missing or invalid.\n\n"
+			+ "Background auto-scan has been paused. Use Import > Scan Library to log in again and resume periodic scans.";
+	}
+}

--- a/Source/LibationUiBase/AutoScanRunner.cs
+++ b/Source/LibationUiBase/AutoScanRunner.cs
@@ -16,7 +16,7 @@ public sealed class AutoScanRunner
 	private readonly Func<bool> isAutoScanEnabled;
 	private readonly Action pauseTimer;
 	private readonly Action resumeTimer;
-	private readonly Func<Task>? notifyAuthRequired;
+	private readonly Func<AuthenticationRequiredException, Task>? notifyAuthRequired;
 
 	private bool pausedForAuthentication;
 
@@ -24,7 +24,7 @@ public sealed class AutoScanRunner
 		Func<bool> isAutoScanEnabled,
 		Action pauseTimer,
 		Action resumeTimer,
-		Func<Task>? notifyAuthRequired = null)
+		Func<AuthenticationRequiredException, Task>? notifyAuthRequired = null)
 	{
 		this.isAutoScanEnabled = isAutoScanEnabled;
 		this.pauseTimer = pauseTimer;
@@ -72,7 +72,9 @@ public sealed class AutoScanRunner
 		}
 		catch (Exception ex) when (AuthenticationExceptionHelper.IsAuthenticationFailure(ex))
 		{
-			await pauseForAuthenticationAsync(ex);
+			var authEx = AuthenticationExceptionHelper.FindAuthenticationRequired(ex)
+				?? new AuthenticationRequiredException(account: null, message: ex.Message, innerException: ex);
+			await pauseForAuthenticationAsync(authEx);
 		}
 		catch (Exception ex)
 		{
@@ -80,7 +82,7 @@ public sealed class AutoScanRunner
 		}
 	}
 
-	private async Task pauseForAuthenticationAsync(Exception ex)
+	private async Task pauseForAuthenticationAsync(AuthenticationRequiredException ex)
 	{
 		if (pausedForAuthentication)
 			return;
@@ -88,9 +90,11 @@ public sealed class AutoScanRunner
 		pausedForAuthentication = true;
 		pauseTimer();
 
-		Log.Warning(ex, "Auto-scan paused: Audible login is required. Log in with Import > Scan Library to resume background scans.");
+		Log.Warning(ex,
+			"Auto-scan paused: Audible login is required for {AccountLabel}. Log in with Import > Scan Library to resume background scans.",
+			AccountCredentialStatus.FormatAccountLabel(ex.Account));
 
 		if (notifyAuthRequired is not null)
-			await notifyAuthRequired();
+			await notifyAuthRequired(ex);
 	}
 }

--- a/Source/LibationUiBase/SearchIndexRecovery.cs
+++ b/Source/LibationUiBase/SearchIndexRecovery.cs
@@ -1,0 +1,17 @@
+using System;
+using LibationSearchEngine;
+
+namespace LibationUiBase;
+
+/// <summary>
+/// Shared copy for library-import failures caused by a corrupted Lucene SearchEngine index.
+/// </summary>
+public static class SearchIndexRecovery
+{
+	public const string Caption = "Error importing library";
+
+	public static string ManualRecoveryInstructions => SearchEngine.ManualIndexRecoveryInstructions;
+
+	public static bool TryFindFailure(Exception ex, out Exception? indexException)
+		=> SearchEngine.TryFindSearchIndexFailure(ex, out indexException);
+}

--- a/Source/LibationWinForms/Form1.ScanAuto.cs
+++ b/Source/LibationWinForms/Form1.ScanAuto.cs
@@ -39,26 +39,25 @@ public partial class Form1
 		Configuration.Instance.PropertyChanged += Configuration_PropertyChanged;
 	}
 
-	private void notifyAutoScanAuthRequired()
+	private void notifyAutoScanAuthRequired(AuthenticationRequiredException ex)
 	{
 		MessageBox.Show(
 			this,
-			"Libation could not refresh your Audible library because your login session expired.\n\n"
-			+ "Background auto-scan has been paused. Use Import > Scan Library to log in again to resume periodic scans.",
-			"Auto-scan paused - login required",
+			AutoScanAuthPrompt.FormatBody(ex),
+			AutoScanAuthPrompt.Caption,
 			MessageBoxButtons.OK,
 			MessageBoxIcon.Warning);
 	}
 
-	private Task notifyAutoScanAuthRequiredAsync()
+	private Task notifyAutoScanAuthRequiredAsync(AuthenticationRequiredException ex)
 	{
 		if (InvokeRequired)
 		{
-			Invoke(notifyAutoScanAuthRequired);
+			Invoke(() => notifyAutoScanAuthRequired(ex));
 			return Task.CompletedTask;
 		}
 
-		notifyAutoScanAuthRequired();
+		notifyAutoScanAuthRequired(ex);
 		return Task.CompletedTask;
 	}
 

--- a/Source/LibationWinForms/Form1.ScanManual.cs
+++ b/Source/LibationWinForms/Form1.ScanManual.cs
@@ -105,6 +105,14 @@ public partial class Form1
 					NonJsonResponseExceptionExtensions.LibraryScanFailedCaption,
 					htmlEx);
 			}
+			else if (SearchIndexRecovery.TryFindFailure(ex, out var indexEx) && indexEx is not null)
+			{
+				MessageBoxLib.ShowAdminAlert(
+					this,
+					SearchIndexRecovery.ManualRecoveryInstructions,
+					SearchIndexRecovery.Caption,
+					indexEx);
+			}
 			else
 			{
 				MessageBoxLib.ShowAdminAlert(

--- a/Source/_Tests/AudibleUtilities.Tests/AccountCredentialStatusTests.cs
+++ b/Source/_Tests/AudibleUtilities.Tests/AccountCredentialStatusTests.cs
@@ -1,0 +1,41 @@
+using AudibleUtilities;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace AudibleUtilities.Tests;
+
+[TestClass]
+public class AccountCredentialStatusTests
+{
+	[TestMethod]
+	public void LooksLikeMissingCredentials_null_account()
+	{
+		Assert.IsTrue(AccountCredentialStatus.LooksLikeMissingCredentials(null));
+	}
+
+	[TestMethod]
+	public void LooksLikeMissingCredentials_null_tokens()
+	{
+		var account = new Account("user@example.com") { AccountName = "User" };
+		Assert.IsTrue(AccountCredentialStatus.LooksLikeMissingCredentials(account));
+	}
+
+	[TestMethod]
+	public void FormatAccountLabel_uses_name_and_id()
+	{
+		var account = new Account("user@example.com") { AccountName = "Jade" };
+		Assert.AreEqual("'Jade' (user@example.com)", AccountCredentialStatus.FormatAccountLabel(account));
+	}
+
+	[TestMethod]
+	public void FormatAccountLabel_falls_back_to_id()
+	{
+		var account = new Account("user@example.com");
+		Assert.AreEqual("'user@example.com'", AccountCredentialStatus.FormatAccountLabel(account));
+	}
+
+	[TestMethod]
+	public void FormatAccountLabel_null_account()
+	{
+		Assert.AreEqual("an Audible account", AccountCredentialStatus.FormatAccountLabel(null));
+	}
+}

--- a/Source/_Tests/AudibleUtilities.Tests/AuthenticationExceptionHelperTests.cs
+++ b/Source/_Tests/AudibleUtilities.Tests/AuthenticationExceptionHelperTests.cs
@@ -1,0 +1,34 @@
+using System;
+using AudibleUtilities;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace AudibleUtilities.Tests;
+
+[TestClass]
+public class AuthenticationExceptionHelperTests
+{
+	[TestMethod]
+	public void FindAuthenticationRequired_finds_nested()
+	{
+		var account = new Account("user@example.com");
+		var inner = new AuthenticationRequiredException(account, "need login");
+		var outer = new Exception("wrapper", inner);
+
+		var found = AuthenticationExceptionHelper.FindAuthenticationRequired(outer);
+		Assert.AreSame(inner, found);
+	}
+
+	[TestMethod]
+	public void FindAuthenticationRequired_returns_null_when_absent()
+	{
+		var ex = new InvalidOperationException("unrelated");
+		Assert.IsNull(AuthenticationExceptionHelper.FindAuthenticationRequired(ex));
+	}
+
+	[TestMethod]
+	public void IsAuthenticationFailure_detects_AuthenticationRequiredException()
+	{
+		var ex = new AuthenticationRequiredException(new Account("user@example.com"));
+		Assert.IsTrue(AuthenticationExceptionHelper.IsAuthenticationFailure(ex));
+	}
+}

--- a/Source/_Tests/LibationSearchEngine.Tests/RecoverableCorruptIndexExceptionTests.cs
+++ b/Source/_Tests/LibationSearchEngine.Tests/RecoverableCorruptIndexExceptionTests.cs
@@ -50,4 +50,29 @@ public class RecoverableCorruptIndexExceptionTests
 		var ex = new InvalidOperationException("something else");
 		Assert.IsFalse(SearchEngine.IsRecoverableCorruptIndexException(ex));
 	}
+
+	[TestMethod]
+	public void TryFindSearchIndexFailure_finds_nested_read_past_EOF()
+	{
+		var inner = new IOException("read past EOF");
+		var outer = new Exception("Error importing library", inner);
+
+		Assert.IsTrue(SearchEngine.TryFindSearchIndexFailure(outer, out var found));
+		Assert.AreSame(inner, found);
+	}
+
+	[TestMethod]
+	public void TryFindSearchIndexFailure_ignores_unrelated_exceptions()
+	{
+		var ex = new InvalidOperationException("not an index problem");
+		Assert.IsFalse(SearchEngine.TryFindSearchIndexFailure(ex, out var found));
+		Assert.IsNull(found);
+	}
+
+	[TestMethod]
+	public void ManualIndexRecoveryInstructions_mentions_SearchEngine_folder()
+	{
+		StringAssert.Contains(SearchEngine.ManualIndexRecoveryInstructions, "SearchEngine");
+		StringAssert.Contains(SearchEngine.ManualIndexRecoveryInstructions, "Open log folder");
+	}
 }

--- a/Source/_Tests/LibationSearchEngine.Tests/RecoverableCorruptIndexExceptionTests.cs
+++ b/Source/_Tests/LibationSearchEngine.Tests/RecoverableCorruptIndexExceptionTests.cs
@@ -1,0 +1,53 @@
+using System;
+using System.IO;
+using LibationSearchEngine;
+using Lucene.Net.Index;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace SearchEngineTests;
+
+[TestClass]
+public class RecoverableCorruptIndexExceptionTests
+{
+	[TestMethod]
+	public void CorruptIndexException_is_recoverable()
+	{
+		var ex = new CorruptIndexException("checksum mismatch in segments file");
+		Assert.IsTrue(SearchEngine.IsRecoverableCorruptIndexException(ex));
+	}
+
+	[TestMethod]
+	public void ReadPastEof_IOException_is_recoverable()
+	{
+		var ex = new IOException("read past EOF");
+		Assert.IsTrue(SearchEngine.IsRecoverableCorruptIndexException(ex));
+	}
+
+	[TestMethod]
+	public void ReadPastEof_IOException_is_recoverable_case_insensitive()
+	{
+		var ex = new IOException("Read Past Eof while filling buffer");
+		Assert.IsTrue(SearchEngine.IsRecoverableCorruptIndexException(ex));
+	}
+
+	[TestMethod]
+	public void CharacterInNumber_ArgumentException_is_recoverable()
+	{
+		var ex = new ArgumentException("Invalid or unsupported character in number");
+		Assert.IsTrue(SearchEngine.IsRecoverableCorruptIndexException(ex));
+	}
+
+	[TestMethod]
+	public void Unrelated_IOException_is_not_recoverable()
+	{
+		var ex = new IOException("The process cannot access the file because it is being used by another process.");
+		Assert.IsFalse(SearchEngine.IsRecoverableCorruptIndexException(ex));
+	}
+
+	[TestMethod]
+	public void Unrelated_Exception_is_not_recoverable()
+	{
+		var ex = new InvalidOperationException("something else");
+		Assert.IsFalse(SearchEngine.IsRecoverableCorruptIndexException(ex));
+	}
+}

--- a/Source/_Tests/LibationUiBase.Tests/AutoScanAuthPromptTests.cs
+++ b/Source/_Tests/LibationUiBase.Tests/AutoScanAuthPromptTests.cs
@@ -1,0 +1,33 @@
+using AudibleUtilities;
+using LibationUiBase;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace LibationUiBase.Tests;
+
+[TestClass]
+public class AutoScanAuthPromptTests
+{
+	[TestMethod]
+	public void FormatBody_missing_credentials_mentions_not_logged_in()
+	{
+		var account = new Account("jade@example.com") { AccountName = "Jade" };
+		var ex = new AuthenticationRequiredException(account, "missing");
+
+		var body = AutoScanAuthPrompt.FormatBody(ex);
+
+		StringAssert.Contains(body, "Jade");
+		StringAssert.Contains(body, "jade@example.com");
+		StringAssert.Contains(body, "has not been logged in");
+		StringAssert.Contains(body, "Import > Scan Library");
+	}
+
+	[TestMethod]
+	public void FormatBody_null_account_uses_generic_label()
+	{
+		var ex = new AuthenticationRequiredException(null, "auth failed");
+		var body = AutoScanAuthPrompt.FormatBody(ex);
+
+		StringAssert.Contains(body, "an Audible account");
+		StringAssert.Contains(body, "has not been logged in");
+	}
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes #1946 (search-index import failure; also improves related auto-scan auth UX).

## Summary
- Treat Lucene `IOException: read past EOF` as recoverable search-index corruption: clear `SearchEngine` and rebuild instead of retrying as a lock conflict.
- When rebuild attempts are exhausted, log and show manual steps to delete the `SearchEngine` folder.
- Improve auto-scan auth pause dialog: name the account and distinguish missing/never-logged-in credentials from a generic expired-session message.

## Commits
1. Lucene EOF recovery + detector unit tests
2. Manual SearchEngine recovery hint (log + import dialog)
3. Auto-scan auth prompt / missing-credentials UX

## Testing
- `dotnet test --project Source/_Tests/LibationSearchEngine.Tests/...` (new recoverable-index tests)
- `dotnet test --project Source/_Tests/AudibleUtilities.Tests/...` (credential/auth helpers)
- `dotnet test --project Source/_Tests/LibationUiBase.Tests/...` (auto-scan prompt copy)
- `dotnet build Source/LibationAvalonia/LibationAvalonia.csproj`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5cb10651-69fc-4fb6-84a8-b3c0678b17e2?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5cb10651-69fc-4fb6-84a8-b3c0678b17e2&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

