### PR TITLE
Adopt Dinah.Core 10.2.2.1 and AudibleApi 11.0.0.1

### DIFF
--- a/Source/AudibleUtilities/Account.cs
+++ b/Source/AudibleUtilities/Account.cs
@@ -1,13 +1,16 @@
 ﻿using AudibleApi;
 using AudibleApi.Authorization;
 using Dinah.Core;
+using Dinah.Core.Security;
+using LibationFileManager;
 using Newtonsoft.Json;
 using System;
-using System.Diagnostics.CodeAnalysis;
+using System.Diagnostics;
 
 namespace AudibleUtilities;
 
-public class Account : IUpdatable
+[DebuggerDisplay("{AccountId,nq} - {Locale}")]
+public class Account : IUpdatable, ILogMasked
 {
 	public event EventHandler? Updated;
 	private void update(object? sender = null, EventArgs? e = null)
@@ -46,15 +49,18 @@ public class Account : IUpdatable
 		}
 	}
 
-	/// <summary>aka: activation bytes</summary>
-	[AllowNull]
-	public string? DecryptKey
+	/// <summary>
+	/// aka: activation bytes. A <see cref="SecretString"/> so that no reflective dump - Serilog's structured
+	/// logging, or Serilog.Exceptions walking a logged exception - can reach the value. Persists as the same
+	/// bare JSON string it always did.
+	/// </summary>
+	public SecretString DecryptKey
 	{
 		get => field;
 		set
 		{
-			var v = (value ?? "").Trim();
-			if (v == field)
+			var v = (value.Reveal() ?? "").Trim();
+			if (v == field.Reveal())
 				return;
 			field = v;
 			update();
@@ -88,7 +94,12 @@ public class Account : IUpdatable
 		AccountId = ArgumentValidator.EnsureNotNullOrWhiteSpace(accountId, nameof(accountId)).Trim();
 	}
 
-	public override string ToString() => $"{AccountId} - {Locale?.Name ?? "[empty]"}";
+	/// <summary>
+	/// Masked, because this is what interpolation and non-destructured logging reach for. Use
+	/// <see cref="AccountCredentialStatus.FormatAccountLabel"/> for dialogs shown to the account's owner, and see
+	/// the DebuggerDisplay above for the unmasked form while debugging.
+	/// </summary>
+	public override string ToString() => MaskedLogEntry;
 
 	public string MaskedLogEntry => @$"AccountId={mask(AccountId)}|AccountName={mask(AccountName)}|Locale={Locale?.Name ?? "[empty]"}";
 	private static string mask(string? str)

--- a/Source/AudibleUtilities/AccountCredentialStatus.cs
+++ b/Source/AudibleUtilities/AccountCredentialStatus.cs
@@ -18,7 +18,7 @@ public static class AccountCredentialStatus
 			return false;
 
 		// without a refresh token there is nothing to renew from, so this needs a fresh login rather than a retry
-		return string.IsNullOrWhiteSpace(tokens.RefreshToken?.Value);
+		return string.IsNullOrWhiteSpace(tokens.RefreshToken?.Reveal());
 	}
 
 	/// <summary>

--- a/Source/AudibleUtilities/AccountSummary.cs
+++ b/Source/AudibleUtilities/AccountSummary.cs
@@ -1,0 +1,43 @@
+namespace AudibleUtilities;
+
+/// <summary>
+/// What a failure needs to say about an account, captured so a live <see cref="Account"/> - with its tokens and
+/// its activation bytes - never rides along on an exception into a log file.
+/// <para>
+/// Logs get attached to public issue reports, and Serilog.Exceptions writes every public property of a logged
+/// exception into one, following nested objects as it goes. So everything public here is masked, and the label
+/// meant for the account's owner is reachable only through a method: reflection reads properties and never calls
+/// methods.
+/// </para>
+/// </summary>
+public sealed class AccountSummary
+{
+	/// <summary>Safe to log. Also what <see cref="ToString"/> returns, so interpolating this cannot leak.</summary>
+	public string MaskedLogEntry { get; }
+
+	/// <summary>
+	/// True when the account was never fully logged in or its credentials were cleared, rather than merely
+	/// holding an expired session.
+	/// </summary>
+	public bool LooksLikeMissingCredentials { get; }
+
+	private readonly string ownerFacingLabel;
+
+	private AccountSummary(Account account)
+	{
+		MaskedLogEntry = account.MaskedLogEntry;
+		LooksLikeMissingCredentials = AccountCredentialStatus.LooksLikeMissingCredentials(account);
+		ownerFacingLabel = AccountCredentialStatus.FormatAccountLabel(account);
+	}
+
+	/// <summary>
+	/// The name and address to show the person who owns the account, on their own screen. Never log this: use
+	/// <see cref="MaskedLogEntry"/>.
+	/// </summary>
+	public string RevealOwnerFacingLabel() => ownerFacingLabel;
+
+	public override string ToString() => MaskedLogEntry;
+
+	public static AccountSummary? From(Account? account)
+		=> account is null ? null : new AccountSummary(account);
+}

--- a/Source/AudibleUtilities/ApiExtended.cs
+++ b/Source/AudibleUtilities/ApiExtended.cs
@@ -76,9 +76,10 @@ public class ApiExtended
 						LooksLikeMissingCredentials = missingCredentials
 					});
 
+				// masked: this message is logged verbatim, both as {Exception} and as ExceptionDetail.Message
 				throw new AuthenticationRequiredException(
 					account,
-					message: $"Stored credentials for '{account.AccountId}' "
+					message: $"Stored credentials for {account.MaskedLogEntry} "
 						+ (missingCredentials ? "are missing or incomplete" : "could not be used")
 						+ (LoginChoiceFactory is null
 							? " and interactive login is not available in this context (CLI/Docker)."

--- a/Source/AudibleUtilities/AudibleUtilities.csproj
+++ b/Source/AudibleUtilities/AudibleUtilities.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AudibleApi" Version="10.3.5.1" />
+    <PackageReference Include="AudibleApi" Version="11.0.0.1" />
     <PackageReference Include="Google.Protobuf" Version="3.34.1" />
   </ItemGroup>
 

--- a/Source/AudibleUtilities/AudibleUtilities.csproj
+++ b/Source/AudibleUtilities/AudibleUtilities.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AudibleApi" Version="11.0.0.1" />
+    <PackageReference Include="AudibleApi" Version="11.0.2.1" />
     <PackageReference Include="Google.Protobuf" Version="3.34.1" />
   </ItemGroup>
 

--- a/Source/AudibleUtilities/AuthenticationRequiredException.cs
+++ b/Source/AudibleUtilities/AuthenticationRequiredException.cs
@@ -6,9 +6,14 @@ namespace AudibleUtilities;
 /// </summary>
 public sealed class AuthenticationRequiredException : Exception
 {
-	public Account? Account { get; }
+	/// <summary>
+	/// A log-safe summary rather than the <see cref="Account"/> itself. Serilog.Exceptions reflects over every
+	/// public property of a logged exception, so holding the live account published its address - and would have
+	/// published its activation bytes - into logs people attach to public issue reports.
+	/// </summary>
+	public AccountSummary? AccountInfo { get; }
 
 	public AuthenticationRequiredException(Account? account, string? message = null, Exception? innerException = null)
 		: base(message ?? "Audible authentication is required.", innerException)
-		=> Account = account;
+		=> AccountInfo = AccountSummary.From(account);
 }

--- a/Source/AudibleUtilities/Mkb79Auth.cs
+++ b/Source/AudibleUtilities/Mkb79Auth.cs
@@ -2,6 +2,7 @@
 using AudibleApi.Authorization;
 using AudibleApi.Cryptography;
 using Dinah.Core;
+using Dinah.Core.Security;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using System;
@@ -208,7 +209,7 @@ public partial class Mkb79Auth
 
 		var authorize = new Authorize(Locale);
 		var newToken = await authorize.RefreshAccessTokenAsync(refreshToken);
-		AccessToken = newToken.TokenValue;
+		AccessToken = newToken.Reveal();
 		AccessTokenExpires = newToken.Expires;
 
 		var api = new Api(this);
@@ -226,7 +227,7 @@ public partial class Mkb79Auth
 			adpToken,
 			newToken,
 			refreshToken,
-			WebsiteCookies?.Select(c => new KeyValuePair<string, string?>(c.Key, c.Value)),
+			WebsiteCookies?.Select(c => new KeyValuePair<string, SecretString>(c.Key, c.Value)),
 			DeviceSerialNumber,
 			DeviceType,
 			AmazonAccountId,
@@ -239,9 +240,9 @@ public partial class Mkb79Auth
 	public static Mkb79Auth FromAccount(Account account)
 		=> new()
 		{
-			AccessToken = account.IdentityTokens?.ExistingAccessToken.TokenValue,
+			AccessToken = account.IdentityTokens?.ExistingAccessToken.Reveal(),
 			ActivationBytes = string.IsNullOrEmpty(account.DecryptKey) ? null : account.DecryptKey,
-			AdpToken = account.IdentityTokens?.AdpToken?.Value,
+			AdpToken = account.IdentityTokens?.AdpToken?.Reveal(),
 			CustomerInfo = new CustomerInfo
 			{
 				AccountPool = "Amazon",
@@ -256,13 +257,14 @@ public partial class Mkb79Auth
 				DeviceSerialNumber = account.IdentityTokens?.DeviceSerialNumber,
 				DeviceType = account.IdentityTokens?.DeviceType,
 			},
-			DevicePrivateKey = account.IdentityTokens?.PrivateKey?.Value,
+			DevicePrivateKey = account.IdentityTokens?.PrivateKey?.Reveal(),
 			AccessTokenExpires = account.IdentityTokens?.ExistingAccessToken.Expires ?? default,
 			LocaleCode = account.Locale?.CountryCode,
 			WithUsername = account.Locale?.WithUsername ?? false,
-			RefreshToken = account.IdentityTokens?.RefreshToken?.Value,
-			StoreAuthenticationCookie = account.IdentityTokens?.StoreAuthenticationCookie,
-			WebsiteCookies = new(account.IdentityTokens?.Cookies ?? []),
+			RefreshToken = account.IdentityTokens?.RefreshToken?.Reveal(),
+			StoreAuthenticationCookie = account.IdentityTokens?.StoreAuthenticationCookie.Reveal(),
+			WebsiteCookies = new(account.IdentityTokens?.Cookies
+				.Select(c => new KeyValuePair<string, string?>(c.Key, c.Value.Reveal())) ?? []),
 		};
 }
 

--- a/Source/AudibleUtilities/Mkb79Auth.cs
+++ b/Source/AudibleUtilities/Mkb79Auth.cs
@@ -241,7 +241,7 @@ public partial class Mkb79Auth
 		=> new()
 		{
 			AccessToken = account.IdentityTokens?.ExistingAccessToken.Reveal(),
-			ActivationBytes = string.IsNullOrEmpty(account.DecryptKey) ? null : account.DecryptKey,
+			ActivationBytes = account.DecryptKey.HasValue ? account.DecryptKey.Reveal() : null,
 			AdpToken = account.IdentityTokens?.AdpToken?.Reveal(),
 			CustomerInfo = new CustomerInfo
 			{

--- a/Source/DataLayer/DataLayer.csproj
+++ b/Source/DataLayer/DataLayer.csproj
@@ -11,7 +11,7 @@
   </PropertyGroup>
   
   <ItemGroup>
-    <PackageReference Include="Dinah.Core" Version="10.2.2.2" />
+    <PackageReference Include="Dinah.Core" Version="10.2.3.1" />
     <PackageReference Include="Dinah.EntityFrameworkCore" Version="10.2.2.1" />
 	<PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.0.1" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.0.7" />

--- a/Source/DataLayer/DataLayer.csproj
+++ b/Source/DataLayer/DataLayer.csproj
@@ -11,7 +11,7 @@
   </PropertyGroup>
   
   <ItemGroup>
-    <PackageReference Include="Dinah.Core" Version="10.2.2.1" />
+    <PackageReference Include="Dinah.Core" Version="10.2.2.2" />
     <PackageReference Include="Dinah.EntityFrameworkCore" Version="10.2.2.1" />
 	<PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.0.1" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.0.7" />

--- a/Source/DataLayer/DataLayer.csproj
+++ b/Source/DataLayer/DataLayer.csproj
@@ -11,8 +11,8 @@
   </PropertyGroup>
   
   <ItemGroup>
-    <PackageReference Include="Dinah.Core" Version="10.2.1.1" />
-    <PackageReference Include="Dinah.EntityFrameworkCore" Version="10.2.1.1" />
+    <PackageReference Include="Dinah.Core" Version="10.2.2.1" />
+    <PackageReference Include="Dinah.EntityFrameworkCore" Version="10.2.2.1" />
 	<PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.0.1" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.0.7" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.7">

--- a/Source/FileManager/FileManager.csproj
+++ b/Source/FileManager/FileManager.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Dinah.Core" Version="10.2.2.1" />
+    <PackageReference Include="Dinah.Core" Version="10.2.2.2" />
     <PackageReference Include="Polly" Version="8.6.6" />
   </ItemGroup>
 

--- a/Source/FileManager/FileManager.csproj
+++ b/Source/FileManager/FileManager.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Dinah.Core" Version="10.2.1.1" />
+    <PackageReference Include="Dinah.Core" Version="10.2.2.1" />
     <PackageReference Include="Polly" Version="8.6.6" />
   </ItemGroup>
 

--- a/Source/FileManager/FileManager.csproj
+++ b/Source/FileManager/FileManager.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Dinah.Core" Version="10.2.2.2" />
+    <PackageReference Include="Dinah.Core" Version="10.2.3.1" />
     <PackageReference Include="Polly" Version="8.6.6" />
   </ItemGroup>
 

--- a/Source/LibationCli/Options/_OptionsBase.cs
+++ b/Source/LibationCli/Options/_OptionsBase.cs
@@ -77,6 +77,11 @@ public abstract class OptionsBase
 				return;
 			}
 
+			// the exception message names the account masked, because it gets logged. stderr is not teed into
+			// Serilog, so this is the one place the owner can be told which account in full.
+			if (AuthenticationExceptionHelper.FindAuthenticationRequired(ex)?.AccountInfo is { } accountInfo)
+				Console.Error.WriteLine($"Audible login is required for {accountInfo.RevealOwnerFacingLabel()}.");
+
 			PrintVerbUsage(
 				"ERROR",
 				"=====",

--- a/Source/LibationFileManager/Configuration.Logging.cs
+++ b/Source/LibationFileManager/Configuration.Logging.cs
@@ -1,4 +1,5 @@
 ﻿using Dinah.Core.Logging;
+using Dinah.Core.Security;
 using FileManager;
 using Microsoft.Extensions.Configuration;
 using Newtonsoft.Json;
@@ -162,6 +163,10 @@ public partial class Configuration
 			 .ReadFrom.Configuration(configuration, readerOptions)
 			 .Destructure.ByTransforming<LongPath>(lp => lp.Path)
 			 .Destructure.With<LogFileFilter>()
+			 // last lines of defense for structured logging: a masked identity instead of the object, and a
+			 // secret that renders as its shape instead of its contents
+			 .Destructure.With<MaskedLogEntryPolicy>()
+			 .Destructure.ByTransforming<SecretString>(secret => secret.ToString())
 			 .CreateLogger();
 		SerilogInitialized = true;
 	}

--- a/Source/LibationFileManager/Configuration.Logging.cs
+++ b/Source/LibationFileManager/Configuration.Logging.cs
@@ -163,10 +163,12 @@ public partial class Configuration
 			 .ReadFrom.Configuration(configuration, readerOptions)
 			 .Destructure.ByTransforming<LongPath>(lp => lp.Path)
 			 .Destructure.With<LogFileFilter>()
-			 // last lines of defense for structured logging: a masked identity instead of the object, and a
-			 // secret that renders as its shape instead of its contents
+			 // protection: without this, an ILogMasked logged as {@Account} is written out property by property
 			 .Destructure.With<MaskedLogEntryPolicy>()
-			 .Destructure.ByTransforming<SecretString>(secret => secret.ToString())
+			 // legibility rather than protection. A SecretString is already safe wherever it lands - it has no
+			 // public member holding the value - but asking Serilog to take one apart yields
+			 // {"HasValue":true,"$type":"SecretString"} instead of the length, so tell Serilog to leave it whole.
+			 .Destructure.AsScalar<SecretString>()
 			 .CreateLogger();
 		SerilogInitialized = true;
 	}

--- a/Source/LibationFileManager/Configuration.Logging.cs
+++ b/Source/LibationFileManager/Configuration.Logging.cs
@@ -1,5 +1,4 @@
 ﻿using Dinah.Core.Logging;
-using Dinah.Core.Security;
 using FileManager;
 using Microsoft.Extensions.Configuration;
 using Newtonsoft.Json;
@@ -163,12 +162,10 @@ public partial class Configuration
 			 .ReadFrom.Configuration(configuration, readerOptions)
 			 .Destructure.ByTransforming<LongPath>(lp => lp.Path)
 			 .Destructure.With<LogFileFilter>()
-			 // protection: without this, an ILogMasked logged as {@Account} is written out property by property
+			 // without this, an ILogMasked logged as {@Account} is written out property by property.
+			 // SecretString needs no counterpart here: it reports its own redaction from a property, so a
+			 // destructured secret carries its shape with nothing registered.
 			 .Destructure.With<MaskedLogEntryPolicy>()
-			 // legibility rather than protection. A SecretString is already safe wherever it lands - it has no
-			 // public member holding the value - but asking Serilog to take one apart yields
-			 // {"HasValue":true,"$type":"SecretString"} instead of the length, so tell Serilog to leave it whole.
-			 .Destructure.AsScalar<SecretString>()
 			 .CreateLogger();
 		SerilogInitialized = true;
 	}

--- a/Source/LibationFileManager/LibationFileManager.csproj
+++ b/Source/LibationFileManager/LibationFileManager.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AudibleApi" Version="10.3.5.1" />
+    <PackageReference Include="AudibleApi" Version="11.0.0.1" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="10.0.7" />
     <PackageReference Include="NameParserSharp" Version="1.5.0" />
     <PackageReference Include="Serilog.Exceptions" Version="8.4.0" />

--- a/Source/LibationFileManager/LibationFileManager.csproj
+++ b/Source/LibationFileManager/LibationFileManager.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AudibleApi" Version="11.0.0.1" />
+    <PackageReference Include="AudibleApi" Version="11.0.2.1" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="10.0.7" />
     <PackageReference Include="NameParserSharp" Version="1.5.0" />
     <PackageReference Include="Serilog.Exceptions" Version="8.4.0" />

--- a/Source/LibationFileManager/MaskedLogEntryPolicy.cs
+++ b/Source/LibationFileManager/MaskedLogEntryPolicy.cs
@@ -1,0 +1,37 @@
+using Serilog.Core;
+using Serilog.Events;
+
+namespace LibationFileManager;
+
+/// <summary>
+/// Implemented by types that identify something private, and so must appear in a log only in masked form.
+/// </summary>
+public interface ILogMasked
+{
+	/// <summary>The only form of this object that may reach a log file.</summary>
+	string MaskedLogEntry { get; }
+}
+
+/// <summary>
+/// Reduces any <see cref="ILogMasked"/> to its masked entry when Serilog destructures it, so that a structured
+/// log call - <c>{@Account}</c>, or an anonymous <c>{@DebugInfo}</c> object holding one - cannot publish the
+/// unmasked object by accident.
+/// <para>
+/// This covers Serilog's own destructuring only. Serilog.Exceptions flattens a logged exception's properties
+/// itself before Serilog sees them, so an exception must not carry one of these in the first place.
+/// </para>
+/// </summary>
+public class MaskedLogEntryPolicy : IDestructuringPolicy
+{
+	public bool TryDestructure(object value, ILogEventPropertyValueFactory propertyValueFactory, out LogEventPropertyValue result)
+	{
+		if (value is ILogMasked masked)
+		{
+			result = new ScalarValue(masked.MaskedLogEntry);
+			return true;
+		}
+
+		result = null!;
+		return false;
+	}
+}

--- a/Source/LibationUiBase/AutoScanAuthPrompt.cs
+++ b/Source/LibationUiBase/AutoScanAuthPrompt.cs
@@ -12,8 +12,10 @@ public static class AutoScanAuthPrompt
 	{
 		ArgumentNullException.ThrowIfNull(ex);
 
-		var account = AccountCredentialStatus.FormatAccountLabel(ex.Account);
-		var cause = AccountCredentialStatus.LooksLikeMissingCredentials(ex.Account)
+		// the owner is looking at their own screen, so the dialog names the account in full. the log gets
+		// ex.AccountInfo.MaskedLogEntry instead
+		var account = ex.AccountInfo?.RevealOwnerFacingLabel() ?? "an Audible account";
+		var cause = ex.AccountInfo?.LooksLikeMissingCredentials ?? true
 			? "that account has never been logged in, or its stored credentials are missing"
 			: "the stored login for that account expired";
 

--- a/Source/LibationUiBase/AutoScanRunner.cs
+++ b/Source/LibationUiBase/AutoScanRunner.cs
@@ -95,7 +95,7 @@ public sealed class AutoScanRunner
 		// masked, not the label the dialog uses: log files get attached to public issue reports
 		Log.Warning(ex,
 			"Auto-scan paused: Audible login is required for {Account}. Log in with Import > Scan Library to resume background scans.",
-			ex.Account?.MaskedLogEntry ?? "[unknown account]");
+			ex.AccountInfo?.MaskedLogEntry ?? "[unknown account]");
 
 		if (notifyAuthRequired is not null)
 			await notifyAuthRequired(ex);

--- a/Source/LibationWinForms/LibationWinForms.csproj
+++ b/Source/LibationWinForms/LibationWinForms.csproj
@@ -41,7 +41,7 @@
 
 
 	<ItemGroup>
-		<PackageReference Include="Dinah.Core.WindowsDesktop" Version="10.2.2.1" />
+		<PackageReference Include="Dinah.Core.WindowsDesktop" Version="10.2.3.1" />
 		<PackageReference Include="Microsoft.Web.WebView2" Version="1.0.3912.50" />
 	</ItemGroup>
 

--- a/Source/LibationWinForms/LibationWinForms.csproj
+++ b/Source/LibationWinForms/LibationWinForms.csproj
@@ -41,7 +41,7 @@
 
 
 	<ItemGroup>
-		<PackageReference Include="Dinah.Core.WindowsDesktop" Version="10.2.1.1" />
+		<PackageReference Include="Dinah.Core.WindowsDesktop" Version="10.2.2.1" />
 		<PackageReference Include="Microsoft.Web.WebView2" Version="1.0.3912.50" />
 	</ItemGroup>
 

--- a/Source/_Demos/LoadByOS/CrossPlatformClientExe/CrossPlatformClientExe.csproj
+++ b/Source/_Demos/LoadByOS/CrossPlatformClientExe/CrossPlatformClientExe.csproj
@@ -19,7 +19,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Dinah.Core" Version="10.2.2.2" />
+    <PackageReference Include="Dinah.Core" Version="10.2.3.1" />
   </ItemGroup>
 
 </Project>

--- a/Source/_Demos/LoadByOS/CrossPlatformClientExe/CrossPlatformClientExe.csproj
+++ b/Source/_Demos/LoadByOS/CrossPlatformClientExe/CrossPlatformClientExe.csproj
@@ -19,7 +19,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Dinah.Core" Version="10.2.1.1" />
+    <PackageReference Include="Dinah.Core" Version="10.2.2.1" />
   </ItemGroup>
 
 </Project>

--- a/Source/_Demos/LoadByOS/CrossPlatformClientExe/CrossPlatformClientExe.csproj
+++ b/Source/_Demos/LoadByOS/CrossPlatformClientExe/CrossPlatformClientExe.csproj
@@ -19,7 +19,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Dinah.Core" Version="10.2.2.1" />
+    <PackageReference Include="Dinah.Core" Version="10.2.2.2" />
   </ItemGroup>
 
 </Project>

--- a/Source/_Tests/AudibleUtilities.Tests/AccountCredentialStatusTests.cs
+++ b/Source/_Tests/AudibleUtilities.Tests/AccountCredentialStatusTests.cs
@@ -1,3 +1,4 @@
+using Dinah.Core.Security;
 using AssertionHelper;
 using AudibleApi;
 using AudibleApi.Authorization;
@@ -21,7 +22,7 @@ public class AccountCredentialStatusTests
 			new AdpToken("{enc:abcdefg}{key:1234}{iv:56789}{name:QURQVG9rZW5FbmNyeXB0aW9uS2V5}{serial:Mg==}"),
 			new AccessToken("Atna|_CHAR_ACCESS_", new DateTime(2200, 1, 1, 12, 0, 0, DateTimeKind.Utc)),
 			new RefreshToken("Atnr|_CHAR_REFRESH_"),
-			new List<KeyValuePair<string, string?>> { new("session-id", "cookie-value") },
+			new List<KeyValuePair<string, SecretString>> { new("session-id", "cookie-value") },
 			deviceSerialNumber: "device-serial",
 			deviceType: "device-type",
 			amazonAccountId: "amzn-account",

--- a/Source/_Tests/AudibleUtilities.Tests/AccountTests.cs
+++ b/Source/_Tests/AudibleUtilities.Tests/AccountTests.cs
@@ -1,4 +1,5 @@
 ﻿using AssertionHelper;
+using Dinah.Core.Security;
 using AudibleApi;
 using AudibleApi.Authorization;
 using AudibleApi.Cryptography;
@@ -675,7 +676,7 @@ BxlXqPnQ4mG66oqSFQgDEmFdMhRb2of6xL1gYYL62C80G2T7QtmPfSab
 			new AdpToken(SampleAdpToken),
 			new AccessToken(SampleAccessToken, SampleExpires),
 			new RefreshToken(SampleRefreshToken),
-			new List<KeyValuePair<string, string?>> { new("session-id", "cookie-secret-value") },
+			new List<KeyValuePair<string, SecretString>> { new("session-id", "cookie-secret-value") },
 			deviceSerialNumber: "device-serial",
 			deviceType: "device-type",
 			amazonAccountId: "amzn-account",

--- a/Source/_Tests/AudibleUtilities.Tests/AuthenticationRequiredExceptionLogSafetyTests.cs
+++ b/Source/_Tests/AudibleUtilities.Tests/AuthenticationRequiredExceptionLogSafetyTests.cs
@@ -1,0 +1,214 @@
+using AudibleApi;
+using AudibleApi.Authorization;
+using AudibleApi.Cryptography;
+using AudibleUtilities;
+using Dinah.Core.Security;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Serilog;
+using Serilog.Core;
+using Serilog.Events;
+using Serilog.Exceptions;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Security.Cryptography;
+
+namespace AudibleUtilities.Tests;
+
+/// <summary>
+/// The reported bug: an account's address reached a log file because the exception carried the live account and
+/// Serilog.Exceptions reflects over every public property of whatever it is given. These tests run the real
+/// pipeline - the same enricher Libation configures - and assert nothing private comes out the other end.
+/// </summary>
+[TestClass]
+public class AuthenticationRequiredExceptionLogSafety
+{
+	private const string AccountId = "jade@example.com";
+	private const string AccountName = "Jade";
+	private const string ActivationBytes = "1a2b3c4d";
+	private const string RefreshTokenValue = "Atnr|_CHAR_REFRESH_";
+	private const string AccessTokenValue = "Atna|_CHAR_ACCESS_";
+	private const string AdpTokenValue = "{enc:abcdefg}{key:1234}{iv:56789}{name:QURQVG9rZW5FbmNyeXB0aW9uS2V5}{serial:Mg==}";
+	private const string CookieValue = "cookie-secret-value";
+	private const string StoreAuthCookie = "store-auth-cookie-value";
+
+	private static Account registeredAccount()
+	{
+		var privateKey = RSA.Create(2048).ExportRSAPrivateKeyPem();
+		var identity = new Identity(Localization.Get("us"));
+		identity.Update(
+			new PrivateKey(privateKey),
+			new AdpToken(AdpTokenValue),
+			new AccessToken(AccessTokenValue, new DateTime(2200, 1, 1, 12, 0, 0, DateTimeKind.Utc)),
+			new RefreshToken(RefreshTokenValue),
+			new List<KeyValuePair<string, SecretString>> { new("session-id", CookieValue) },
+			deviceSerialNumber: "device-serial",
+			deviceType: "device-type",
+			amazonAccountId: "amzn-account",
+			deviceName: "device-name",
+			storeAuthenticationCookie: StoreAuthCookie);
+
+		return new Account(AccountId)
+		{
+			AccountName = AccountName,
+			DecryptKey = ActivationBytes,
+			IdentityTokens = identity
+		};
+	}
+
+	[TestMethod]
+	public void logging_the_exception_writes_nothing_private()
+	{
+		var account = registeredAccount();
+		var privateKeyHeader = account.IdentityTokens!.PrivateKey!.Reveal()[..40];
+		var ex = new AuthenticationRequiredException(
+			account,
+			message: $"Stored credentials for {account.MaskedLogEntry} are missing or incomplete.");
+
+		var written = renderThroughSerilog(ex);
+
+		// the masked form is present, so the entry is still useful for telling accounts apart
+		StringAssert.Contains(written, account.MaskedLogEntry);
+
+		foreach (var secret in new[] { AccountId, AccountName, ActivationBytes, RefreshTokenValue, AccessTokenValue, AdpTokenValue, CookieValue, StoreAuthCookie, privateKeyHeader })
+			Assert.IsFalse(written.Contains(secret, StringComparison.Ordinal), $"log contained a secret: {secret}");
+	}
+
+	/// <summary>
+	/// The inner exception is logged too, so a failure that names an account on its way up the chain has the same
+	/// problem. This is the shape AutoScanRunner logs: an outer exception wrapping the authentication failure.
+	/// </summary>
+	[TestMethod]
+	public void logging_it_as_an_inner_exception_writes_nothing_private()
+	{
+		var ex = new InvalidOperationException(
+			"Error scanning library",
+			new AuthenticationRequiredException(registeredAccount()));
+
+		var written = renderThroughSerilog(ex);
+
+		Assert.IsFalse(written.Contains(AccountId, StringComparison.Ordinal), "log contained the account id");
+		Assert.IsFalse(written.Contains(ActivationBytes, StringComparison.Ordinal), "log contained the activation bytes");
+	}
+
+	[TestMethod]
+	public void the_dialog_still_gets_the_full_label()
+	{
+		var summary = AccountSummary.From(registeredAccount())!;
+
+		StringAssert.Contains(summary.RevealOwnerFacingLabel(), AccountId);
+		Assert.IsFalse(summary.MaskedLogEntry.Contains(AccountId, StringComparison.Ordinal));
+	}
+
+	/// <summary>
+	/// Renders a log event the way Libation's file sink does: the message, the exception, and the expanded
+	/// {Properties:j} that WithExceptionDetails fills in.
+	/// </summary>
+	private static string renderThroughSerilog(Exception ex)
+	{
+		var sink = new CollectingSink();
+		using var logger = new LoggerConfiguration()
+			.Enrich.WithExceptionDetails()
+			.WriteTo.Sink(sink)
+			.CreateLogger();
+
+		logger.Warning(ex, "Auto-scan paused: Audible login is required.");
+
+		var logEvent = sink.Events.Single();
+		return logEvent.RenderMessage()
+			+ logEvent.Exception
+			+ string.Join("|", logEvent.Properties.Select(p => $"{p.Key}={p.Value}"));
+	}
+
+	private class CollectingSink : ILogEventSink
+	{
+		public List<LogEvent> Events { get; } = [];
+		public void Emit(LogEvent logEvent) => Events.Add(logEvent);
+	}
+}
+
+/// <summary>
+/// A guard against the next exception type reintroducing this. Serilog.Exceptions walks the public property
+/// graph of whatever exception it is handed, to a default depth of 10, so no exception may be able to reach an
+/// account or an identity that way.
+/// </summary>
+[TestClass]
+public class ExceptionsCannotReachAnAccount
+{
+	private static readonly Type[] Forbidden =
+	[
+		typeof(Account),
+		typeof(AccountsSettings),
+		typeof(Identity),
+		typeof(AccessToken),
+		typeof(RefreshToken),
+		typeof(AdpToken),
+		typeof(PrivateKey)
+	];
+
+	[TestMethod]
+	public void no_exception_type_exposes_one_through_its_public_properties()
+	{
+		// the assemblies this test project can see. Account and the authentication exception live in the first.
+		var assemblies = new[]
+		{
+			typeof(Account).Assembly,
+			typeof(LibationFileManager.Configuration).Assembly,
+			typeof(FileManager.LongPath).Assembly
+		};
+
+		var exceptionTypes = assemblies
+			.SelectMany(a => a.GetTypes())
+			.Where(t => typeof(Exception).IsAssignableFrom(t))
+			.ToArray();
+
+		Assert.IsTrue(exceptionTypes.Length > 0, "found no exception types to check");
+
+		foreach (var exceptionType in exceptionTypes)
+		{
+			var path = findForbidden(exceptionType, depth: 0, [], []);
+			Assert.IsNull(path, $"{exceptionType.Name} can reach a secret-bearing type through public properties: {path}");
+		}
+	}
+
+	private static string? findForbidden(Type type, int depth, HashSet<Type> visited, List<string> trail)
+	{
+		if (depth > 10 || !visited.Add(type))
+			return null;
+
+		foreach (var property in type.GetProperties(BindingFlags.Public | BindingFlags.Instance))
+		{
+			if (property.GetIndexParameters().Length > 0)
+				continue;
+
+			var propertyType = unwrap(property.PropertyType);
+			var step = trail.Append($"{type.Name}.{property.Name}").ToList();
+
+			if (Forbidden.Contains(propertyType))
+				return string.Join(" -> ", step);
+
+			if (propertyType.Assembly == typeof(Account).Assembly || propertyType.Assembly == typeof(Identity).Assembly)
+			{
+				var found = findForbidden(propertyType, depth + 1, visited, step);
+				if (found is not null)
+					return found;
+			}
+		}
+
+		return null;
+	}
+
+	/// <summary>Collections and nullables hide the interesting type one level down.</summary>
+	private static Type unwrap(Type type)
+	{
+		if (type.IsArray)
+			return unwrap(type.GetElementType()!);
+
+		if (!type.IsGenericType)
+			return type;
+
+		var arguments = type.GetGenericArguments();
+		return arguments.Length == 1 ? unwrap(arguments[0]) : type;
+	}
+}

--- a/Source/_Tests/AudibleUtilities.Tests/AuthenticationRequiredExceptionLogSafetyTests.cs
+++ b/Source/_Tests/AudibleUtilities.Tests/AuthenticationRequiredExceptionLogSafetyTests.cs
@@ -3,7 +3,10 @@ using AudibleApi.Authorization;
 using AudibleApi.Cryptography;
 using AudibleUtilities;
 using Dinah.Core.Security;
+using LibationFileManager;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
 using Serilog;
 using Serilog.Core;
 using Serilog.Events;
@@ -129,6 +132,44 @@ public class AuthenticationRequiredExceptionLogSafety
 }
 
 /// <summary>
+/// The paths that do not involve an exception at all: interpolating an account, and persisting its activation
+/// bytes.
+/// </summary>
+[TestClass]
+public class AccountMasking
+{
+	[TestMethod]
+	public void interpolating_an_account_is_masked()
+	{
+		var account = new Account("jade@example.com") { AccountName = "Jade" };
+
+		var interpolated = $"{account}";
+
+		Assert.AreEqual(account.MaskedLogEntry, interpolated);
+		Assert.IsFalse(interpolated.Contains("jade@example.com", StringComparison.Ordinal));
+		Assert.IsFalse(interpolated.Contains("Jade", StringComparison.Ordinal));
+	}
+
+	[TestMethod]
+	public void an_account_declares_itself_maskable_for_serilog()
+		=> Assert.IsInstanceOfType<ILogMasked>(new Account("jade@example.com"));
+
+	/// <summary>
+	/// DecryptKey became a SecretString, which would serialize as an object and lose the value if the converter
+	/// were not doing its job. Existing settings files have to keep loading, and keep the shape they had.
+	/// </summary>
+	[TestMethod]
+	public void the_activation_bytes_still_persist_as_a_bare_string()
+	{
+		var json = JsonConvert.SerializeObject(new Account("jade@example.com") { DecryptKey = "1a2b3c4d" });
+
+		var decryptKey = JObject.Parse(json)["DecryptKey"]!;
+		Assert.AreEqual(JTokenType.String, decryptKey.Type);
+		Assert.AreEqual("1a2b3c4d", decryptKey.ToObject<string>());
+	}
+}
+
+/// <summary>
 /// A guard against the next exception type reintroducing this. Serilog.Exceptions walks the public property
 /// graph of whatever exception it is handed, to a default depth of 10, so no exception may be able to reach an
 /// account or an identity that way.
@@ -154,7 +195,7 @@ public class ExceptionsCannotReachAnAccount
 		var assemblies = new[]
 		{
 			typeof(Account).Assembly,
-			typeof(LibationFileManager.Configuration).Assembly,
+			typeof(Configuration).Assembly,
 			typeof(FileManager.LongPath).Assembly
 		};
 

--- a/Source/_Tests/AudibleUtilities.Tests/IdentityTokenStorageWiringTests.cs
+++ b/Source/_Tests/AudibleUtilities.Tests/IdentityTokenStorageWiringTests.cs
@@ -307,7 +307,7 @@ BxlXqPnQ4mG66oqSFQgDEmFdMhRb2of6xL1gYYL62C80G2T7QtmPfSab
 			new AdpToken(SampleAdpToken),
 			new AccessToken(SampleAccessToken, SampleExpires),
 			new RefreshToken(SampleRefreshToken),
-			new List<KeyValuePair<string, string?>> { new(SampleCookieName, SampleCookieValue) },
+			new List<KeyValuePair<string, SecretString>> { new(SampleCookieName, SampleCookieValue) },
 			deviceSerialNumber: "device-serial",
 			deviceType: "device-type",
 			amazonAccountId: "amzn-account",

--- a/Source/_Tests/LibationFileManager.Tests/MaskedLogEntryLoggingTests.cs
+++ b/Source/_Tests/LibationFileManager.Tests/MaskedLogEntryLoggingTests.cs
@@ -95,8 +95,8 @@ public class MaskedLogEntryLoggingTests
 	}
 
 	/// <summary>
-	/// Destructured on purpose. Without the transform a secret renders as an empty structure - safe, but it says
-	/// nothing, and the shape is the whole point of the redaction.
+	/// Destructured on purpose, and with nothing registered for it: SecretString reports its own redaction from a
+	/// property, so the shape survives being taken apart.
 	/// </summary>
 	[TestMethod]
 	public void a_destructured_secret_is_written_as_its_shape()

--- a/Source/_Tests/LibationFileManager.Tests/MaskedLogEntryLoggingTests.cs
+++ b/Source/_Tests/LibationFileManager.Tests/MaskedLogEntryLoggingTests.cs
@@ -1,0 +1,109 @@
+using Dinah.Core.Security;
+using LibationFileManager;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Newtonsoft.Json.Linq;
+using Serilog;
+using System;
+using System.IO;
+using System.Linq;
+
+namespace SerilogConfigurationTests;
+
+/// <summary>
+/// Builds the logger the way Libation does and writes through it, rather than testing the destructuring policy
+/// on its own: the policy only protects anything if <see cref="Configuration.ConfigureLogging"/> actually
+/// registers it, and a missing registration is silent.
+/// </summary>
+[TestClass]
+[DoNotParallelize]
+public class MaskedLogEntryLoggingTests
+{
+	private const string Secret = "jade@example.com";
+	private const string Masked = "AccountId=j[...]e|Locale=us";
+
+	private string tempDir = string.Empty;
+	private ILogger originalLogger = Serilog.Log.Logger;
+
+	private class MaskedThing : ILogMasked
+	{
+		public string MaskedLogEntry => Masked;
+		public string Address => Secret;
+		public override string ToString() => Masked;
+	}
+
+	[TestInitialize]
+	public void Initialize()
+	{
+		originalLogger = Serilog.Log.Logger;
+		tempDir = Path.Combine(Path.GetTempPath(), $"libation-masked-log-tests-{Guid.NewGuid():N}");
+		Directory.CreateDirectory(tempDir);
+	}
+
+	[TestCleanup]
+	public void Cleanup()
+	{
+		Serilog.Log.CloseAndFlush();
+		Serilog.Log.Logger = originalLogger;
+		Configuration.RestoreSingletonInstance();
+
+		try
+		{
+			Directory.Delete(tempDir, recursive: true);
+		}
+		catch (IOException)
+		{
+			// A leftover temp directory is not worth failing a test over.
+		}
+	}
+
+	private string LogThrough(Action<ILogger> write)
+	{
+		var config = Configuration.CreateMockInstance();
+		config.EnsureSerilogConfig();
+
+		var args = (JObject)((JObject)config.GetObject("Serilog")!).SelectToken("$.WriteTo[0].Args")!;
+		args["path"] = Path.Combine(tempDir, "Log.log");
+		args["outputTemplate"] = "{Message:lj} {Properties:j}{NewLine}";
+		config.SetNonString((JObject)config.GetObject("Serilog")!, "Serilog");
+
+		config.ConfigureLogging();
+
+		write(Serilog.Log.Logger);
+		Serilog.Log.CloseAndFlush();
+
+		return string.Join("\n", Directory.GetFiles(tempDir, "Log*.log").Select(File.ReadAllText));
+	}
+
+	/// <summary>Destructured, so the policy is what has to catch it: without one, Address would be written.</summary>
+	[TestMethod]
+	public void a_destructured_masked_type_is_reduced_to_its_masked_entry()
+	{
+		var written = LogThrough(logger => logger.Information("scanning {@Account}", new MaskedThing()));
+
+		StringAssert.Contains(written, Masked);
+		Assert.IsFalse(written.Contains(Secret, StringComparison.Ordinal), "the log contained the unmasked value");
+	}
+
+	/// <summary>The shape most of Libation's logging uses: an anonymous object holding the thing.</summary>
+	[TestMethod]
+	public void a_masked_type_nested_in_a_debug_object_is_reduced_too()
+	{
+		var written = LogThrough(logger => logger.Information("scanning {@DebugInfo}", new { Account = new MaskedThing(), Attempt = 2 }));
+
+		StringAssert.Contains(written, Masked);
+		Assert.IsFalse(written.Contains(Secret, StringComparison.Ordinal), "the log contained the unmasked value");
+	}
+
+	/// <summary>
+	/// Destructured on purpose. Without the transform a secret renders as an empty structure - safe, but it says
+	/// nothing, and the shape is the whole point of the redaction.
+	/// </summary>
+	[TestMethod]
+	public void a_destructured_secret_is_written_as_its_shape()
+	{
+		var written = LogThrough(logger => logger.Information("key {@Key}", new SecretString(Secret)));
+
+		StringAssert.Contains(written, $"[REDACTED length={Secret.Length}]");
+		Assert.IsFalse(written.Contains(Secret, StringComparison.Ordinal), "the log contained the secret");
+	}
+}

--- a/Source/_Tests/LibationUiBase.Tests/AutoScanAuthPromptTests.cs
+++ b/Source/_Tests/LibationUiBase.Tests/AutoScanAuthPromptTests.cs
@@ -1,3 +1,4 @@
+using Dinah.Core.Security;
 using AudibleApi;
 using AudibleApi.Authorization;
 using AudibleApi.Cryptography;
@@ -21,7 +22,7 @@ public class AutoScanAuthPromptTests
 			new AdpToken("{enc:abcdefg}{key:1234}{iv:56789}{name:QURQVG9rZW5FbmNyeXB0aW9uS2V5}{serial:Mg==}"),
 			new AccessToken("Atna|_CHAR_ACCESS_", new DateTime(2200, 1, 1, 12, 0, 0, DateTimeKind.Utc)),
 			new RefreshToken("Atnr|_CHAR_REFRESH_"),
-			new List<KeyValuePair<string, string?>> { new("session-id", "cookie-value") },
+			new List<KeyValuePair<string, SecretString>> { new("session-id", "cookie-value") },
 			deviceSerialNumber: "device-serial",
 			deviceType: "device-type",
 			amazonAccountId: "amzn-account",

--- a/docs/development/contribute.md
+++ b/docs/development/contribute.md
@@ -20,6 +20,16 @@ We welcome contributions! Whether it's fixing bugs, adding features, or improvin
 - Ensure your code builds and runs without errors.
 - Clean up any unused dependencies or imports.
 
+## Logging and secrets
+
+We ask people to attach `Log.log` to public issue reports, so treat everything written there as published.
+
+- Log `account.MaskedLogEntry`, never an account's id or name. `AccountCredentialStatus.FormatAccountLabel` gives the unmasked label and is for dialogs shown to the account's owner only.
+- Never hang an `Account`, an `Identity`, or anything holding one off an exception. Serilog.Exceptions reflects over every public property of a logged exception and follows nested objects, so a live account on an exception publishes its address and activation bytes no matter what `ToString` says. Carry an `AccountSummary` instead. A test enforces this: see `ExceptionsCannotReachAnAccount`.
+- Remember that an exception's `Message` gets logged too, so mask anything you interpolate into one.
+- Wrap a new secret in `Dinah.Core.Security.SecretString`, which keeps the value behind `Reveal()` where reflection cannot find it and prints `[REDACTED length=N]` everywhere else. Implement `ILogMasked` on a type that needs a masked identity in logs.
+- `Reveal()` at the point of use, and nowhere else. Interpolating a secret into a string is not a compile error, so a redaction can end up sent over the wire in place of the real value - cover any new call site with a test.
+
 ## Submitting a Pull Request
 
 1.  **Commit your changes** with a clear message.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Dependency bump only, to pick up the `SecretString` work upstream. The log leak this enables fixing is still open; see below.

## What moved

| Package | From | To | Projects |
|---|---|---|---|
| `Dinah.Core` | 10.2.1.1 | 10.2.2.1 | `FileManager`, `DataLayer`, `CrossPlatformClientExe` |
| `Dinah.Core.WindowsDesktop` | 10.2.1.1 | 10.2.2.1 | `LibationWinForms` |
| `Dinah.EntityFrameworkCore` | 10.2.1.1 | 10.2.2.1 | `DataLayer` |
| `AudibleApi` | 10.3.5.1 | 11.0.0.1 | `AudibleUtilities`, `LibationFileManager` |

`AudibleApi` 11 is a breaking release: token, key, and cookie values are held in a `SecretString` rather than a `string`, so no public member exposes plaintext for a reflective logger to find. Nine call sites here read one and now call `Reveal()` - `AccountCredentialStatus` plus eight in `Mkb79Auth` - and four test fixtures build cookie lists whose type changed.

Two spots needed more than a mechanical edit. `Mkb79Auth` exports to and imports from audible-cli's JSON format, which is plaintext by definition, so both directions reveal explicitly and the on-disk format is unchanged. And `Account.DecryptKey` stays a plain string in this PR - converting it is separate work.

## Testing

All 1396 tests pass (23 skipped, the opt-in ones). `LibationAvalonia` and `LibationCli` build clean; the only warning is the pre-existing `NU1903` SQLite advisory.

`LibationWinForms` cannot be compiled on Linux (`net10.0-windows7.0`), so I verified it by restore instead: it resolves `Dinah.Core.WindowsDesktop/10.2.2.1` and `Dinah.Core/10.2.2.1`. I also grepped the whole `Source` tree, Windows-only projects included, for any remaining read of a token or cookie value - there are none, so a Windows build should not turn up more of these.

One test-integrity check worth recording. Assertions like `RefreshToken.Value.Should().Be(SampleRefreshToken)` now compare a `SecretString` against a `string` and still compile, which raised the question of whether they had quietly become vacuous. They have not: substituting a deliberately wrong expected value fails the test, so the persistence round-trip is still genuinely verified.

## Not in this PR

The reported leak is untouched. `AuthenticationRequiredException` still carries a live `Account`, so `Serilog.Exceptions` still writes the account's address into `Log.log` - the file people are asked to attach to public issues - and would write the activation bytes with it. What this bump does is remove the tokens, keys, and session cookies from that same dump, since those objects no longer expose plaintext at all.

Still to do, in rough order: give the exception a log-safe account summary instead of the live object and mask the address out of its message; make `Account.ToString()` masked and register a Serilog destructuring policy so `{@Account}` cannot leak; convert `Account.DecryptKey` to `SecretString`; and add the regression test that logs a real `AuthenticationRequiredException` through `Serilog.Exceptions` and asserts no plaintext.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b80210b1-d979-43bf-808b-38924f2dd9d1?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b80210b1-d979-43bf-808b-38924f2dd9d1&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

