### PR TITLE
Keep real metadata when Audible's catalog is empty, verify PDFs, and set PDF status on its own

### DIFF
--- a/Source/FileLiberator/DownloadDecryptBook.cs
+++ b/Source/FileLiberator/DownloadDecryptBook.cs
@@ -525,6 +525,24 @@ public class DownloadDecryptBook : AudioDecodable, IProcessable<DownloadDecryptB
 
 		try
 		{
+			// Fetched before the destination is touched. A storefront that no longer lists the title answers
+			// with an empty product, and the file already on disk is then the better of the two.
+			var item = await api.GetCatalogProductAsync(options.LibraryBook.Book.AudibleProductId, AudibleApi.CatalogOptions.ResponseGroupOptions.ALL_OPTIONS);
+
+			if (item?.SourceJson is not { } sourceJson)
+			{
+				Serilog.Log.Logger.Error("Failed to retrieve metadata from server for {@Book}.", options.LibraryBook.LogFriendly());
+				return;
+			}
+
+			if (CatalogProductIsEmpty(sourceJson))
+			{
+				Serilog.Log.Logger.Warning(
+					"Audible's catalog holds no details for {@Book}, so its metadata file was left as it was. This happens when the title is no longer listed in the storefront of the account that owns it.",
+					options.LibraryBook.LogFriendly());
+				return;
+			}
+
 			metadataPath
 				= AudibleFileStorage.Audio.GetCustomDirFilename(
 					options.LibraryBook,
@@ -535,13 +553,6 @@ public class DownloadDecryptBook : AudioDecodable, IProcessable<DownloadDecryptB
 			if (File.Exists(metadataPath))
 				FileUtility.SaferDelete(metadataPath);
 
-			var item = await api.GetCatalogProductAsync(options.LibraryBook.Book.AudibleProductId, AudibleApi.CatalogOptions.ResponseGroupOptions.ALL_OPTIONS);
-
-			if (item?.SourceJson is not { } sourceJson)
-			{
-				Serilog.Log.Logger.Error("Failed to retrieve metadata from server for {@Book}.", options.LibraryBook.LogFriendly());
-				return;
-			}
 			sourceJson.Add(nameof(ContentMetadata.ChapterInfo), Newtonsoft.Json.Linq.JObject.FromObject(options.ContentMetadata.ChapterInfo));
 			sourceJson.Add(nameof(ContentMetadata.ContentReference), Newtonsoft.Json.Linq.JObject.FromObject(options.ContentMetadata.ContentReference));
 
@@ -558,6 +569,24 @@ public class DownloadDecryptBook : AudioDecodable, IProcessable<DownloadDecryptB
 			throw;
 		}
 	}
+
+	/// <summary>
+	/// Whether a catalog product carries no details at all.
+	/// <para>
+	/// A storefront that no longer lists a title still answers a request for it: HTTP 200, total_results 1,
+	/// and a product holding an asin and a handful of always-returned flags. Nothing between the request and
+	/// the file notices, so a re-download of such a title used to replace a metadata file written while the
+	/// title was still listed - the only copy of that data - with the placeholder. Reported in issue #1947,
+	/// where a Canada-only title produced
+	/// <c>{"asin":"...","asset_details":[],"is_preview_enabled":false,"is_vvab":false,"rating":{...zeros...}}</c>.
+	/// </para>
+	/// <para>
+	/// Keyed off the title because every response group that returns anything descriptive returns one, and
+	/// the placeholder's own fields are Audible's to change.
+	/// </para>
+	/// </summary>
+	internal static bool CatalogProductIsEmpty(Newtonsoft.Json.Linq.JObject sourceJson)
+		=> string.IsNullOrWhiteSpace(sourceJson.Value<string>("title"));
 	#endregion
 
 	#region Macros

--- a/Source/FileLiberator/DownloadPdf.cs
+++ b/Source/FileLiberator/DownloadPdf.cs
@@ -1,7 +1,9 @@
 ﻿using ApplicationServices;
 using DataLayer;
+using Dinah.Core;
 using Dinah.Core.ErrorHandling;
 using Dinah.Core.Net.Http;
+using FileManager;
 using LibationFileManager;
 using System;
 using System.IO;
@@ -32,10 +34,18 @@ public class DownloadPdf : Processable, IProcessable<DownloadPdf>
 
 			if (result.IsSuccess)
 			{
+				OnFileCreated(libraryBook, actualDownloadedFilePath);
 				SetFileTime(libraryBook, actualDownloadedFilePath);
 				if (Path.GetDirectoryName(actualDownloadedFilePath) is string outputDir)
 					SetDirectoryTime(libraryBook, outputDir);
 			}
+			else
+			{
+				// Keeping it would leave a file in the library that is not the supplement, under a name that
+				// says it is, and would stop the folder cleanup below from running.
+				FileUtility.SaferDelete(actualDownloadedFilePath);
+			}
+
 			await libraryBook.UpdatePdfStatusAsync(result.IsSuccess ? LiberatedStatus.Liberated : LiberatedStatus.NotLiberated);
 
 			return result;
@@ -119,16 +129,51 @@ public class DownloadPdf : Processable, IProcessable<DownloadPdf>
 		var client = new HttpClient();
 
 		var actualDownloadedFilePath = await client.DownloadFileAsync(downloadUrl, proposedDownloadFilePath, progress);
-		OnFileCreated(libraryBook, actualDownloadedFilePath);
 
 		OnStatusUpdate(actualDownloadedFilePath);
 		return actualDownloadedFilePath;
 	}
 
-	private static StatusHandler verifyDownload(string actualDownloadedFilePath)
-		=> !File.Exists(actualDownloadedFilePath)
-		? new StatusHandler { "Downloaded PDF cannot be found" }
-		: new StatusHandler();
+	/// <summary>
+	/// That the file exists says only that the server sent a body, and an Audible error is a 200 with a JSON
+	/// body like any other response. Dinah's downloader renames by Content-Disposition, so such a body lands
+	/// in the book's folder under whatever Audible called it and the title is recorded as having its PDF.
+	/// <para>
+	/// A supplement is whatever its URL says it is, usually a PDF and occasionally an archive, so only a file
+	/// named .pdf is held to the PDF header. Everything else is checked for the one thing no supplement of
+	/// any kind starts with: the opening character of a JSON or markup document.
+	/// </para>
+	/// </summary>
+	internal static StatusHandler verifyDownload(string actualDownloadedFilePath)
+	{
+		if (!File.Exists(actualDownloadedFilePath))
+			return new StatusHandler { "Downloaded PDF cannot be found" };
+
+		var firstBytes = readFirstBytes(actualDownloadedFilePath);
+
+		if (firstBytes.Length == 0)
+			return new StatusHandler { "Downloaded PDF is empty" };
+
+		if (Path.GetExtension(actualDownloadedFilePath).EqualsInsensitive(".pdf")
+			&& !firstBytes.AsSpan().StartsWith("%PDF"u8))
+			return new StatusHandler { "What Audible returned is not a PDF. Nothing was saved; the PDF is still marked as not downloaded." };
+
+		if (firstBytes[0] is (byte)'{' or (byte)'[' or (byte)'<')
+			return new StatusHandler { "Audible returned a document instead of the supplement. Nothing was saved; the PDF is still marked as not downloaded." };
+
+		return new StatusHandler();
+	}
+
+	/// <summary>Enough to recognise a file signature, and past a byte-order mark if the body carries one.</summary>
+	private static byte[] readFirstBytes(string path)
+	{
+		var buffer = new byte[8];
+
+		using var stream = File.OpenRead(path);
+		var read = buffer[..stream.ReadAtLeast(buffer, buffer.Length, throwOnEndOfStream: false)];
+
+		return read.AsSpan().StartsWith("\uFEFF"u8) ? read[3..] : read;
+	}
 
 	public static DownloadPdf Create(Configuration config) => new() { Configuration = config };
 	private DownloadPdf() { }

--- a/Source/LibationAvalonia/Views/ProductsDisplay.axaml.cs
+++ b/Source/LibationAvalonia/Views/ProductsDisplay.axaml.cs
@@ -322,6 +322,26 @@ public partial class ProductsDisplay : UserControl
 		});
 
 		#endregion
+		#region Set PDF status, without touching the audiobook
+
+		if (ctx.ShowPdfStatusItems)
+		{
+			args.ContextMenuItems.Add(new MenuItem()
+			{
+				Header = ctx.SetPdfDownloadedText,
+				IsEnabled = ctx.SetPdfDownloadedEnabled,
+				Command = ReactiveCommand.Create(ctx.SetPdfDownloaded)
+			});
+
+			args.ContextMenuItems.Add(new MenuItem()
+			{
+				Header = ctx.SetPdfNotDownloadedText,
+				IsEnabled = ctx.SetPdfNotDownloadedEnabled,
+				Command = ReactiveCommand.Create(ctx.SetPdfNotDownloaded)
+			});
+		}
+
+		#endregion
 		#region Locate file (Single book only)
 
 		if (entries.Length == 1 && entries[0] is LibraryBookEntry entry)

--- a/Source/LibationUiBase/GridView/GridContextMenu.cs
+++ b/Source/LibationUiBase/GridView/GridContextMenu.cs
@@ -19,6 +19,8 @@ public class GridContextMenu
 	public string LiberateEpisodesText => $"{Accelerator}Liberate All Episodes";
 	public string SetDownloadedText => $"Set Download status to '{Accelerator}Downloaded'";
 	public string SetNotDownloadedText => $"Set Download status to '{Accelerator}Not Downloaded'";
+	public string SetPdfDownloadedText => "Set PDF status to 'Downloaded'";
+	public string SetPdfNotDownloadedText => "Set PDF status to 'Not Downloaded'";
 	public string RemoveText => $"{Accelerator}Remove from library";
 	public string RemoveFromAudibleText => $"Remove Plus {(GridEntries.Count(e => e.LibraryBook.IsAudiblePlus) == 1 ? "Book" : "Books")} from Audible Library";
 	public string LocateFileText => $"{Accelerator}Locate file...";
@@ -39,6 +41,19 @@ public class GridContextMenu
 	public bool LiberateEpisodesEnabled => GridEntries.OfType<SeriesEntry>().Any(sEntry => sEntry.Children.Any(c => c.Liberate?.BookStatus is LiberatedStatus.NotLiberated or LiberatedStatus.PartialDownload));
 	public bool SetDownloadedEnabled => LibraryBookEntries.Any(ge => ge.Book?.UserDefinedItem.BookStatus != LiberatedStatus.Liberated || ge.Liberate?.IsSeries is true);
 	public bool SetNotDownloadedEnabled => LibraryBookEntries.Any(ge => ge.Book?.UserDefinedItem.BookStatus != LiberatedStatus.NotLiberated || ge.Liberate?.IsSeries is true);
+
+	/// <summary>
+	/// Whether to offer the PDF status on its own. The pair above deliberately moves both statuses together,
+	/// which left a user who wanted only the PDF back with no way to say so: resetting a title's PDF also
+	/// queued its audiobook for a fresh download, and that download rewrote the title's other files. Offered
+	/// only for a selection that has a PDF, since for anything else the pair above is already audio-only.
+	/// </summary>
+	public bool ShowPdfStatusItems => PdfItems.Any();
+	public bool SetPdfDownloadedEnabled => PdfItems.Any(udi => udi.PdfStatus != LiberatedStatus.Liberated);
+	public bool SetPdfNotDownloadedEnabled => PdfItems.Any(udi => udi.PdfStatus != LiberatedStatus.NotLiberated);
+
+	private IEnumerable<UserDefinedItem> PdfItems
+		=> LibraryBookEntries.Select(ge => ge.Book?.UserDefinedItem).OfType<UserDefinedItem>().Where(udi => udi.Book.HasPdf);
 	public bool ConvertToMp3Enabled => LibraryBookEntries.Any(ge => ge.Book?.UserDefinedItem.BookStatus is LiberatedStatus.Liberated);
 	public bool DownloadBookEnabled => LibraryBookEntries.Any(ge => ge.LibraryBook.NeedsBookDownload || ge.LibraryBook.NeedsPdfDownload);
 	public bool DownloadAsChaptersEnabled => LibraryBookEntries.Any(ge => ge.Book?.UserDefinedItem.BookStatus is not LiberatedStatus.Error);
@@ -83,6 +98,20 @@ public class GridContextMenu
 				udi.BookStatus = LiberatedStatus.NotLiberated;
 				if (udi.Book.HasPdf)
 					udi.SetPdfStatus(LiberatedStatus.NotLiberated);
+			});
+	}
+
+	public void SetPdfDownloaded() => setPdfStatus(LiberatedStatus.Liberated);
+
+	public void SetPdfNotDownloaded() => setPdfStatus(LiberatedStatus.NotLiberated);
+
+	private void setPdfStatus(LiberatedStatus pdfStatus)
+	{
+		LibraryBookEntries.Select(e => e.LibraryBook)
+			.UpdateUserDefinedItemAsync(udi =>
+			{
+				if (udi.Book.HasPdf)
+					udi.SetPdfStatus(pdfStatus);
 			});
 	}
 

--- a/Source/LibationWinForms/GridView/ProductsDisplay.cs
+++ b/Source/LibationWinForms/GridView/ProductsDisplay.cs
@@ -162,6 +162,28 @@ public partial class ProductsDisplay : UserControl
 		ctxMenu.Items.Add(setNotDownloadMenuItem);
 
 		#endregion
+		#region Set PDF status, without touching the audiobook
+
+		if (ctx.ShowPdfStatusItems)
+		{
+			var setPdfDownloadMenuItem = new ToolStripMenuItem()
+			{
+				Text = ctx.SetPdfDownloadedText,
+				Enabled = ctx.SetPdfDownloadedEnabled
+			};
+			setPdfDownloadMenuItem.Click += (_, _) => ctx.SetPdfDownloaded();
+			ctxMenu.Items.Add(setPdfDownloadMenuItem);
+
+			var setPdfNotDownloadMenuItem = new ToolStripMenuItem()
+			{
+				Text = ctx.SetPdfNotDownloadedText,
+				Enabled = ctx.SetPdfNotDownloadedEnabled
+			};
+			setPdfNotDownloadMenuItem.Click += (_, _) => ctx.SetPdfNotDownloaded();
+			ctxMenu.Items.Add(setPdfNotDownloadMenuItem);
+		}
+
+		#endregion
 		#region Locate file (Single book only)
 
 		if (entries.Length == 1 && entries[0] is LibraryBookEntry entry)

--- a/Source/_Tests/FileLiberator.Tests/CatalogMetadataTests.cs
+++ b/Source/_Tests/FileLiberator.Tests/CatalogMetadataTests.cs
@@ -1,0 +1,73 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Newtonsoft.Json.Linq;
+
+namespace FileLiberator.Tests;
+
+/// <summary>
+/// Recognising the placeholder product Audible returns for a title its storefront no longer lists, so a
+/// re-download of that title does not replace a real metadata file with the placeholder. Reported in
+/// issue #1947.
+/// </summary>
+[TestClass]
+public class CatalogMetadataTests
+{
+	/// <summary>
+	/// Verbatim from <c>api.audible.com/1.0/catalog/products/?asins=B089T8FSK6&amp;response_groups=&lt;all&gt;</c>,
+	/// the response behind the empty metadata file in the report. The title itself is real and downloadable;
+	/// it is only listed in the Canadian storefront, so every other one answers with this.
+	/// </summary>
+	private const string DelistedProduct = """
+		{
+			"asin": "B089T8FSK6",
+			"asset_details": [],
+			"is_preview_enabled": false,
+			"is_vvab": false,
+			"rating": {
+				"num_reviews": 0,
+				"overall_distribution": { "average_rating": 0.0, "display_stars": 0.0, "num_ratings": 0 },
+				"performance_distribution": { "average_rating": 0.0, "display_stars": 0.0, "num_ratings": 0 },
+				"story_distribution": { "average_rating": 0.0, "display_stars": 0.0, "num_ratings": 0 }
+			}
+		}
+		""";
+
+	/// <summary>The same asin from the one storefront that still lists it, trimmed to the fields that matter here.</summary>
+	private const string ListedProduct = """
+		{
+			"asin": "B089T8FSK6",
+			"asset_details": [],
+			"authors": [ { "asin": "B002BMEJ9I", "name": "David D. Friedman" } ],
+			"content_type": "Product",
+			"is_vvab": false,
+			"publisher_name": "David Friedman",
+			"release_date": "2020-06-10",
+			"runtime_length_min": 610,
+			"subtitle": "Technology and Freedom in an Uncertain World",
+			"title": "Future Imperfect"
+		}
+		""";
+
+	[TestMethod]
+	public void A_delisted_titles_placeholder_product_is_empty()
+		=> Assert.IsTrue(DownloadDecryptBook.CatalogProductIsEmpty(JObject.Parse(DelistedProduct)));
+
+	[TestMethod]
+	public void A_product_the_storefront_still_lists_is_not_empty()
+		=> Assert.IsFalse(DownloadDecryptBook.CatalogProductIsEmpty(JObject.Parse(ListedProduct)));
+
+	[TestMethod]
+	public void A_product_with_nothing_at_all_is_empty()
+		=> Assert.IsTrue(DownloadDecryptBook.CatalogProductIsEmpty(JObject.Parse("""{ "asin": "B089T8FSK6" }""")));
+
+	[TestMethod]
+	public void A_title_of_whitespace_counts_as_no_title()
+		=> Assert.IsTrue(DownloadDecryptBook.CatalogProductIsEmpty(JObject.Parse("""{ "asin": "B089T8FSK6", "title": "   " }""")));
+
+	/// <summary>
+	/// A product carrying nothing but its title is thin, but it is data Audible sent and the user asked for.
+	/// The guard only rejects the placeholder.
+	/// </summary>
+	[TestMethod]
+	public void A_product_with_only_a_title_is_kept()
+		=> Assert.IsFalse(DownloadDecryptBook.CatalogProductIsEmpty(JObject.Parse("""{ "asin": "B089T8FSK6", "title": "Future Imperfect" }""")));
+}

--- a/Source/_Tests/FileLiberator.Tests/DownloadPdfVerificationTests.cs
+++ b/Source/_Tests/FileLiberator.Tests/DownloadPdfVerificationTests.cs
@@ -1,0 +1,98 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.IO;
+using System.Text;
+
+namespace FileLiberator.Tests;
+
+/// <summary>
+/// What counts as a supplement having been downloaded. Reported in issue #1947: an Audible response that was
+/// not the PDF was saved into the book's folder and the title recorded as having its PDF.
+/// </summary>
+[TestClass]
+public class DownloadPdfVerificationTests
+{
+	private string directory = string.Empty;
+
+	[TestInitialize]
+	public void Initialize()
+	{
+		directory = Path.Combine(Path.GetTempPath(), $"libation-pdf-verify-tests-{Guid.NewGuid():N}");
+		Directory.CreateDirectory(directory);
+	}
+
+	[TestCleanup]
+	public void Cleanup()
+	{
+		try
+		{
+			Directory.Delete(directory, recursive: true);
+		}
+		catch (IOException)
+		{
+			// A leftover temp directory is not worth failing a test over.
+		}
+	}
+
+	private string Write(string fileName, byte[] contents)
+	{
+		var path = Path.Combine(directory, fileName);
+		File.WriteAllBytes(path, contents);
+		return path;
+	}
+
+	private string Write(string fileName, string contents) => Write(fileName, Encoding.UTF8.GetBytes(contents));
+
+	private static byte[] Pdf => Encoding.ASCII.GetBytes("%PDF-1.4\n1 0 obj\n<< >>\nendobj\n");
+
+	[TestMethod]
+	public void A_real_pdf_passes()
+		=> Assert.IsTrue(DownloadPdf.verifyDownload(Write("book.pdf", Pdf)).IsSuccess);
+
+	[TestMethod]
+	public void A_file_that_is_not_there_fails()
+		=> Assert.IsFalse(DownloadPdf.verifyDownload(Path.Combine(directory, "never-written.pdf")).IsSuccess);
+
+	[TestMethod]
+	public void An_empty_file_fails()
+		=> Assert.IsFalse(DownloadPdf.verifyDownload(Write("book.pdf", Array.Empty<byte>())).IsSuccess);
+
+	[TestMethod]
+	public void A_file_named_pdf_that_is_not_a_pdf_fails()
+		=> Assert.IsFalse(DownloadPdf.verifyDownload(Write("book.pdf", "Not a PDF at all")).IsSuccess);
+
+	/// <summary>
+	/// The reported failure. Dinah's downloader renames by Content-Disposition, so an Audible JSON body does
+	/// not even arrive named .pdf and an extension check alone would wave it through.
+	/// </summary>
+	[TestMethod]
+	public void An_audible_json_body_fails_whatever_it_is_named()
+	{
+		const string body = """{"asin":"B089T8FSK6","asset_details":[],"is_preview_enabled":false,"is_vvab":false}""";
+
+		Assert.IsFalse(DownloadPdf.verifyDownload(Write("book.json", body)).IsSuccess);
+		Assert.IsFalse(DownloadPdf.verifyDownload(Write("book.pdf", body)).IsSuccess);
+	}
+
+	[TestMethod]
+	public void A_json_body_behind_a_byte_order_mark_fails()
+		=> Assert.IsFalse(DownloadPdf.verifyDownload(Write("book.json", Encoding.UTF8.GetPreamble().Concat("""{"asin":"B089T8FSK6"}"""))).IsSuccess);
+
+	[TestMethod]
+	public void A_login_page_fails()
+		=> Assert.IsFalse(DownloadPdf.verifyDownload(Write("book.html", "<!DOCTYPE html><html><body>Sign in</body></html>")).IsSuccess);
+
+	/// <summary>
+	/// A supplement is whatever its URL says it is, so a non-PDF one is only rejected when it looks like a
+	/// document Audible sent instead of the file. This is a zip's signature.
+	/// </summary>
+	[TestMethod]
+	public void A_non_pdf_supplement_passes()
+		=> Assert.IsTrue(DownloadPdf.verifyDownload(Write("book.zip", [0x50, 0x4B, 0x03, 0x04, 0x14, 0x00])).IsSuccess);
+}
+
+file static class ByteExtensions
+{
+	public static byte[] Concat(this byte[] first, string second)
+		=> [.. first, .. Encoding.UTF8.GetBytes(second)];
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Follow-up to the report in #1947 that a PDF download left behind a `.metadata.json` containing nothing but an ASIN.

## What that file is

Libation's own "Save audiobook metadata to metadata.json" output. `DownloadDecryptBook.DownloadMetadataAsync` is the only place that writes a `.metadata.json`, and the only caller of `GetCatalogProductAsync`. The PDF path cannot produce that name: the only renaming it does is `Path.ChangeExtension(proposed, Path.GetExtension(headerFilename))` inside Dinah's downloader, which yields a single extension.

Its contents are the verbatim catalog response, reproducible against the public endpoint:

```
curl "https://api.audible.com/1.0/catalog/products/?asins=B089T8FSK6&response_groups=<all>"
{"products":[{"asin":"B089T8FSK6","asset_details":[],"is_preview_enabled":false,"is_vvab":false,
 "rating":{"num_reviews":0,...all zeros...}}],"total_results":1}
```

The title is real ("Future Imperfect", David D. Friedman) and `api.audible.ca` returns the full record. Every other storefront answers with that placeholder: HTTP 200, `total_results: 1`, a product with an ASIN and nothing else. Libation's only guard was `item?.SourceJson is not { }`, which the placeholder passes, so any download of a title the storefront does not list writes the placeholder - over a real metadata file, if one was there.

The reporter has since confirmed no audiobook re-downloaded during his run, so what put that particular file on his disk is still open; it is most likely the original download of a title that has never had a catalog record in his storefront. The overwrite is a real hazard either way, and the guard is the same.

## Changes

- **`DownloadDecryptBook.DownloadMetadataAsync`** fetches the product before touching the destination and leaves the existing file alone when the product carries no title, logging why. Keyed off the title because every response group that returns anything descriptive returns one, and the placeholder's own fields are Audible's to change.
- **`DownloadPdf.verifyDownload`** checks the payload instead of only `File.Exists`. A file named `.pdf` must carry the `%PDF` header, and nothing may begin with the opening character of a JSON or markup document - an Audible error body is a 200 like any other, and Dinah's downloader renames by `Content-Disposition`, so it does not even arrive named `.pdf`. A rejected download is deleted rather than left in the library, which also lets the empty-folder cleanup run, and the file is added to the path cache only after it passes. Non-PDF supplements such as a `.zip` still pass.
- **Grid context menu** gains "Set PDF status to 'Downloaded'" / "'Not Downloaded'", shown only for a selection that has a PDF. A separate footgun found on the way in, not the cause of the report: the existing pair moves both statuses together, so resetting one title's PDF from the grid also queues its audiobook for a fresh download. `Visible Books > Set PDF 'Downloaded' status manually` was already PDF-only, but applies to everything on screen. Wired into both the Avalonia and WinForms grids.

## Testing

`dotnet test` from `Source/`: 1409 tests, 0 failures. 15 new tests cover recognising the placeholder product against the real response bodies from both storefronts, and every supplement payload shape (real PDF, empty, mislabelled `.pdf`, JSON under either name, JSON behind a byte-order mark, a login page, and a zip).

Setting a title's PDF status on its own, against a seeded demo library. Row "03 Green | PDF done | purchased" keeps its green audiobook lamp while its PDF glyph gains the download arrow, matching row 05:

[set_pdf_status_leaves_audiobook_status_alone.mp4](https://cursor.com/agents/bc-5389a423-a4e5-45b7-b102-80795781ffa6/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fset_pdf_status_leaves_audiobook_status_alone.mp4)

The database confirms only the PDF moved - `BookStatus` stayed `Liberated`, `PdfStatus` went `Liberated` to `NotLiberated`, and the neighbouring row was untouched:

```
AudibleProductId  Title                            BookStatus  PdfStatus     (before -> after)
DEMO003           03 Green | PDF done | purchased  1           1  ->  0
DEMO004           04 Green | PDF done | PLUS       1           1  ->  1
```

The new items appear only for a title that has a PDF, and each is disabled when the PDF is already in that state:

[Context menu on a book with a PDF, showing both Set Download status items and both new Set PDF status items](https://cursor.com/agents/bc-5389a423-a4e5-45b7-b102-80795781ffa6/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fpdf_status_menu_book_with_pdf.webp)

[Context menu on a book with no PDF, showing only the two Set Download status items](https://cursor.com/agents/bc-5389a423-a4e5-45b7-b102-80795781ffa6/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fpdf_status_menu_book_without_pdf.webp)

Live catalog responses behind the metadata fix: `/opt/cursor/artifacts/audible_catalog_response_B089T8FSK6.log`


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5389a423-a4e5-45b7-b102-80795781ffa6?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5389a423-a4e5-45b7-b102-80795781ffa6&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

