### PR TITLE
docs(faq): clarify Audible Standard after subscription ends

### DIFF
--- a/docs/frequently-asked-questions.md
+++ b/docs/frequently-asked-questions.md
@@ -111,6 +111,6 @@ Libation no longer requests spatial/Atmos from Audible (see [Spatial Audio, Dolb
 
 For spatial files you already have, see [Playing spatial files you already have](./advanced/spatial-audio.md#playing-spatial-files-you-already-have) and [Supported Media Players](./features/audio-file-formats.md#supported-media-players).
 
-## Does Libation work with books from Audible Standard?
+### Does Libation work with books from Audible Standard?
 
-Yes, at least while the subscription is active. Not yet tested without a subscription.
+Yes, while the subscription is active. After the subscription becomes inactive, Libation cannot get a license and so does not download those books.

--- a/docs/frequently-asked-questions.md
+++ b/docs/frequently-asked-questions.md
@@ -110,3 +110,7 @@ No. **Use Widevine DRM** unlocks **Request xHE-AAC Codec** for higher-bitrate st
 Libation no longer requests spatial/Atmos from Audible (see [Spatial Audio, Dolby Atmos, and Widevine DRM](./advanced/spatial-audio.md)). Books you liberated before 13.1.3 may be E-AC-3 or AC-4; newer downloads are stereo unless you kept older files.
 
 For spatial files you already have, see [Playing spatial files you already have](./advanced/spatial-audio.md#playing-spatial-files-you-already-have) and [Supported Media Players](./features/audio-file-formats.md#supported-media-players).
+
+## Does Libation work with books from Audible Standard?
+
+Yes, at least while the subscription is active. Not yet tested without a subscription.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Updates the Audible Standard FAQ entry from #1948 to reflect [@wtanksleyjr](https://github.com/wtanksleyjr)'s testing: once the subscription is inactive, Libation cannot get a license and does not download those books.

Also aligns the heading level with the other FAQ entries (`###`).

This branch includes tippfehlr's original FAQ addition plus the clarification, so it can supersede #1948.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f69d8d81-51cf-4afd-bb17-bbfb8c0d1b36?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f69d8d81-51cf-4afd-bb17-bbfb8c0d1b36&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

