### PR TITLE
Fix the CI flake, the crash it was hiding, and widen the exception guard

### DIFF
--- a/Source/AudibleUtilities/AudibleUtilities.csproj
+++ b/Source/AudibleUtilities/AudibleUtilities.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AudibleApi" Version="11.0.2.1" />
+    <PackageReference Include="AudibleApi" Version="11.0.3.1" />
     <PackageReference Include="Google.Protobuf" Version="3.34.1" />
   </ItemGroup>
 

--- a/Source/DataLayer/DataLayer.csproj
+++ b/Source/DataLayer/DataLayer.csproj
@@ -11,8 +11,8 @@
   </PropertyGroup>
   
   <ItemGroup>
-    <PackageReference Include="Dinah.Core" Version="10.2.3.1" />
-    <PackageReference Include="Dinah.EntityFrameworkCore" Version="10.2.2.1" />
+    <PackageReference Include="Dinah.Core" Version="10.2.4.1" />
+    <PackageReference Include="Dinah.EntityFrameworkCore" Version="10.2.4.1" />
 	<PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.0.1" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.0.7" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.7">

--- a/Source/FileManager/BackgroundFileSystem.cs
+++ b/Source/FileManager/BackgroundFileSystem.cs
@@ -85,8 +85,18 @@ public class BackgroundFileSystem : IDisposable
 	}
 	private void Stop()
 	{
-		//Stop raising events
-		fileSystemWatcher?.Dispose();
+		//Stop raising events. Detach first so a handler cannot run after this returns, and clear the field so a
+		//second Stop() is harmless.
+		var watcher = fileSystemWatcher;
+		fileSystemWatcher = null;
+		if (watcher is not null)
+		{
+			watcher.Created -= FileSystemWatcher_Changed;
+			watcher.Deleted -= FileSystemWatcher_Changed;
+			watcher.Renamed -= FileSystemWatcher_Changed;
+			watcher.Error -= FileSystemWatcher_Error;
+			watcher.Dispose();
+		}
 
 		try
 		{
@@ -99,8 +109,12 @@ public class BackgroundFileSystem : IDisposable
 		//Wait for background scanner to terminate before reinitializing.
 		backgroundScanner?.Wait();
 
-		//Dispose of directoryChangesEvents after backgroundScanner exists.
-		directoryChangesEvents?.Dispose();
+		//Dispose of directoryChangesEvents after backgroundScanner exists. Clear the field first so a late event
+		//has nothing to add to. CompleteAdding has to have happened while it was still set, or the scanner would
+		//still be blocked waiting for it.
+		var events = directoryChangesEvents;
+		directoryChangesEvents = null;
+		events?.Dispose();
 
 		lock (fsCacheLocker)
 			fsCache.Clear();
@@ -113,7 +127,18 @@ public class BackgroundFileSystem : IDisposable
 
 	private void FileSystemWatcher_Changed(object sender, FileSystemEventArgs e)
 	{
-		directoryChangesEvents?.Add(e);
+		try
+		{
+			directoryChangesEvents?.Add(e);
+		}
+		// Stop() completes and disposes the collection, but events the OS had already buffered still arrive after
+		// that. On Windows they arrive on a native completion callback, where an exception does not fail a call -
+		// it takes the process down. Dropping them is correct: whoever called Stop() is either reinitializing,
+		// which rebuilds the cache from disk, or disposing.
+		//
+		// Covers both ways the collection refuses: completed for additions, and disposed, whose
+		// ObjectDisposedException derives from this.
+		catch (InvalidOperationException) { }
 	}
 
 	#region Background Thread

--- a/Source/FileManager/FileManager.csproj
+++ b/Source/FileManager/FileManager.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Dinah.Core" Version="10.2.3.1" />
+    <PackageReference Include="Dinah.Core" Version="10.2.4.1" />
     <PackageReference Include="Polly" Version="8.6.6" />
   </ItemGroup>
 

--- a/Source/LibationFileManager/LibationFileManager.csproj
+++ b/Source/LibationFileManager/LibationFileManager.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AudibleApi" Version="11.0.2.1" />
+    <PackageReference Include="AudibleApi" Version="11.0.3.1" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="10.0.7" />
     <PackageReference Include="NameParserSharp" Version="1.5.0" />
     <PackageReference Include="Serilog.Exceptions" Version="8.4.0" />

--- a/Source/LibationWinForms/LibationWinForms.csproj
+++ b/Source/LibationWinForms/LibationWinForms.csproj
@@ -41,7 +41,7 @@
 
 
 	<ItemGroup>
-		<PackageReference Include="Dinah.Core.WindowsDesktop" Version="10.2.3.1" />
+		<PackageReference Include="Dinah.Core.WindowsDesktop" Version="10.2.4.1" />
 		<PackageReference Include="Microsoft.Web.WebView2" Version="1.0.3912.50" />
 	</ItemGroup>
 

--- a/Source/_Demos/LoadByOS/CrossPlatformClientExe/CrossPlatformClientExe.csproj
+++ b/Source/_Demos/LoadByOS/CrossPlatformClientExe/CrossPlatformClientExe.csproj
@@ -19,7 +19,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Dinah.Core" Version="10.2.3.1" />
+    <PackageReference Include="Dinah.Core" Version="10.2.4.1" />
   </ItemGroup>
 
 </Project>

--- a/Source/_Tests/AudibleUtilities.Tests/AuthenticationRequiredExceptionLogSafetyTests.cs
+++ b/Source/_Tests/AudibleUtilities.Tests/AuthenticationRequiredExceptionLogSafetyTests.cs
@@ -14,7 +14,6 @@ using Serilog.Exceptions;
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Reflection;
 using System.Security.Cryptography;
 
 namespace AudibleUtilities.Tests;
@@ -169,87 +168,6 @@ public class AccountMasking
 	}
 }
 
-/// <summary>
-/// A guard against the next exception type reintroducing this. Serilog.Exceptions walks the public property
-/// graph of whatever exception it is handed, to a default depth of 10, so no exception may be able to reach an
-/// account or an identity that way.
-/// </summary>
-[TestClass]
-public class ExceptionsCannotReachAnAccount
-{
-	private static readonly Type[] Forbidden =
-	[
-		typeof(Account),
-		typeof(AccountsSettings),
-		typeof(Identity),
-		typeof(AccessToken),
-		typeof(RefreshToken),
-		typeof(AdpToken),
-		typeof(PrivateKey)
-	];
-
-	[TestMethod]
-	public void no_exception_type_exposes_one_through_its_public_properties()
-	{
-		// the assemblies this test project can see. Account and the authentication exception live in the first.
-		var assemblies = new[]
-		{
-			typeof(Account).Assembly,
-			typeof(Configuration).Assembly,
-			typeof(FileManager.LongPath).Assembly
-		};
-
-		var exceptionTypes = assemblies
-			.SelectMany(a => a.GetTypes())
-			.Where(t => typeof(Exception).IsAssignableFrom(t))
-			.ToArray();
-
-		Assert.IsTrue(exceptionTypes.Length > 0, "found no exception types to check");
-
-		foreach (var exceptionType in exceptionTypes)
-		{
-			var path = findForbidden(exceptionType, depth: 0, [], []);
-			Assert.IsNull(path, $"{exceptionType.Name} can reach a secret-bearing type through public properties: {path}");
-		}
-	}
-
-	private static string? findForbidden(Type type, int depth, HashSet<Type> visited, List<string> trail)
-	{
-		if (depth > 10 || !visited.Add(type))
-			return null;
-
-		foreach (var property in type.GetProperties(BindingFlags.Public | BindingFlags.Instance))
-		{
-			if (property.GetIndexParameters().Length > 0)
-				continue;
-
-			var propertyType = unwrap(property.PropertyType);
-			var step = trail.Append($"{type.Name}.{property.Name}").ToList();
-
-			if (Forbidden.Contains(propertyType))
-				return string.Join(" -> ", step);
-
-			if (propertyType.Assembly == typeof(Account).Assembly || propertyType.Assembly == typeof(Identity).Assembly)
-			{
-				var found = findForbidden(propertyType, depth + 1, visited, step);
-				if (found is not null)
-					return found;
-			}
-		}
-
-		return null;
-	}
-
-	/// <summary>Collections and nullables hide the interesting type one level down.</summary>
-	private static Type unwrap(Type type)
-	{
-		if (type.IsArray)
-			return unwrap(type.GetElementType()!);
-
-		if (!type.IsGenericType)
-			return type;
-
-		var arguments = type.GetGenericArguments();
-		return arguments.Length == 1 ? unwrap(arguments[0]) : type;
-	}
-}
+// The guard that no exception type can reach an Account lives in LibationUiBase.Tests
+// (ExceptionsCannotReachAnAccount): a test only sees the assemblies its own project references, and that one
+// reaches ApplicationServices, FileLiberator, and DataLayer as well as these.

--- a/Source/_Tests/FileLiberator.Tests/DownloadDecryptBookTests.cs
+++ b/Source/_Tests/FileLiberator.Tests/DownloadDecryptBookTests.cs
@@ -3,7 +3,15 @@ using AudibleApi.Common;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System.Collections.Generic;
 
-[assembly: Parallelize]
+// Deliberately not [assembly: Parallelize]. Classes here reach for state that is process-wide by nature - the
+// Configuration singleton, the LIBATION_FILES_DIR environment variable, and AudibleFileStorage's static file
+// cache - so running two of them at once means one swapping the config or deleting its temp directory while
+// another is enumerating it. That surfaced as seven failures in a Windows CI leg, all thrown from a
+// TestInitialize rather than an assertion, on a path no test in the failing class had created.
+//
+// Opting out per class was the previous arrangement and it does not hold: three classes carried
+// [DoNotParallelize] while two others touching the same state did not, and nothing points that out to whoever
+// adds the sixth. Those attributes are kept below as a statement of intent should this ever come back.
 
 namespace FileLiberator.Tests;
 

--- a/Source/_Tests/FileManager.Tests/BackgroundFileSystemTests.cs
+++ b/Source/_Tests/FileManager.Tests/BackgroundFileSystemTests.cs
@@ -1,0 +1,105 @@
+using FileManager;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.IO;
+using System.Text.RegularExpressions;
+using System.Threading;
+
+namespace BackgroundFileSystemTests;
+
+/// <summary>
+/// The first tests for this class, prompted by a CI run where every test passed and the run still failed:
+/// FileLiberator.Tests exited with 0xE0434352 and
+/// <c>InvalidOperationException: The collection has been marked as complete with regards to additions</c>,
+/// thrown from FileSystemWatcher_Changed. Disposing while the OS still had events buffered took the process
+/// down, because on Windows those arrive on a native completion callback where nothing catches anything.
+/// </summary>
+[TestClass]
+[DoNotParallelize]
+public class DisposeWhileEventsAreArriving
+{
+	private string tempDir = string.Empty;
+
+	[TestInitialize]
+	public void Initialize()
+	{
+		tempDir = Path.Combine(Path.GetTempPath(), $"libation-bfs-tests-{Guid.NewGuid():N}");
+		Directory.CreateDirectory(tempDir);
+	}
+
+	[TestCleanup]
+	public void Cleanup()
+	{
+		try
+		{
+			Directory.Delete(tempDir, recursive: true);
+		}
+		catch (IOException)
+		{
+			// A leftover temp directory is not worth failing a test over.
+		}
+	}
+
+	/// <summary>
+	/// Churns the directory hard enough that events are in flight, then disposes underneath them. The assertion
+	/// that matters is that the process is still alive afterwards: before the fix this crashed the test host
+	/// rather than failing anything.
+	/// </summary>
+	[TestMethod]
+	public void disposing_under_a_flood_of_events_does_not_crash()
+	{
+		for (var attempt = 0; attempt < 20; attempt++)
+		{
+			var sut = new BackgroundFileSystem(tempDir, "*.*", SearchOption.AllDirectories);
+
+			for (var i = 0; i < 50; i++)
+				File.WriteAllText(Path.Combine(tempDir, $"file-{attempt}-{i}.txt"), "x");
+
+			// no wait: the point is to dispose while the watcher still has events to deliver
+			sut.Dispose();
+
+			foreach (var file in Directory.GetFiles(tempDir))
+				File.Delete(file);
+		}
+
+		// give any late callback the chance to arrive and take the process with it
+		Thread.Sleep(250);
+	}
+
+	[TestMethod]
+	public void disposing_twice_is_harmless()
+	{
+		var sut = new BackgroundFileSystem(tempDir, "*.*", SearchOption.AllDirectories);
+
+		sut.Dispose();
+		sut.Dispose();
+	}
+
+	[TestMethod]
+	public void files_present_before_and_after_construction_are_both_found()
+	{
+		File.WriteAllText(Path.Combine(tempDir, "before.txt"), "x");
+
+		using var sut = new BackgroundFileSystem(tempDir, "*.*", SearchOption.AllDirectories);
+
+		Assert.IsNotNull(sut.FindFile(new Regex(@"before\.txt$")));
+
+		File.WriteAllText(Path.Combine(tempDir, "after.txt"), "x");
+
+		// the watcher feeds a background scanner, so the new file appears when it gets there
+		var found = WaitFor(() => sut.FindFile(new Regex(@"after\.txt$")) is not null);
+		Assert.IsTrue(found, "a file created after construction never reached the cache");
+	}
+
+	private static bool WaitFor(Func<bool> condition, int timeoutMs = 5000)
+	{
+		for (var waited = 0; waited < timeoutMs; waited += 50)
+		{
+			if (condition())
+				return true;
+			Thread.Sleep(50);
+		}
+
+		return false;
+	}
+}

--- a/Source/_Tests/LibationUiBase.Tests/ExceptionsCannotReachAnAccountTests.cs
+++ b/Source/_Tests/LibationUiBase.Tests/ExceptionsCannotReachAnAccountTests.cs
@@ -1,0 +1,126 @@
+using ApplicationServices;
+using AudibleApi;
+using AppScaffolding;
+using AudibleApi.Authorization;
+using AudibleApi.Cryptography;
+using AudibleUtilities;
+using DataLayer;
+using FileLiberator;
+using LibationFileManager;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+
+namespace LibationUiBase.Tests;
+
+/// <summary>
+/// A guard against reintroducing the leak fixed in #1960: an AuthenticationRequiredException carried a live
+/// <see cref="Account"/>, and Serilog.Exceptions writes every public property of a logged exception - following
+/// nested objects to a depth of 10 - into the log file people attach to public issue reports. So no exception
+/// anywhere may be able to reach an account or an identity that way.
+/// <para>
+/// This lives here rather than beside the exception it guards because a test only sees the assemblies its own
+/// project references, and this one reaches the most of them.
+/// </para>
+/// </summary>
+[TestClass]
+public class ExceptionsCannotReachAnAccount
+{
+	private static readonly Type[] Forbidden =
+	[
+		typeof(Account),
+		typeof(AccountsSettings),
+		typeof(Identity),
+		typeof(AccessToken),
+		typeof(RefreshToken),
+		typeof(AdpToken),
+		typeof(PrivateKey)
+	];
+
+	/// <summary>
+	/// One public type per assembly, used only to reach the assembly. The AudibleApi packages are in here
+	/// deliberately: <see cref="Identity"/> is theirs, so an upstream exception that started carrying one would
+	/// leak through Libation, and this is where we would want to find that out - at the version bump, rather
+	/// than in someone's log.
+	/// </summary>
+	private static readonly Assembly[] Assemblies =
+	[
+		typeof(AutoScanRunner).Assembly,           // LibationUiBase
+		typeof(LibraryCommands).Assembly,          // ApplicationServices
+		typeof(LibationScaffolding).Assembly,      // AppScaffolding
+		typeof(Processable).Assembly,              // FileLiberator
+		typeof(Account).Assembly,                  // AudibleUtilities
+		typeof(Configuration).Assembly,            // LibationFileManager
+		typeof(FileManager.LongPath).Assembly,     // FileManager
+		typeof(LibraryBook).Assembly,              // DataLayer
+		typeof(Identity).Assembly,                 // AudibleApi
+		typeof(NonJsonResponseException).Assembly  // AudibleApi.Common
+	];
+
+	[TestMethod]
+	public void no_exception_type_exposes_one_through_its_public_properties()
+	{
+		var exceptionTypes = Assemblies
+			.Distinct()
+			.SelectMany(a => a.GetTypes())
+			.Where(t => typeof(Exception).IsAssignableFrom(t))
+			.ToArray();
+
+		// if a rename or a project split ever empties this, the test must fail rather than pass silently
+		Assert.IsTrue(exceptionTypes.Length > 0, "found no exception types to check");
+
+		foreach (var exceptionType in exceptionTypes)
+		{
+			var path = FindForbidden(exceptionType, depth: 0, [], []);
+			Assert.IsNull(path, $"{exceptionType.Name} can reach a secret-bearing type through public properties: {path}");
+		}
+	}
+
+	/// <summary>
+	/// Walks public instance properties the way Serilog.Exceptions' ReflectionBasedDestructurer does, to the same
+	/// default depth, and returns the path to the first forbidden type it can reach.
+	/// </summary>
+	private static string? FindForbidden(Type type, int depth, HashSet<Type> visited, List<string> trail)
+	{
+		if (depth > 10 || !visited.Add(type))
+			return null;
+
+		foreach (var property in type.GetProperties(BindingFlags.Public | BindingFlags.Instance))
+		{
+			if (property.GetIndexParameters().Length > 0)
+				continue;
+
+			var propertyType = Unwrap(property.PropertyType);
+			var step = trail.Append($"{type.Name}.{property.Name}").ToList();
+
+			if (Forbidden.Contains(propertyType))
+				return string.Join(" -> ", step);
+
+			// only follow types from the assemblies at issue: the framework's own graphs are vast and cannot
+			// reach an Audible account
+			if (Assemblies.Contains(propertyType.Assembly))
+			{
+				var found = FindForbidden(propertyType, depth + 1, visited, step);
+				if (found is not null)
+					return found;
+			}
+		}
+
+		return null;
+	}
+
+	/// <summary>Collections and nullables hide the interesting type one level down.</summary>
+	private static Type Unwrap(Type type)
+	{
+		if (type.IsArray)
+			return Unwrap(type.GetElementType()!);
+
+		if (!type.IsGenericType)
+			return type;
+
+		var arguments = type.GetGenericArguments();
+		return arguments.Length == 1 ? Unwrap(arguments[0]) : type;
+	}
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Four commits: two test-infrastructure fixes, one product fix, and a dependency upgrade. Reviewable in that order.

## 1. Run FileLiberator's tests serially

Seven tests failed in a Windows CI leg, every one thrown from a `TestInitialize` rather than an assertion, and on a path no test in the failing class had created:

    Initialization method DownloadPdfPathTests.Initialize threw exception.
    System.IO.FileNotFoundException: Could not find file
    '...\libation-pdf-path-tests-9842e25a...\Books\üüüü...'

The cause is `[assembly: Parallelize]` over classes that reach for state which is process-wide by nature: the `Configuration` singleton, the `LIBATION_FILES_DIR` environment variable, and `AudibleFileStorage`'s static file cache. Two running at once means one swapping the config or deleting its temp directory while the other enumerates it.

Opting out per class was the previous arrangement and it does not hold - three classes carried `[DoNotParallelize]` while `PdfBackFillSelectionTests` and `WidevineRecommendationTests` touched the same state without it, and nothing tells whoever adds the sixth. The attribute is gone, with a comment saying why; the existing markers stay as a statement of intent if parallelism ever returns.

Costs nothing measurable: 68 tests in about 3.1 seconds serially, against 9.8 seconds for that assembly in the CI leg that failed. Ran three times to check.

## 2. Widen the exception guard

`ExceptionsCannotReachAnAccount` guards against reintroducing #1960's leak - an exception carrying a live `Account`, which `Serilog.Exceptions` writes into the log file people attach to public issues. It lived in `AudibleUtilities.Tests`, so it saw three assemblies and four exception types, because a test only sees what its own project references.

Moved to `LibationUiBase.Tests`, which also reaches `ApplicationServices`, `AppScaffolding`, `FileLiberator` and `DataLayer`, it now covers **16 exception types across 10 assemblies**.

Two of those ten are the `AudibleApi` packages, on purpose: `Identity` is theirs, so an upstream exception that started carrying one would leak through Libation, and a version bump is where we would want to learn that rather than in someone's log. Nothing there reaches one today.

## 3. Stop a disposing file watcher from crashing the process

With the flake gone, the next run failed with **every test passing** - `failed: 0`, 1439 of them - because `FileLiberator.Tests` exited `0xE0434352`:

    Unhandled exception. System.InvalidOperationException: The collection has been marked as
    complete with regards to additions.
       at BlockingCollection`1.Add(T item)
       at FileManager.BackgroundFileSystem.FileSystemWatcher_Changed(...)
       at FileSystemWatcher.ReadDirectoryChangesCallback(...)

`BackgroundFileSystem.Stop()` disposes the watcher and then calls `CompleteAdding()`, on the assumption that disposing stops events. It does not stop the ones the OS has already buffered, and on Windows those arrive on a native completion callback, where an exception is not a failed call - it is a dead process.

This is not only a test problem. `FileSystemWatcher_Error` calls `Init()`, which calls `Stop()`, so any Libation run that reinitialises or disposes its file cache while the Books directory is busy can be killed the same way.

Adding to a completed collection is now caught and the event dropped, which is correct rather than a swallow: whoever called `Stop()` is either reinitialising, which rebuilds the cache from disk, or disposing. `Stop()` also detaches its handlers before disposing and clears its fields, narrowing the window and making a second `Stop()` harmless - the collection field is cleared only after `CompleteAdding`, since the background scanner is waiting on that.

The class had no tests; it has three now, including dispose under a flood of events.

## 4. Upgrade the packages

| Package | To | Projects |
|---|---|---|
| `Dinah.Core` | 10.2.4.1 | `FileManager`, `DataLayer`, `CrossPlatformClientExe` |
| `Dinah.Core.WindowsDesktop` | 10.2.4.1 | `LibationWinForms` |
| `Dinah.EntityFrameworkCore` | 10.2.4.1 | `DataLayer` |
| `AudibleApi` | 11.0.3.1 | `AudibleUtilities`, `LibationFileManager` |

The upgrade that does something for users is `Dinah.Core`: `OsSecretStore.Create` now bounds how long it waits for the backend, so a Linux or macOS start against a keyring that never answers falls through to the portable master-key path instead of hanging. `ResolveSecretStore` is the caller, and it runs at startup whenever no key file or env var is set. `AudibleApi` 11.0.3.1 brings no code change here - it is the release where its nuspec declares the `Dinah.Core` floor its own code needs.

## Verification

All 1442 tests pass. Both cross-platform apps build clean, `LibationWinForms` restores with both Dinah packages at 10.2.4.1, and every reference resolves from nuget.org.

Where I could, I checked each new test fails for the right reason rather than trusting a green run:

- Adding `AccountSummary` to the guard's forbidden list fails it, naming `AuthenticationRequiredException.AccountInfo` - so the walk reaches exception properties instead of passing on an empty set. The 4-to-16 type count is measured, not assumed; the widening would have been pointless otherwise.
- Serial execution was run three times over for stability.

**One honest gap.** The crash in commit 3 does not reproduce on Linux even with the fix fully reverted - inotify does not deliver post-dispose events the way Windows does. So the new `BackgroundFileSystem` tests cannot prove that fix from this machine; they are aimed at Windows CI, which is the only place that saw it. The fix matches that stack trace exactly and the race is visible in the source either way.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b80210b1-d979-43bf-808b-38924f2dd9d1?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b80210b1-d979-43bf-808b-38924f2dd9d1&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

