### PR TITLE
bugfix #1925: surface titles Audible labels as childless podcast series

### DIFF
--- a/Source/AudibleUtilities/ApiExtended.cs
+++ b/Source/AudibleUtilities/ApiExtended.cs
@@ -228,12 +228,23 @@ public class ApiExtended
 
 		//Name the casualties: an unlinked episode silently vanishes from the library, and without this
 		//there is nothing in the log to explain why.
-		var orphans = LinkEpisodesToSeries(items).Select(describe).Distinct().ToList();
+		var linkResult = LinkEpisodesToSeries(items);
+		var orphans = linkResult.Unlinked.Select(describe).Distinct().ToList();
 		if (orphans.Count > 0)
 			Serilog.Log.Logger.Warning(
 				"{orphansRemoved} podcast episodes were not imported because their series parent was missing from this scan. {@DebugInfo}",
 				orphans.Count,
 				new { Orphans = orphans.Take(MaxLoggedTitles).ToList(), Truncated = orphans.Count > MaxLoggedTitles });
+
+		//Audible labels these as podcast series, so they import as parents: not downloadable, and filtered out
+		//of the counts and the search index. An audiobook labelled this way by mistake would otherwise go
+		//missing with no explanation, so name them.
+		var childlessParents = linkResult.ChildlessParents.Select(describe).Distinct().ToList();
+		if (childlessParents.Count > 0)
+			Serilog.Log.Logger.Warning(
+				"{childlessParentCount} titles are series parents with no episodes in this scan. They import as podcast series, which cannot be downloaded. {@DebugInfo}",
+				childlessParents.Count,
+				new { ChildlessParents = childlessParents.Take(MaxLoggedTitles).ToList(), Truncated = childlessParents.Count > MaxLoggedTitles });
 
 		sw.Stop();
 		totalTime += sw.Elapsed;
@@ -244,6 +255,7 @@ public class ApiExtended
 			LibraryItems = libraryItemCount,
 			EpisodesFetched = allEps.Count,
 			OrphanedEpisodesDropped = orphans.Count,
+			ChildlessSeriesParents = childlessParents.Count,
 			ImportEpisodes = importEpisodes,
 			EpisodeItemsExcluded = episodeItemsExcluded,
 			ImportPlusTitles = importPlusTitles,
@@ -261,26 +273,44 @@ public class ApiExtended
 		static string describe(Item item) => $"[{item.Asin}] {item.Title}";
 	}
 
+	/// <summary>Outcome of <see cref="LinkEpisodesToSeries"/>.</summary>
+	/// <param name="Unlinked">Episodes and parents removed for having no series to belong to.</param>
+	/// <param name="ChildlessParents">
+	/// Items Audible reports as series parents that have no episodes in the scan. Libation imports these as
+	/// <c>ContentType.Parent</c>, which is not downloadable and is hidden wherever parents are filtered out,
+	/// so a mislabelled audiobook lands here and becomes hard to find.
+	/// </param>
+	public sealed record EpisodeLinkResult(List<Item> Unlinked, List<Item> ChildlessParents);
+
 	/// <summary>
 	/// Set <see cref="Item.Series"/> on every series parent in <paramref name="items"/> and on the episodes
 	/// belonging to it, then drop the episodes and parents left unlinked. An episode is left unlinked when
 	/// its parent is not among <paramref name="items"/>, which happens when Audible omits the parent from a
 	/// catalog response or when the parent is a container Libation does not treat as a series (e.g. a season).
 	/// </summary>
-	/// <returns>The unlinked items removed from <paramref name="items"/>.</returns>
-	public static List<Item> LinkEpisodesToSeries(List<Item> items)
+	public static EpisodeLinkResult LinkEpisodesToSeries(List<Item> items)
 	{
 		ArgumentValidator.EnsureNotNull(items, nameof(items));
 
+		var childlessParents = new List<Item>();
+
 		foreach (var parent in items.Where(i => i.IsSeriesParent))
 		{
-			var children = items.Where(i => i.IsEpisodes && i.Relationships?.Any(r => r.Asin == parent.Asin) is true);
+			var children = items.Where(i => i.IsEpisodes && i.Relationships?.Any(r => r.Asin == parent.Asin) is true).ToList();
+
+			if (children.Count == 0)
+				childlessParents.Add(parent);
+
 			SetSeries(parent, children);
 		}
 
 		var unlinked = items.Where(isUnlinked).ToList();
 		items.RemoveAll(isUnlinked);
-		return unlinked;
+
+		//A parent removed as unlinked is already reported as unlinked; don't report it twice.
+		childlessParents.RemoveAll(unlinked.Contains);
+
+		return new EpisodeLinkResult(unlinked, childlessParents);
 
 		static bool isUnlinked(Item item) => (item.IsEpisodes || item.IsSeriesParent) && item.Series is null;
 	}

--- a/Source/DataLayer/QueryObjects/LibraryBookQueries.cs
+++ b/Source/DataLayer/QueryObjects/LibraryBookQueries.cs
@@ -109,14 +109,24 @@ public static class LibraryBookQueries
 					.Select(ge => ge.Book.AudibleProductId), ge => ge.Book.AudibleProductId);
 
 		/// <summary>
-		/// Books displayed as top-level rows: ordinary products plus episodes whose series parent
-		/// is not in the database. Showing orphaned episodes here keeps a successfully imported
-		/// title discoverable instead of silently hiding it from both grids.
+		/// Episode parents with no episodes in the library. A grid shows a parent only as the header of
+		/// its children, so one with no children is drawn nowhere. Audible sometimes labels an ordinary
+		/// audiobook as a podcast series, and such a book would otherwise be impossible to find.
+		/// </summary>
+		public IEnumerable<LibraryBook> ChildlessEpisodeParents()
+			=> libraryBooks
+				.Where(lb => lb.Book.IsEpisodeParent() && !libraryBooks.FindChildren(lb).Any());
+
+		/// <summary>
+		/// Books displayed as top-level rows: ordinary products, episodes whose series parent is not in
+		/// the database, and parents with no episodes. Showing the latter two keeps a successfully
+		/// imported title discoverable instead of silently hiding it from both grids.
 		/// </summary>
 		public IEnumerable<LibraryBook> StandaloneBooks()
 			=> libraryBooks
 				.Where(lb => lb.Book.IsProduct())
-				.Concat(libraryBooks.FindOrphanedEpisodes());
+				.Concat(libraryBooks.FindOrphanedEpisodes())
+				.Concat(libraryBooks.ChildlessEpisodeParents());
 
 		public IEnumerable<LibraryBook> FindChildren(LibraryBook parent)
 			=> libraryBooks.Where(lb => lb.Book.IsEpisodeChild() && lb.HasSeriesId(parent.Book.AudibleProductId));

--- a/Source/LibationAvalonia/ViewModels/ProductsDisplayViewModel.cs
+++ b/Source/LibationAvalonia/ViewModels/ProductsDisplayViewModel.cs
@@ -172,7 +172,8 @@ public class ProductsDisplayViewModel : ViewModelBase
 		var allEntries = SOURCE.BookEntries().ToDictionarySafe(b => b.AudibleProductId);
 		var seriesEntries = SOURCE.SeriesEntries().ToList();
 		var parentedEpisodes = dbBooks.ParentedEpisodes().ToHashSet();
-		var orphanedEpisodes = dbBooks.FindOrphanedEpisodes().ToHashSet();
+		//Same query that builds the initial grid, so the two paths agree on what is a top-level row.
+		var standaloneBooks = dbBooks.StandaloneBooks().ToHashSet();
 
 		await Dispatcher.UIThread.InvokeAsync(() =>
 		{
@@ -180,7 +181,7 @@ public class ProductsDisplayViewModel : ViewModelBase
 			{
 				var existingEntry = allEntries.TryGetValue(libraryBook.Book.AudibleProductId, out var e) ? e : null;
 
-				if (libraryBook.Book.IsProduct() || orphanedEpisodes.Contains(libraryBook))
+				if (standaloneBooks.Contains(libraryBook))
 				{
 					// An episode can become orphaned when its parent is removed. Move it out from under
 					// the old parent and keep it visible as a standalone row.

--- a/Source/LibationWinForms/GridView/ProductsGrid.cs
+++ b/Source/LibationWinForms/GridView/ProductsGrid.cs
@@ -350,7 +350,8 @@ public partial class ProductsGrid : UserControl
 		var allEntries = bindingList.AllItems().BookEntries().ToDictionarySafe(b => b.AudibleProductId);
 		var seriesEntries = bindingList.AllItems().SeriesEntries().ToList();
 		var parentedEpisodes = dbBooks.ParentedEpisodes().ToHashSet();
-		var orphanedEpisodes = dbBooks.FindOrphanedEpisodes().ToHashSet();
+		//Same query that builds the initial grid, so the two paths agree on what is a top-level row.
+		var standaloneBooks = dbBooks.StandaloneBooks().ToHashSet();
 
 		//Get the UI thread's synchronization context and set it on the current thread to ensure
 		//it's available for creation of new IGridEntry items during upsert
@@ -362,7 +363,7 @@ public partial class ProductsGrid : UserControl
 		{
 			var existingEntry = allEntries.TryGetValue(libraryBook.Book.AudibleProductId, out var e) ? e : null;
 
-			if (libraryBook.Book.IsProduct() || orphanedEpisodes.Contains(libraryBook))
+			if (standaloneBooks.Contains(libraryBook))
 			{
 				// An episode can become orphaned when its parent is removed. Move it out from under
 				// the old parent and keep it visible as a standalone row.

--- a/Source/_Tests/AudibleUtilities.Tests/ApiExtendedLinkEpisodesTests.cs
+++ b/Source/_Tests/AudibleUtilities.Tests/ApiExtendedLinkEpisodesTests.cs
@@ -68,7 +68,7 @@ public class LinkEpisodesToSeries
 			episode("EP2", "Episode two", "SHOW", 2)
 		};
 
-		var unlinked = ApiExtended.LinkEpisodesToSeries(items);
+		var unlinked = ApiExtended.LinkEpisodesToSeries(items).Unlinked;
 
 		Assert.AreEqual(0, unlinked.Count);
 		Assert.AreEqual(3, items.Count);
@@ -88,7 +88,7 @@ public class LinkEpisodesToSeries
 			book("BOOK")
 		};
 
-		var unlinked = ApiExtended.LinkEpisodesToSeries(items);
+		var unlinked = ApiExtended.LinkEpisodesToSeries(items).Unlinked;
 
 		CollectionAssert.AreEqual(new[] { "EP2" }, unlinked.Select(i => i.Asin).ToList());
 		CollectionAssert.AreEqual(new[] { "BOOK" }, items.Select(i => i.Asin).ToList());
@@ -105,7 +105,7 @@ public class LinkEpisodesToSeries
 			episode("EP3", "Episode three", "SHOW", 3)
 		};
 
-		var unlinked = ApiExtended.LinkEpisodesToSeries(items);
+		var unlinked = ApiExtended.LinkEpisodesToSeries(items).Unlinked;
 
 		CollectionAssert.AreEqual(new[] { "EP2" }, unlinked.Select(i => i.Asin).ToList());
 		CollectionAssert.AreEquivalent(new[] { "SHOW", "EP1", "EP3" }, items.Select(i => i.Asin).ToList());
@@ -119,7 +119,7 @@ public class LinkEpisodesToSeries
 
 		var items = new List<Item> { seasonItem, episode("EP1", "Episode one", "SEASON", 1) };
 
-		var unlinked = ApiExtended.LinkEpisodesToSeries(items);
+		var unlinked = ApiExtended.LinkEpisodesToSeries(items).Unlinked;
 
 		// The episode has nothing to link to, so it is dropped. The season itself is left alone here;
 		// it is filtered out of the scan earlier for being neither a series parent nor an episode.
@@ -133,7 +133,7 @@ public class LinkEpisodesToSeries
 	{
 		var items = new List<Item> { book("BOOK1"), book("BOOK2") };
 
-		var unlinked = ApiExtended.LinkEpisodesToSeries(items);
+		var unlinked = ApiExtended.LinkEpisodesToSeries(items).Unlinked;
 
 		Assert.AreEqual(0, unlinked.Count);
 		Assert.AreEqual(2, items.Count);
@@ -144,7 +144,7 @@ public class LinkEpisodesToSeries
 	{
 		var items = new List<Item> { show("SHOW", "My Show", "EP1") };
 
-		var unlinked = ApiExtended.LinkEpisodesToSeries(items);
+		var unlinked = ApiExtended.LinkEpisodesToSeries(items).Unlinked;
 
 		Assert.AreEqual(0, unlinked.Count);
 		Assert.AreEqual("SHOW", items.Single().Series!.Single().Asin);
@@ -161,10 +161,47 @@ public class LinkEpisodesToSeries
 			episode("EP1", "Episode one", "SHOW", 1)
 		};
 
-		var unlinked = ApiExtended.LinkEpisodesToSeries(items);
+		var unlinked = ApiExtended.LinkEpisodesToSeries(items).Unlinked;
 
 		Assert.AreEqual(0, unlinked.Count);
 		Assert.AreEqual(3, items.Count);
+	}
+
+	[TestMethod]
+	public void a_series_parent_with_no_episodes_is_reported_as_childless()
+	{
+		// Audible labels some ordinary audiobooks this way; they import as podcast series and cannot be downloaded.
+		var items = new List<Item> { show("SHOW", "Mislabelled audiobook", "EP1"), book("BOOK") };
+
+		var result = ApiExtended.LinkEpisodesToSeries(items);
+
+		Assert.AreEqual(0, result.Unlinked.Count);
+		CollectionAssert.AreEqual(new[] { "SHOW" }, result.ChildlessParents.Select(i => i.Asin).ToList());
+	}
+
+	[TestMethod]
+	public void a_series_parent_with_episodes_is_not_reported_as_childless()
+	{
+		var items = new List<Item>
+		{
+			show("SHOW", "My Show", "EP1"),
+			episode("EP1", "Episode one", "SHOW", 1)
+		};
+
+		var result = ApiExtended.LinkEpisodesToSeries(items);
+
+		Assert.AreEqual(0, result.ChildlessParents.Count);
+	}
+
+	[TestMethod]
+	public void a_dropped_parent_is_not_also_reported_as_childless()
+	{
+		// A season container is removed as unlinked; reporting it twice would be noise.
+		var items = new List<Item> { season("SEASON", "SHOW", "EP1") };
+
+		var result = ApiExtended.LinkEpisodesToSeries(items);
+
+		Assert.AreEqual(0, result.ChildlessParents.Count);
 	}
 
 	[TestMethod]
@@ -172,9 +209,10 @@ public class LinkEpisodesToSeries
 	{
 		var items = new List<Item>();
 
-		var unlinked = ApiExtended.LinkEpisodesToSeries(items);
+		var result = ApiExtended.LinkEpisodesToSeries(items);
 
-		Assert.AreEqual(0, unlinked.Count);
+		Assert.AreEqual(0, result.Unlinked.Count);
+		Assert.AreEqual(0, result.ChildlessParents.Count);
 		Assert.AreEqual(0, items.Count);
 	}
 }

--- a/Source/_Tests/LibationUiBase.Tests/StandaloneBooksTests.cs
+++ b/Source/_Tests/LibationUiBase.Tests/StandaloneBooksTests.cs
@@ -73,6 +73,39 @@ public class StandaloneBooksTests
 	}
 
 	[TestMethod]
+	public void childless_episode_parent_is_standalone()
+	{
+		// A grid only draws a parent as the header of its children, so a childless one appears nowhere.
+		var parent = libraryBook("SHOW", ContentType.Parent, "SHOW");
+
+		var standalone = new[] { parent }.StandaloneBooks().ToList();
+
+		CollectionAssert.AreEqual(new[] { "SHOW" }, standalone.Select(lb => lb.Book.AudibleProductId).ToList());
+	}
+
+	[TestMethod]
+	public void episode_parent_with_children_is_not_standalone()
+	{
+		var parent = libraryBook("SHOW", ContentType.Parent, "SHOW");
+		var child = libraryBook("CHILD", ContentType.Episode, "SHOW");
+
+		var standalone = new[] { parent, child }.StandaloneBooks().ToList();
+
+		Assert.AreEqual(0, standalone.Count);
+	}
+
+	[TestMethod]
+	public async Task grid_entries_include_childless_parent_as_a_standalone_row()
+	{
+		var parent = libraryBook("SHOW", ContentType.Parent, "SHOW");
+
+		SynchronizationContext.SetSynchronizationContext(new SynchronizationContext());
+		var entries = await LibraryBookEntry.GetAllProductsAsync([parent]);
+
+		CollectionAssert.AreEqual(new[] { "SHOW" }, entries.Select(entry => entry.AudibleProductId).ToList());
+	}
+
+	[TestMethod]
 	public async Task grid_entries_include_orphaned_episode_as_a_standalone_row()
 	{
 		var parent = libraryBook("SHOW", ContentType.Parent, "SHOW");


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Follow-up to #1926 for #1925. The reporter has now identified the missing title, and the new debug logs disprove the cause #1926 fixed.

## What the new logs establish

The missing title is **"Epicenter" by Joel C. Rosenberg**, a purchased audiobook (7/27/2026), not a podcast episode. The reporter ran v13.7.9 with Debug on, which exercised the diagnostics added in #1926:

```
Library scan tally. {"LibraryItems":434,"EpisodesFetched":1724,"OrphanedEpisodesDropped":15,
                     "ImportEpisodes":true,"EpisodeItemsExcluded":0,
                     "ImportPlusTitles":true,"PlusTitlesExcluded":0,"ItemsToImport":2143}
Import complete. New count 0
```

Ruled out:

- **Catalog omissions.** All 36 batches returned exactly what was asked: 1763 ASINs requested, 1763 returned, zero shortfall. The retry added in #1926 never fired, and no "did not return" warning was emitted.
- **Import filters.** `EpisodeItemsExcluded: 0`, `PlusTitlesExcluded: 0`.
- **Orphaned episodes.** 15 were dropped and are now named in the log; all are American History Tellers / Wondery episodes. "Epicenter" is not among them.

A useful constraint comes from the counts: `booksNoProgress: 0`. That count is books present in the scan and not downloaded. If "Epicenter" were in the database as a Product or Episode and undownloaded, it would have to appear there. It does not, and `New count 0` means the scan added nothing.

## The gap this closes

`BookImporter.GetContentType` maps **any** item Audible reports with a child/episode relationship to `ContentType.Parent`. A parent with no episodes in the library is then unreachable everywhere:

| Path | Effect |
|-|-|
| `SeriesEntry.GetAllSeriesEntriesAsync` | `Where(s => s.Children.Count != 0)` drops it, so no grid row |
| `LibraryBookEntry.GetAllProductsAsync` | parents are not products, so no row from there either |
| `WithoutParents()` in `GetCounts` | excluded from every status count, so it cannot appear in `booksNoProgress` |
| `WithoutParents()` in `FullReIndex` | excluded from the search index |
| `LibraryBook.Downloadable` | requires `Product` or `Episode`, so it never downloads |
| trash bin views | filter `ContentType.Parent` out |

So a title labelled this way is invisible, unsearchable, uncounted and undownloadable, while every number in the log still looks healthy. That matches the report exactly: cannot find it, never downloaded, nothing in the log.

I want to be clear that this is **not confirmed** to be the reporter's cause. It is the one Libation-side path still consistent with every value in these logs. The remaining alternative is that Audible simply does not return the title in its paged library response, which Libation cannot work around.

## Changes

- `LinkEpisodesToSeries` now also reports series parents that ended up with no episodes.
- Warn at scan time, naming asin and title, and add `ChildlessSeriesParents` to the scan tally. If this is the cause, the reporter's next log will name "Epicenter" outright.
- `ChildlessEpisodeParents()` query, included in `StandaloneBooks()`, so such a title gets a top-level row instead of no row. It reuses `FindChildren` so it cannot disagree with the grid about what counts as a child.
- Both grids now drive their initial bind and their incremental update from `StandaloneBooks()`, instead of one using it and the other re-deriving the rule.

A childless parent still renders with a series-style expander, since `EntryStatus.IsSeries` comes from `ContentType`. Clicking it is inert: the handlers are type-guarded on `SeriesEntry` and a standalone row is a `LibraryBookEntry`. It remains undownloadable, because fixing that needs the classification itself corrected in `AudibleApi` (`Item.IsSeriesParent` is unchanged in 11.0.3.1). Making the title visible and logged is what turns this from a black hole into something diagnosable.

## Verification

Built off current `master` (0d13200d, AudibleApi 11.0.3.1). Avalonia and CLI both build with 0 errors. Full suite, each project under a hard timeout:

```
AudibleUtilities       total: 96  failed: 0  succeeded: 94  skipped: 2   1s 832ms
LibationUiBase         total: 168 failed: 0  succeeded: 168             1s 540ms
ApplicationServices    total: 96  failed: 0  succeeded: 96              5s 095ms
FileLiberator          total: 68  failed: 0  succeeded: 68              2s 713ms
FileManager            total: 214 failed: 0  succeeded: 214             8s 345ms
LibationFileManager    total: 670 failed: 0  succeeded: 649 skipped: 21 1s 243ms
LibationSearchEngine   total: 69  failed: 0  succeeded: 69             11s 478ms
```

New tests cover childless-parent detection (including not double-reporting a parent already dropped as unlinked) and that such a parent becomes a standalone `LibraryBookEntry`.

## Still open

To settle it definitively, the reporter's `LibraryScans.zip` would show whether Audible returns "Epicenter" at all and, if so, what relationships it carries. That file is written automatically whenever a scan runs with Debug enabled, which they have already done.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6ff1bfc7-305d-4d52-ab87-f69c83e07ce7?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6ff1bfc7-305d-4d52-ab87-f69c83e07ce7&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

