### PR TITLE
Fix concurrent-collection crash when reading settings from multiple threads (#1959)

### DIFF
--- a/Source/FileManager/PersistentDictionary.cs
+++ b/Source/FileManager/PersistentDictionary.cs
@@ -4,6 +4,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.IO;
+using System.Threading;
 
 namespace FileManager;
 
@@ -15,6 +16,12 @@ public class PersistentDictionary : IJsonBackedDictionary
 	// optimize for strings. expectation is most settings will be strings and a rare exception will be something else
 	private Dictionary<string, string?> stringCache { get; } = new();
 	private Dictionary<string, object?> objectCache { get; } = new();
+
+	// Configuration.Instance is a process-wide singleton whose properties are read and written from
+	// the UI thread, BackgroundWorker callbacks and download workers simultaneously. Every cache and
+	// file access below must be serialized: unsynchronized Dictionary writes corrupt the cache, and
+	// unsynchronized file access lets a reader observe a half-written file.
+	private Lock locker { get; } = new();
 
 	public PersistentDictionary(string filepath, bool isReadOnly = false)
 	{
@@ -36,32 +43,48 @@ public class PersistentDictionary : IJsonBackedDictionary
 	[return: NotNullIfNotNull(nameof(defaultValue))]
 	public string? GetString(string propertyName, string? defaultValue = null)
 	{
-		if (!stringCache.ContainsKey(propertyName))
+		lock (locker)
 		{
-			var jObject = readFile();
-			if (jObject.ContainsKey(propertyName))
-				stringCache[propertyName] = jObject[propertyName]?.Value<string>();
-			else
-				stringCache[propertyName] = defaultValue;
-		}
+			if (!stringCache.ContainsKey(propertyName))
+			{
+				var jObject = readFile();
+				if (jObject.ContainsKey(propertyName))
+					stringCache[propertyName] = jObject[propertyName]?.Value<string>();
+				else
+					stringCache[propertyName] = defaultValue;
+			}
 
-		return stringCache[propertyName];
+			return stringCache[propertyName];
+		}
 	}
 
 	[return: NotNullIfNotNull(nameof(defaultValue))]
 	public T? GetNonString<T>(string propertyName, T? defaultValue = default)
 	{
-		var obj = GetObject(propertyName);
-
-		if (obj is null)
+		object? obj;
+		lock (locker)
 		{
-			objectCache[propertyName] = defaultValue;
-			return defaultValue;
+			obj = getObject(propertyName);
+
+			if (obj is null)
+			{
+				objectCache[propertyName] = defaultValue;
+				return defaultValue;
+			}
 		}
+
+		// UpCast can throw InvalidConfigurationValueException. Do it outside the lock: it neither
+		// reads nor writes the cache, and callers turn the exception into a user-facing error.
 		return IJsonBackedDictionary.UpCast<T>(obj, propertyName);
 	}
 
 	public object? GetObject(string propertyName)
+	{
+		lock (locker)
+			return getObject(propertyName);
+	}
+
+	private object? getObject(string propertyName)
 	{
 		if (!objectCache.ContainsKey(propertyName))
 		{
@@ -76,47 +99,68 @@ public class PersistentDictionary : IJsonBackedDictionary
 
 	public string? GetStringFromJsonPath(string jsonPath)
 	{
-		if (!stringCache.ContainsKey(jsonPath))
+		lock (locker)
 		{
-			try
+			if (!stringCache.ContainsKey(jsonPath))
 			{
-				var jObject = readFile();
-				var token = jObject.SelectToken(jsonPath);
-				if (token is null)
+				try
+				{
+					var jObject = readFile();
+					var token = jObject.SelectToken(jsonPath);
+					if (token is null)
+						return null;
+					stringCache[jsonPath] = token.Value<string>();
+				}
+				catch
+				{
 					return null;
-				stringCache[jsonPath] = token.Value<string>();
+				}
 			}
-			catch
-			{
-				return null;
-			}
-		}
 
-		return stringCache[jsonPath];
+			return stringCache[jsonPath];
+		}
 	}
 
-	public bool Exists(string propertyName) => readFile().ContainsKey(propertyName);
+	public bool Exists(string propertyName)
+	{
+		lock (locker)
+			return readFile().ContainsKey(propertyName);
+	}
 
-	private object locker { get; } = new object();
 	public void SetString(string propertyName, string? newValue)
 	{
-		// only do this check in string cache, NOT object cache
-		if (stringCache.ContainsKey(propertyName) && stringCache[propertyName] == newValue)
-			return;
+		bool written;
+		lock (locker)
+		{
+			// only do this check in string cache, NOT object cache
+			if (stringCache.ContainsKey(propertyName) && stringCache[propertyName] == newValue)
+				return;
 
-		// set cache
-		stringCache[propertyName] = newValue;
+			// set cache
+			stringCache[propertyName] = newValue;
 
-		writeFile(propertyName, newValue);
+			written = writeFile(propertyName, newValue);
+		}
+
+		if (written)
+			logConfigChanged(propertyName, newValue);
 	}
 
 	public void SetNonString(string propertyName, object? newValue)
 	{
-		// set cache
-		objectCache[propertyName] = newValue;
+		bool written;
+		JToken parsedNewValue;
+		lock (locker)
+		{
+			// set cache
+			objectCache[propertyName] = newValue;
 
-		var parsedNewValue = JToken.Parse(JsonConvert.SerializeObject(newValue));
-		writeFile(propertyName, parsedNewValue);
+			parsedNewValue = JToken.Parse(JsonConvert.SerializeObject(newValue));
+			written = writeFile(propertyName, parsedNewValue);
+		}
+
+		if (written)
+			logConfigChanged(propertyName, parsedNewValue.ToString());
 	}
 
 	public bool RemoveProperty(string propertyName)
@@ -148,30 +192,32 @@ public class PersistentDictionary : IJsonBackedDictionary
 		return success;
 	}
 
-	private void writeFile(string propertyName, JToken? newValue)
+	/// <summary>Caller must hold <see cref="locker"/>.</summary>
+	/// <returns>The file was rewritten</returns>
+	private bool writeFile(string propertyName, JToken? newValue)
 	{
 		if (IsReadOnly)
-			return;
+			return false;
 
 		// write new setting to file
-		lock (locker)
-		{
-			var jObject = readFile();
-			var startContents = JsonConvert.SerializeObject(jObject, Formatting.Indented);
+		var jObject = readFile();
+		var startContents = JsonConvert.SerializeObject(jObject, Formatting.Indented);
 
-			jObject[propertyName] = newValue;
-			var endContents = JsonConvert.SerializeObject(jObject, Formatting.Indented);
+		jObject[propertyName] = newValue;
+		var endContents = JsonConvert.SerializeObject(jObject, Formatting.Indented);
 
-			if (startContents == endContents)
-				return;
+		if (startContents == endContents)
+			return false;
 
-			File.WriteAllText(Filepath, endContents);
-		}
+		File.WriteAllText(Filepath, endContents);
+		return true;
+	}
 
+	private static void logConfigChanged(string propertyName, string? newValue)
+	{
 		try
 		{
-			var str = formatValueForLog(newValue?.ToString());
-			Serilog.Log.Logger.Information("Config changed. {@DebugInfo}", new { propertyName, newValue = str });
+			Serilog.Log.Logger.Information("Config changed. {@DebugInfo}", new { propertyName, newValue = formatValueForLog(newValue) });
 		}
 		catch { }
 	}
@@ -185,19 +231,17 @@ public class PersistentDictionary : IJsonBackedDictionary
 
 		var path = $"{jsonPath}.{propertyName}";
 
-		{
-			// only do this check in string cache, NOT object cache
-			if (stringCache.ContainsKey(path) && stringCache[path] == newValue)
-				return false;
-
-			// set cache
-			stringCache[path] = newValue;
-		}
-
 		try
 		{
 			lock (locker)
 			{
+				// only do this check in string cache, NOT object cache
+				if (stringCache.ContainsKey(path) && stringCache[path] == newValue)
+					return false;
+
+				// set cache
+				stringCache[path] = newValue;
+
 				var jObject = readFile();
 				var token = jObject.SelectToken(jsonPath);
 				if (token is null || token[propertyName] is null)
@@ -237,6 +281,7 @@ public class PersistentDictionary : IJsonBackedDictionary
 		: value.Length > 100 ? $"[Length={value.Length}] {value[0..50]}...{value[^50..^0]}"
 		: value;
 
+	/// <summary>Caller must hold <see cref="locker"/>.</summary>
 	private JObject readFile()
 	{
 		if (!File.Exists(Filepath))
@@ -273,5 +318,9 @@ public class PersistentDictionary : IJsonBackedDictionary
 		File.WriteAllText(Filepath, "{}");
 	}
 
-	public JObject GetJObject() => readFile();
+	public JObject GetJObject()
+	{
+		lock (locker)
+			return readFile();
+	}
 }

--- a/Source/FileManager/PersistentDictionary.cs
+++ b/Source/FileManager/PersistentDictionary.cs
@@ -1,4 +1,5 @@
-﻿using Newtonsoft.Json;
+﻿using Dinah.Core.IO;
+using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using System;
 using System.Collections.Generic;
@@ -21,6 +22,9 @@ public class PersistentDictionary : IJsonBackedDictionary
 	// the UI thread, BackgroundWorker callbacks and download workers simultaneously. Every cache and
 	// file access below must be serialized: unsynchronized Dictionary writes corrupt the cache, and
 	// unsynchronized file access lets a reader observe a half-written file.
+	// This lock cannot reach a second process (the GUI and the CLI share Settings.json), which is why
+	// every write goes through AtomicFileWriter: an outside reader sees either the old file or the new
+	// one, never a truncated one.
 	private Lock locker { get; } = new();
 
 	public PersistentDictionary(string filepath, bool isReadOnly = false)
@@ -182,7 +186,7 @@ public class PersistentDictionary : IJsonBackedDictionary
 
 				var endContents = JsonConvert.SerializeObject(jObject, Formatting.Indented);
 
-				File.WriteAllText(Filepath, endContents);
+				writeFileContents(endContents);
 				success = true;
 			}
 			Serilog.Log.Logger.Information("Removed property. {propertyName}", propertyName);
@@ -209,7 +213,7 @@ public class PersistentDictionary : IJsonBackedDictionary
 		if (startContents == endContents)
 			return false;
 
-		File.WriteAllText(Filepath, endContents);
+		writeFileContents(endContents);
 		return true;
 	}
 
@@ -252,7 +256,7 @@ public class PersistentDictionary : IJsonBackedDictionary
 					return false;
 
 				token[propertyName] = newValue;
-				File.WriteAllText(Filepath, JsonConvert.SerializeObject(jObject, Formatting.Indented));
+				writeFileContents(JsonConvert.SerializeObject(jObject, Formatting.Indented));
 			}
 		}
 		catch (Exception exDebug)
@@ -280,6 +284,23 @@ public class PersistentDictionary : IJsonBackedDictionary
 		: string.IsNullOrWhiteSpace(value) ? $"[whitespace. Length={value.Length}]"
 		: value.Length > 100 ? $"[Length={value.Length}] {value[0..50]}...{value[^50..^0]}"
 		: value;
+
+	/// <summary>
+	/// Replaces the settings file in one step, so a concurrent reader - including one in another
+	/// Libation process - sees either the whole old file or the whole new one. Mirrors how
+	/// <see cref="Dinah.Core.IO.JsonFilePersister{T}"/> saves AccountsSettings.json.
+	/// </summary>
+	private void writeFileContents(string contents)
+		=> AtomicFileWriter.WriteAllText(Filepath, contents, validateJsonTempFile);
+
+	/// <summary>Throws before the temp file replaces the real one, leaving the real one untouched.</summary>
+	private static void validateJsonTempFile(string tempPath)
+	{
+		var contents = File.ReadAllText(tempPath);
+		if (string.IsNullOrWhiteSpace(contents))
+			throw new JsonSerializationException($"Refusing to write an empty settings file to {tempPath}");
+		JToken.Parse(contents);
+	}
 
 	/// <summary>Caller must hold <see cref="locker"/>.</summary>
 	private JObject readFile()
@@ -315,7 +336,7 @@ public class PersistentDictionary : IJsonBackedDictionary
 
 	private void createNewFile()
 	{
-		File.WriteAllText(Filepath, "{}");
+		writeFileContents("{}");
 	}
 
 	public JObject GetJObject()

--- a/Source/FileManager/PersistentDictionary.cs
+++ b/Source/FileManager/PersistentDictionary.cs
@@ -289,9 +289,27 @@ public class PersistentDictionary : IJsonBackedDictionary
 	/// Replaces the settings file in one step, so a concurrent reader - including one in another
 	/// Libation process - sees either the whole old file or the whole new one. Mirrors how
 	/// <see cref="Dinah.Core.IO.JsonFilePersister{T}"/> saves AccountsSettings.json.
+	/// <para/>
+	/// Windows refuses to rename over a file while someone else holds a handle to it, and the CLI,
+	/// another GUI instance or a virus scanner can all hold Settings.json for a moment, so retry
+	/// before giving up and letting the caller see the failure.
 	/// </summary>
 	private void writeFileContents(string contents)
-		=> AtomicFileWriter.WriteAllText(Filepath, contents, validateJsonTempFile);
+	{
+		const int attempts = 5;
+		for (var attempt = 1; ; attempt++)
+		{
+			try
+			{
+				AtomicFileWriter.WriteAllText(Filepath, contents, validateJsonTempFile);
+				return;
+			}
+			catch (Exception ex) when (attempt < attempts && ex is IOException or UnauthorizedAccessException)
+			{
+				Thread.Sleep(20 * attempt);
+			}
+		}
+	}
 
 	/// <summary>Throws before the temp file replaces the real one, leaving the real one untouched.</summary>
 	private static void validateJsonTempFile(string tempPath)

--- a/Source/_Tests/FileManager.Tests/PersistentDictionaryConcurrencyTests.cs
+++ b/Source/_Tests/FileManager.Tests/PersistentDictionaryConcurrencyTests.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Threading;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 
 namespace FileManager.Tests;
@@ -188,6 +189,71 @@ public class PersistentDictionaryConcurrencyTests
 					}
 				});
 			}
+		}
+		finally
+		{
+			deleteSettingsFile(file);
+		}
+	}
+
+	/// <summary>
+	/// The lock cannot reach a second process - the GUI and the CLI share one Settings.json - so a
+	/// write must never leave the file truncated. Reading it straight off disk, bypassing the
+	/// dictionary, stands in for that outside reader.
+	/// </summary>
+	[TestMethod]
+	public void ExternalReaderNeverSeesAPartiallyWrittenFile()
+	{
+		var file = createSettingsFile();
+		try
+		{
+			var dictionary = new PersistentDictionary(file);
+
+			// a payload big enough that a non-atomic write has a window to be caught mid-flight
+			var padding = new string('x', 64 * 1024);
+			var done = false;
+
+			runConcurrently(thread =>
+			{
+				if (thread == 0)
+				{
+					try
+					{
+						for (var i = 0; i < Keys; i++)
+							dictionary.SetString("Padded", $"{padding}{i}");
+					}
+					finally
+					{
+						Volatile.Write(ref done, true);
+					}
+					return;
+				}
+
+				while (!Volatile.Read(ref done))
+				{
+					string contents;
+					try
+					{
+						// share the file the way a cooperative outside reader would, so an atomic
+						// replace is never blocked by this test
+						using var stream = new FileStream(file, FileMode.Open, FileAccess.Read, FileShare.ReadWrite | FileShare.Delete);
+						using var reader = new StreamReader(stream);
+						contents = reader.ReadToEnd();
+					}
+					catch (IOException)
+					{
+						// a sharing violation is the OS refusing the read, not a corrupt file
+						continue;
+					}
+
+					Assert.IsFalse(string.IsNullOrWhiteSpace(contents), "read an empty Settings.json mid-write");
+					// throws JsonReaderException on a truncated file
+					Assert.IsNotNull(JsonConvert.DeserializeObject<JObject>(contents));
+				}
+			});
+
+			// no temp files left behind
+			Assert.AreEqual(1, Directory.GetFiles(Path.GetDirectoryName(file)!).Length);
 		}
 		finally
 		{

--- a/Source/_Tests/FileManager.Tests/PersistentDictionaryConcurrencyTests.cs
+++ b/Source/_Tests/FileManager.Tests/PersistentDictionaryConcurrencyTests.cs
@@ -1,0 +1,225 @@
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.IO;
+using System.Threading;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Newtonsoft.Json.Linq;
+
+namespace FileManager.Tests;
+
+/// <summary>
+/// Configuration is a process-wide singleton whose properties are read from the UI thread, from
+/// BackgroundWorker callbacks and from download workers at the same time, so every
+/// <see cref="PersistentDictionary"/> member has to tolerate concurrent callers.
+/// </summary>
+[TestClass]
+public class PersistentDictionaryConcurrencyTests
+{
+	private const int Threads = 16;
+	private const int Keys = 200;
+	// a data race needs a few attempts to show up reliably; a fresh dictionary each round means
+	// every round races on an empty cache, which is where the colliding inserts happen
+	private const int Rounds = 20;
+
+	private static string createSettingsFile(string contents = "{}")
+	{
+		var dir = Directory.CreateDirectory(Path.Combine(Path.GetTempPath(), "LibationTest_" + Guid.NewGuid().ToString("N"))).FullName;
+		var file = Path.Combine(dir, "Settings.json");
+		File.WriteAllText(file, contents);
+		return file;
+	}
+
+	private static void deleteSettingsFile(string file)
+	{
+		try { Directory.Delete(Path.GetDirectoryName(file)!, recursive: true); } catch { /* ignore */ }
+	}
+
+	private static void assertNoFailures(ConcurrentQueue<Exception> failures)
+	{
+		if (failures.IsEmpty)
+			return;
+
+		var messages = new List<string>();
+		foreach (var ex in failures)
+			messages.Add(ex.ToString());
+
+		Assert.Fail($"{failures.Count} concurrent operation(s) threw:{Environment.NewLine}{string.Join(Environment.NewLine, messages)}");
+	}
+
+	/// <summary>Runs <paramref name="body"/> on <see cref="Threads"/> threads released at the same instant.</summary>
+	private static void runConcurrently(Action<int> body)
+	{
+		var failures = new ConcurrentQueue<Exception>();
+		using var startLine = new Barrier(Threads);
+
+		var threads = new Thread[Threads];
+		for (var i = 0; i < Threads; i++)
+		{
+			var thread = i;
+			threads[i] = new Thread(() =>
+			{
+				try
+				{
+					startLine.SignalAndWait();
+					body(thread);
+				}
+				catch (Exception ex)
+				{
+					failures.Enqueue(ex);
+				}
+			});
+			threads[i].Start();
+		}
+
+		foreach (var thread in threads)
+			thread.Join();
+
+		assertNoFailures(failures);
+	}
+
+	[TestMethod]
+	public void GetNonString_ConcurrentReadersOfUnsetProperties_DoNotCorruptCache()
+	{
+		var file = createSettingsFile();
+		try
+		{
+			for (var round = 0; round < Rounds; round++)
+			{
+				var dictionary = new PersistentDictionary(file);
+
+				// every thread walks the same key set so the cache misses collide
+				runConcurrently(_ =>
+				{
+					for (var i = 0; i < Keys; i++)
+						Assert.IsFalse(dictionary.GetNonString($"Bool{i}", defaultValue: false));
+				});
+			}
+		}
+		finally
+		{
+			deleteSettingsFile(file);
+		}
+	}
+
+	[TestMethod]
+	public void GetString_ConcurrentReadersOfUnsetProperties_DoNotCorruptCache()
+	{
+		var file = createSettingsFile();
+		try
+		{
+			for (var round = 0; round < Rounds; round++)
+			{
+				var dictionary = new PersistentDictionary(file);
+
+				runConcurrently(_ =>
+				{
+					for (var i = 0; i < Keys; i++)
+						Assert.AreEqual($"default{i}", dictionary.GetString($"String{i}", $"default{i}"));
+				});
+			}
+		}
+		finally
+		{
+			deleteSettingsFile(file);
+		}
+	}
+
+	[TestMethod]
+	public void GetAndSet_Concurrently_ReadsBackEveryWrittenValue()
+	{
+		var file = createSettingsFile();
+		try
+		{
+			var dictionary = new PersistentDictionary(file);
+
+			// each thread owns its own keys, so a write is always visible to its own later read
+			runConcurrently(thread =>
+			{
+				for (var i = 0; i < 25; i++)
+				{
+					var boolName = $"Bool_{thread}_{i}";
+					dictionary.SetNonString(boolName, true);
+					Assert.IsTrue(dictionary.GetNonString(boolName, defaultValue: false));
+
+					var stringName = $"String_{thread}_{i}";
+					dictionary.SetString(stringName, $"value_{thread}_{i}");
+					Assert.AreEqual($"value_{thread}_{i}", dictionary.GetString(stringName));
+				}
+			});
+
+			// the file must still be valid json holding every write
+			var reread = new PersistentDictionary(file);
+			for (var thread = 0; thread < Threads; thread++)
+			{
+				for (var i = 0; i < 25; i++)
+				{
+					Assert.IsTrue(reread.GetNonString($"Bool_{thread}_{i}", defaultValue: false), $"Bool_{thread}_{i} was lost");
+					Assert.AreEqual($"value_{thread}_{i}", reread.GetString($"String_{thread}_{i}"), $"String_{thread}_{i} was lost");
+				}
+			}
+		}
+		finally
+		{
+			deleteSettingsFile(file);
+		}
+	}
+
+	[TestMethod]
+	public void GetStringFromJsonPath_ConcurrentReaders_DoNotCorruptCache()
+	{
+		var nested = new JObject();
+		for (var i = 0; i < Keys; i++)
+			nested[$"Name{i}"] = $"value{i}";
+
+		var file = createSettingsFile(new JObject { ["Nested"] = nested }.ToString());
+		try
+		{
+			for (var round = 0; round < Rounds; round++)
+			{
+				var dictionary = new PersistentDictionary(file);
+
+				runConcurrently(_ =>
+				{
+					for (var i = 0; i < Keys; i++)
+					{
+						Assert.AreEqual($"value{i}", dictionary.GetStringFromJsonPath($"Nested.Name{i}"));
+						Assert.IsNull(dictionary.GetStringFromJsonPath($"Nested.Missing{i}"));
+					}
+				});
+			}
+		}
+		finally
+		{
+			deleteSettingsFile(file);
+		}
+	}
+
+	[TestMethod]
+	public void ReadWhileWriting_DoesNotThrow()
+	{
+		var file = createSettingsFile();
+		try
+		{
+			var dictionary = new PersistentDictionary(file);
+
+			// readers keep hitting the file (Exists/GetJObject never cache) while writers rewrite it
+			runConcurrently(thread =>
+			{
+				if (thread % 2 == 0)
+					for (var i = 0; i < Keys; i++)
+						dictionary.SetNonString($"Written_{thread}", i);
+				else
+					for (var i = 0; i < Keys; i++)
+					{
+						dictionary.Exists($"Written_{i}");
+						Assert.IsNotNull(dictionary.GetJObject());
+					}
+			});
+		}
+		finally
+		{
+			deleteSettingsFile(file);
+		}
+	}
+}

--- a/Source/_Tests/FileManager.Tests/PersistentDictionaryConcurrencyTests.cs
+++ b/Source/_Tests/FileManager.Tests/PersistentDictionaryConcurrencyTests.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.IO;
+using System.Runtime.Versioning;
 using System.Threading;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Newtonsoft.Json;
@@ -276,9 +277,23 @@ public class PersistentDictionaryConcurrencyTests
 	[TestMethod]
 	public void Write_SurvivesATemporarilyUnwritableDirectory()
 	{
+		// Assert.Inconclusive is not [DoesNotReturn], so return explicitly or the body below still
+		// looks reachable on Windows to the platform compatibility analyzer
 		if (!OperatingSystem.IsLinux() && !OperatingSystem.IsMacOS())
+		{
 			Assert.Inconclusive("Skipped because revoking directory write permission needs unix file modes.");
+			return;
+		}
 
+		writeSurvivesATemporarilyUnwritableDirectory();
+	}
+
+	// the attributes, rather than a guard, are what let the restore callback below use unix file modes:
+	// platform narrowing from an OperatingSystem.IsX() check does not reach inside a lambda
+	[SupportedOSPlatform("linux")]
+	[SupportedOSPlatform("macos")]
+	private static void writeSurvivesATemporarilyUnwritableDirectory()
+	{
 		var file = createSettingsFile();
 		var directory = Path.GetDirectoryName(file)!;
 		var original = File.GetUnixFileMode(directory);

--- a/Source/_Tests/FileManager.Tests/PersistentDictionaryConcurrencyTests.cs
+++ b/Source/_Tests/FileManager.Tests/PersistentDictionaryConcurrencyTests.cs
@@ -200,10 +200,17 @@ public class PersistentDictionaryConcurrencyTests
 	/// The lock cannot reach a second process - the GUI and the CLI share one Settings.json - so a
 	/// write must never leave the file truncated. Reading it straight off disk, bypassing the
 	/// dictionary, stands in for that outside reader.
+	/// <para/>
+	/// Unix only. These readers hold a handle almost continuously, and Windows denies a rename over
+	/// an open file however generously the reader shares it, so on Windows this would test the
+	/// retry in <c>writeFileContents</c> rather than the atomicity of the write.
 	/// </summary>
 	[TestMethod]
 	public void ExternalReaderNeverSeesAPartiallyWrittenFile()
 	{
+		if (Environment.OSVersion.Platform != PlatformID.Unix)
+			Assert.Inconclusive($"Skipped because OS is not {PlatformID.Unix}.");
+
 		var file = createSettingsFile();
 		try
 		{
@@ -258,6 +265,57 @@ public class PersistentDictionaryConcurrencyTests
 		finally
 		{
 			deleteSettingsFile(file);
+		}
+	}
+
+	/// <summary>
+	/// Windows denies a rename over a file another handle holds open, and the CLI, a second GUI or a
+	/// virus scanner can all do that for a moment, so a write has to outlast a brief denial. Revoking
+	/// write permission on the containing directory reproduces that denial portably.
+	/// </summary>
+	[TestMethod]
+	public void Write_SurvivesATemporarilyUnwritableDirectory()
+	{
+		if (!OperatingSystem.IsLinux() && !OperatingSystem.IsMacOS())
+			Assert.Inconclusive("Skipped because revoking directory write permission needs unix file modes.");
+
+		var file = createSettingsFile();
+		var directory = Path.GetDirectoryName(file)!;
+		var original = File.GetUnixFileMode(directory);
+		try
+		{
+			var dictionary = new PersistentDictionary(file);
+			File.SetUnixFileMode(directory, UnixFileMode.UserRead | UnixFileMode.UserExecute);
+
+			if (canCreateFileIn(directory))
+				Assert.Inconclusive("Skipped because this user can write to a read-only directory (running as root?).");
+
+			// shorter than the retry budget in writeFileContents
+			using var restore = new Timer(_ => File.SetUnixFileMode(directory, original), null, dueTime: 50, period: Timeout.Infinite);
+
+			dictionary.SetString("WrittenDespiteTheOutage", "value");
+
+			Assert.AreEqual("value", new PersistentDictionary(file).GetString("WrittenDespiteTheOutage"));
+		}
+		finally
+		{
+			try { File.SetUnixFileMode(directory, original); } catch { /* ignore */ }
+			deleteSettingsFile(file);
+		}
+	}
+
+	private static bool canCreateFileIn(string directory)
+	{
+		var probe = Path.Combine(directory, Guid.NewGuid().ToString("N"));
+		try
+		{
+			File.WriteAllText(probe, "");
+			File.Delete(probe);
+			return true;
+		}
+		catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+		{
+			return false;
 		}
 	}
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes the crash reported in [#1959](https://github.com/rmcrackan/Libation/issues/1959), and hardens the same file against torn writes.

Three commits:
1. `fix(config): serialize PersistentDictionary cache and file access` - the crash.
2. `fix(config): replace Settings.json atomically instead of truncating it` - the non-atomic write.
3. `fix(config): outlast a brief lock on Settings.json, and scope the reader test to unix` - fallout from 2 that Windows CI caught.

## 1. The crash

The reporter's log shows:

```
[ERR] (at LibationAvalonia.Program.LogAndShowCrashMessage(System.Exception)) CRASH
System.InvalidOperationException: Operations that change non-concurrent collections must have
exclusive access. A concurrent update was performed on this collection and corrupted its state.
   at FileManager.PersistentDictionary.GetNonString[T](String propertyName, T defaultValue)
   at LibationAvalonia.ViewModels.MainVM.UpdateCountsBw_Completed(Object sender, RunWorkerCompletedEventArgs e)
```

`Configuration.Instance` is a process-wide singleton, and every property read funnels into `PersistentDictionary.GetString` / `GetNonString`, both of which *write* to a plain `Dictionary` cache on a miss. `PersistentDictionary` guarded only its file writes, so nothing serialized the caches. Two threads inserting at once corrupt the dictionary, and the next lookup throws.

The log pins down the two threads. Immediately before each crash, two `GetCounts` passes finish in the same tenth of a second: one over all 308 books from `updateCountsBw`, one over the 8 visible books from `setLiberatedVisibleMenuItemAsync` (which runs `GetCounts` on `Task.Run`). `RunWorkerCompleted` executes on a thread-pool thread with no `SynchronizationContext`, so its read of `AutoDownloadEpisodes` raced the other pass.

Worth noting: the corruption is permanent for the process. The reporter's crashes recur at 18:30:49, 18:33:24 and 18:38:24, matching their `AutoScan` interval, so once it trips they get a crash dialog every few minutes rather than a one-off. (The other `[ERR]` entries in that log are unrelated - a transient `NameResolutionError` reaching `api.audible.com` that recovered on the next attempt.)

`PersistentDictionary` now takes a single lock across each operation's cache access *and* file access. `writeFile` no longer locks internally (callers hold the lock) and instead reports whether it rewrote the file, which keeps the "Config changed" log line outside the lock and only on a real write, as before.

## 2. The non-atomic write

`File.WriteAllText` truncates the destination before writing, so an interrupted write leaves `Settings.json` half-written or empty. The lock in commit 1 cannot help here, because the GUI and the CLI are separate processes sharing this file.

`Dinah.Core.IO.AtomicFileWriter` already solves exactly this - it writes a sibling temp file, flushes to disk, and renames it over the destination - and `FileManager` already references the package. Every write in `PersistentDictionary` now goes through it, with a `validateTempFile` callback that rejects an empty or unparseable payload before the swap so a bad write leaves the existing file untouched.

This also closes the nastiest variant of the old behaviour: `readFile` responds to empty contents by calling `createNewFile`, so a reader that caught a mid-write truncation would stamp `{}` over `Settings.json`. My `ReadWhileWriting` test reproduces that on unpatched code.

## 3. The Windows fallout

Windows CI then failed, which was worth knowing:

```
System.UnauthorizedAccessException: Access to the path is denied.
   at Dinah.Core.IO.AtomicFileWriter.WriteAllBytes(String path, Byte[] bytes, Action`1 validateTempFile)
   at FileManager.PersistentDictionary.writeFileContents(String contents)
```

Windows refuses to rename over a file while another handle holds it open, however generously that handle shares it. That is not only a test artifact: in production the CLI, a second GUI instance or a virus scanner can each hold `Settings.json` for a moment. So `writeFileContents` now retries the replace a few times with a short backoff before letting the caller see the failure. The old `File.WriteAllText` threw on the same holds, so this is strictly more forgiving than before, not a regression being papered over.

`ExternalReaderNeverSeesAPartiallyWrittenFile` keeps a handle open almost continuously, which no retry budget can outlast on Windows, so it is now restricted to unix where it genuinely tests write atomicity. `Write_SurvivesATemporarilyUnwritableDirectory` covers the retry instead, by revoking write permission on the containing directory mid-test (skipped if the user turns out to be root).

Still not covered: two processes writing concurrently. Each write is now all-or-nothing, but it is a whole-file rewrite, so a simultaneous GUI and CLI write is last-writer-wins. That needs cross-process file locking, which is a bigger change than this bug.

## Does this belong higher up, in `Dinah.Core`?

Half of it, and that half is already there.

The **atomic write** is a general-purpose primitive and it does live in `Dinah.Core.IO.AtomicFileWriter`. Better still, `Dinah.Core.IO.JsonFilePersister<T>` - the base class behind `AccountsSettingsPersister` and `ChardonnayThemePersister` - already combines a per-path lock, an atomic write, and a temp-file JSON validator. `PersistentDictionary` is Libation's own parallel implementation of the same job for `Settings.json`, and it was simply missing both halves. So there is nothing to push upstream; commit 2 is `PersistentDictionary` catching up to the convention already set in `Dinah.Core`, and I copied the validator approach from `JsonFilePersister<T>` deliberately.

The **lock** should stay here. `PersistentDictionary` is a Libation type in `Source/FileManager`, and the race is over its own in-memory `stringCache`/`objectCache` - state `Dinah.Core` has no knowledge of. `AtomicFileWriter` is intentionally stateless and correctly makes no attempt to serialize its callers.

One thing arguably does belong upstream: the retry from commit 3. `JsonFilePersister<T>` writes `AccountsSettings.json` through the same `AtomicFileWriter` and is exposed to the same Windows denial, with no retry. Rather than reach into the package I kept the retry local to `PersistentDictionary`; if you would rather it live in `AtomicFileWriter` so both callers benefit, that is a `Dinah.Core` change and I am happy to open it there instead.

Replacing `PersistentDictionary` with `JsonFilePersister<T>` outright would be the real deduplication, but they are not interchangeable: `JsonFilePersister<T>` persists a strongly-typed `T : IUpdatable`, whereas `PersistentDictionary` is schema-less property-bag access over an arbitrary `JObject`, with per-property caching and JSON-path reads. That is a refactor, not a bug fix, so I have left it alone.

## Testing

`Source/_Tests/FileManager.Tests/PersistentDictionaryConcurrencyTests.cs` hammers each accessor from 16 threads released together on a barrier. Six of the seven tests fail against the unpatched class and pass with the fix.

For the crash, four tests reproduce the issue's exception:

```
failed GetNonString_ConcurrentReadersOfUnsetProperties_DoNotCorruptCache
failed GetString_ConcurrentReadersOfUnsetProperties_DoNotCorruptCache
failed GetStringFromJsonPath_ConcurrentReaders_DoNotCorruptCache
failed ReadWhileWriting_DoesNotThrow
  total: 209  failed: 4  succeeded: 205

System.InvalidOperationException: Operations that change non-concurrent collections must have exclusive access. ...
   at System.Collections.Generic.Dictionary`2.ContainsKey(TKey key)
   at FileManager.PersistentDictionary.GetObject(String propertyName)
   at FileManager.PersistentDictionary.GetNonString[T](String propertyName, T defaultValue)
```

For the atomic write, `ExternalReaderNeverSeesAPartiallyWrittenFile` reads the file straight off disk, bypassing the dictionary, to stand in for a second process. Swapping just the `AtomicFileWriter` calls back to `File.WriteAllText`:

```
failed ExternalReaderNeverSeesAPartiallyWrittenFile
  Assert.Fail failed. 15 concurrent operation(s) threw:
  Assert.IsFalse failed. ... read an empty Settings.json mid-write
```

Fifteen of the fifteen readers caught the file truncated; with `AtomicFileWriter`, none do, and no `.tmp` files are left behind.

For the retry, removing just the retry loop:

```
failed Write_SurvivesATemporarilyUnwritableDirectory
  System.UnauthorizedAccessException: Access to the path
  '/tmp/LibationTest_.../Settings.json.c7cf0f54....tmp' is denied.
```

CI is green on all 11 checks across Windows x64/arm64, macOS x64/arm64, Debian and Redhat x64/arm64, and docker. Locally the full suite from `Source/` passes (`total: 1429  failed: 0  skipped: 23`, the skips being the opt-in OS secret store tests), `FileManager.Tests` passes 5 consecutive runs with no flake, and both `LibationAvalonia` and `LibationCli` build.

[atomic_write_tests_before_and_after.log](https://cursor.com/agents/bc-548d49ff-71bc-4227-9ce2-597033d205e1/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fatomic_write_tests_before_and_after.log)

In the GUI against a seeded demo library, checking two settings on different tabs, saving once, and re-opening Settings shows both persisted. `Settings.json` is still valid JSON with unchanged permissions, no `.tmp` files remain, and there is no `CRASH` entry:

```
[INF] (at FileManager.PersistentDictionary.logConfigChanged(...)) Config changed. {"propertyName":"AutoDownloadEpisodes","newValue":"True"}
[INF] (at FileManager.PersistentDictionary.logConfigChanged(...)) Config changed. {"propertyName":"CreateCueSheet","newValue":"True"}
```

[two_settings_saved_atomically_and_persisted.mp4](https://cursor.com/agents/bc-548d49ff-71bc-4227-9ce2-597033d205e1/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Ftwo_settings_saved_atomically_and_persisted.mp4)

Earlier walkthrough from commit 1, toggling the very setting the crash was reading and confirming the grid recount still works:

[settings_save_and_grid_filter_after_fix.mp4](https://cursor.com/agents/bc-548d49ff-71bc-4227-9ce2-597033d205e1/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fsettings_save_and_grid_filter_after_fix.mp4)

[Settings dialog re-opened with the Auto download books checkbox still checked](https://cursor.com/agents/bc-548d49ff-71bc-4227-9ce2-597033d205e1/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fsettings_reopened_value_persisted.webp)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-548d49ff-71bc-4227-9ce2-597033d205e1?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-548d49ff-71bc-4227-9ce2-597033d205e1&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

