### PR TITLE
Bump version to 13.7.10

### DIFF
--- a/Source/AppScaffolding/AppScaffolding.csproj
+++ b/Source/AppScaffolding/AppScaffolding.csproj
@@ -2,7 +2,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
-    <Version>13.7.9</Version>
+    <Version>13.7.10</Version>
     <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Bump `<Version>` in `Source/AppScaffolding/AppScaffolding.csproj` from 13.7.9 to 13.7.10 for the next release.

`AppScaffolding.csproj` is the only place the version is declared - a grep for `13.7.9` across the tree turns up nothing else that needs moving (the other hits are docs and test comments describing pre-13.7.9 behavior, which stay as they are).

After merge: annotated tag `v13.7.10` will be pushed to trigger `release.yml` (draft GitHub release).

## Verification

Both cross-platform apps build, and the full suite from `Source/` passes: `total: 1442  failed: 0  skipped: 23` (the skips being the opt-in OS secret store tests).

The CLI reports the new version:

```
$ dotnet run -- version
Libation Chardonnay v13.7.10
```

And so does the Avalonia GUI, under Settings > About... (the `.0` suffix is the assembly's fourth field, unchanged from previous releases):

[libation_about_dialog_shows_v13_7_10.mp4](https://cursor.com/agents/bc-89a40861-4800-4cd5-86dd-4461c42f8397/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Flibation_about_dialog_shows_v13_7_10.mp4)

[About Libation dialog showing Libation Chardonnay v13.7.10.0](https://cursor.com/agents/bc-89a40861-4800-4cd5-86dd-4461c42f8397/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fabout_dialog_v13_7_10.webp)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-89a40861-4800-4cd5-86dd-4461c42f8397?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-89a40861-4800-4cd5-86dd-4461c42f8397&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

