### PR TITLE
Recover a stranded comment fix from the #1956 branch

### DIFF
--- a/Source/LibationUiBase/GridView/GridContextMenu.cs
+++ b/Source/LibationUiBase/GridView/GridContextMenu.cs
@@ -44,9 +44,10 @@ public class GridContextMenu
 
 	/// <summary>
 	/// Whether to offer the PDF status on its own. The pair above deliberately moves both statuses together,
-	/// which left a user who wanted only the PDF back with no way to say so: resetting a title's PDF also
-	/// queued its audiobook for a fresh download, and that download rewrote the title's other files. Offered
-	/// only for a selection that has a PDF, since for anything else the pair above is already audio-only.
+	/// so resetting a title's PDF from here also queues its audiobook for a fresh download. The only PDF-only
+	/// control was the bulk one under Visible Books, which applies to everything on screen, leaving no way to
+	/// say it about one title. Offered only for a selection that has a PDF, since for anything else the pair
+	/// above is already audio-only.
 	/// </summary>
 	public bool ShowPdfStatusItems => PdfItems.Any();
 	public bool SetPdfDownloadedEnabled => PdfItems.Any(udi => udi.PdfStatus != LiberatedStatus.Liberated);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Cherry-pick of `8344d72e` from `cursor/empty-metadata-and-pdf-verification-ffa6`.

That commit was pushed at 00:35 UTC, 24 minutes after [#1956](https://github.com/rmcrackan/Libation/pull/1956) merged at 00:11, so the already-closed PR never picked it up and the change was left stranded on the branch. This carries it over so the branch can be deleted without losing anything.

Comment-only, no behavior change. It corrects the doc comment on `ShowPdfStatusItems`: a PDF-only control did already exist before the new per-row items, namely the bulk `Visible Books > Set PDF 'Downloaded' status manually`. That one applies to everything on screen, so the gap the row items fill is the inability to say it about a single title, not the absence of any PDF-only control at all.

`LibationUiBase` builds clean.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-548d49ff-71bc-4227-9ce2-597033d205e1?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-548d49ff-71bc-4227-9ce2-597033d205e1&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

