### PR TITLE
Correct the Smart App Control guidance in the docs and the in-app dialog

### DIFF
--- a/Source/LibationFileManager/StartupAssemblyBootstrap.cs
+++ b/Source/LibationFileManager/StartupAssemblyBootstrap.cs
@@ -75,6 +75,8 @@ public static class StartupAssemblyBootstrap
 		{Path.Combine(Configuration.ProcessDirectory, EntityFrameworkCoreSqliteAssemblyFileName)}
 		""";
 
+	// Release status, such as code signing progress, belongs in the linked docs rather than here:
+	// this string ships frozen in each build and cannot be corrected after release.
 	public static string GetApplicationControlBlockedMessage(Exception? ex = null)
 	{
 		var blockedFile = TryGetBlockedAssemblyPath(ex) ?? "(unknown)";
@@ -94,7 +96,7 @@ public static class StartupAssemblyBootstrap
 
 			To check whether this is Smart App Control, open Settings -> Privacy & Security -> Windows Security -> App & browser control -> Smart App Control settings. Only the On setting blocks anything; Evaluation observes without blocking.
 
-			If it is On, you can turn it off, but be aware that Windows cannot turn it back on again without a reset or reinstall. If it is already off, the block comes from a policy set by whoever manages this PC.
+			If it is On, turning it off is one way out, but Windows cannot turn it back on again without a reset or reinstall. Check the page below for the current options before you change anything. If it is already off, the block comes from a policy set by whoever manages this PC.
 
 			More help:
 			{TroubleshootApplicationControlUrl}

--- a/Source/LibationFileManager/StartupAssemblyBootstrap.cs
+++ b/Source/LibationFileManager/StartupAssemblyBootstrap.cs
@@ -14,7 +14,7 @@ public static class StartupAssemblyBootstrap
 	public const string EntityFrameworkCoreSqliteAssemblyFileName = "Microsoft.EntityFrameworkCore.Sqlite.dll";
 	public const int ApplicationControlBlockedHResult = unchecked((int)0x800711C7);
 	private const string TroubleshootApplicationControlUrl = "https://getlibation.com/docs/advanced/troubleshoot#windows-smart-app-control-and-in-app-upgrades";
-	internal const string TroubleshootIncompleteUpgradeUrl = "https://getlibation.com/docs/advanced/troubleshoot#windows-smart-app-control-and-in-app-upgrades";
+	internal const string TroubleshootIncompleteUpgradeUrl = "https://getlibation.com/docs/advanced/troubleshoot#windows-incomplete-in-app-upgrade";
 
 	/// <summary>
 	/// Registers <see cref="InteropFactory"/> assembly resolution and verifies required install-folder assemblies exist.
@@ -80,7 +80,7 @@ public static class StartupAssemblyBootstrap
 		var blockedFile = TryGetBlockedAssemblyPath(ex) ?? "(unknown)";
 
 		return $"""
-			Windows blocked Libation from loading a required file in its install folder. This often happens after an in-app upgrade when Smart App Control or another Application Control policy is enabled.
+			Windows blocked Libation from loading a required file in its install folder. An Application Control policy, usually Smart App Control, is refusing to run it.
 
 			Blocked file:
 			{blockedFile}
@@ -88,15 +88,13 @@ public static class StartupAssemblyBootstrap
 			Install folder:
 			{Configuration.ProcessDirectory}
 
+			Smart App Control runs only code that Microsoft's reputation service recognises or that is signed with a trusted certificate. Libation's Windows builds are not signed yet. Windows offers no way to allow a single app through, so reinstalling to another folder and unblocking the files do not help.
+
 			Your library database, accounts, and settings are stored separately and should be unaffected.
 
-			To recover:
-			1. Quit Libation completely.
-			2. Download the latest release zip from GitHub and extract it to a new folder (do not copy files on top of the old install).
-			3. Run Libation from the new folder.
+			To check whether this is Smart App Control, open Settings -> Privacy & Security -> Windows Security -> App & browser control -> Smart App Control settings. Only the On setting blocks anything; Evaluation observes without blocking.
 
-			If Windows still blocks the app, review Smart App Control under Windows Security -> App & browser control, or run this in PowerShell (replace the path if needed):
-			Unblock-File -Path '{Configuration.ProcessDirectory}\*' -Recurse
+			If it is On, you can turn it off, but be aware that Windows cannot turn it back on again without a reset or reinstall. If it is already off, the block comes from a policy set by whoever manages this PC.
 
 			More help:
 			{TroubleshootApplicationControlUrl}
@@ -255,11 +253,11 @@ public static class StartupAssemblyBootstrap
 
 			To recover:
 			1. Quit Libation completely.
-			2. Download the latest release zip from GitHub.
-			3. Extract it to a new folder (do not copy files on top of the old install).
-			4. Run Libation from the new folder.
+			2. Download the latest release from GitHub. The setup.exe installer is the easiest option.
+			3. If you use the zip instead, extract it to a new folder (do not copy files on top of the old install).
+			4. Run Libation from the new install.
 
-			If Windows Smart App Control blocked updated files, see:
+			More help:
 			{TroubleshootIncompleteUpgradeUrl}
 			""";
 	}

--- a/Source/_Tests/LibationFileManager.Tests/InstallUpgradeManagerTests.cs
+++ b/Source/_Tests/LibationFileManager.Tests/InstallUpgradeManagerTests.cs
@@ -148,6 +148,47 @@ public class InstallUpgradeManagerTests
 		StringAssert.Contains(message.Body, "LibationUiBase");
 	}
 
+	[TestMethod]
+	public void GetStartupFailureMessage_names_the_blocked_file_and_explains_the_missing_signature()
+	{
+		var ex = new FileLoadException(
+			"An Application Control policy has blocked this file. (0x800711C7)",
+			@"C:\Libation\Serilog.Settings.Configuration.dll");
+
+		Assert.IsTrue(StartupAssemblyBootstrap.IsApplicationControlBlockedAssembly(ex));
+
+		var message = StartupAssemblyBootstrap.GetStartupFailureMessage(ex);
+
+		Assert.IsNotNull(message);
+		Assert.AreEqual("Libation blocked by Windows security", message.Title);
+		StringAssert.Contains(message.Body, @"C:\Libation\Serilog.Settings.Configuration.dll");
+		StringAssert.Contains(message.Body, "Smart App Control");
+		StringAssert.Contains(message.Body, "not signed");
+	}
+
+	// Unblock-File takes no -Recurse argument, and Smart App Control gates on the signature
+	// rather than on Mark-of-the-Web, so telling users to unblock the folder sent them after a
+	// command that both fails to run and cannot fix the block. See issue #1967.
+	[TestMethod]
+	public void GetApplicationControlBlockedMessage_does_not_suggest_unblocking_the_install_folder()
+	{
+		var body = StartupAssemblyBootstrap.GetApplicationControlBlockedMessage();
+
+		Assert.IsFalse(body.Contains("Unblock-File", StringComparison.OrdinalIgnoreCase));
+	}
+
+	[TestMethod]
+	public void Startup_messages_link_to_their_own_docs_sections()
+	{
+		StringAssert.Contains(
+			StartupAssemblyBootstrap.GetIncompleteUpgradeFailureMessage(),
+			"troubleshoot#windows-incomplete-in-app-upgrade");
+
+		StringAssert.Contains(
+			StartupAssemblyBootstrap.GetApplicationControlBlockedMessage(),
+			"troubleshoot#windows-smart-app-control-and-in-app-upgrades");
+	}
+
 	private void WriteInstallFile(string fileName, string contents)
 		=> File.WriteAllText(Path.Combine(_installDir, fileName), contents);
 

--- a/docs/advanced/troubleshoot.md
+++ b/docs/advanced/troubleshoot.md
@@ -134,7 +134,7 @@ If Libation reports that an in-app upgrade did not replace every install file, o
 
 Install Libation to a normal local path, not inside OneDrive, Dropbox, or a similar synced folder. The `*-setup.exe` installer does this for you by installing under `%LocalAppData%`.
 
-Sync clients replace files with placeholders, restore old copies, and leave conflict copies behind. In an install folder that breaks in-app upgrades and, when it happens to the search index, corrupts it.
+Sync clients replace files with placeholders, restore old copies, and leave conflict copies behind. Inside an install folder that breaks in-app upgrades, and inside your Libation data folder it can corrupt the search index.
 
 ### Hangover (Windows)
 

--- a/docs/advanced/troubleshoot.md
+++ b/docs/advanced/troubleshoot.md
@@ -110,10 +110,12 @@ Windows can move itself from Evaluation to On on its own, which is why Libation 
 
 Windows has no way to allow a single app through Smart App Control. Microsoft's guidance is to turn it off or to ask the developer to sign the app. Reinstalling, extracting to a different folder, and unblocking files all leave the signature missing, so none of them help.
 
-That leaves two real options: turn Smart App Control off, or run Libation on a machine that does not have it on.
+That leaves three options: wait for signed builds, run Libation on a machine that does not have Smart App Control on, or turn Smart App Control off.
+
+Code signing is in progress. Libation has applied to the [SignPath Foundation](https://signpath.io/), which signs open source projects for free. Signed builds run under Smart App Control with nothing to change on your side. The application has to be approved first, so there is no date for it; watch the [releases page](https://github.com/rmcrackan/Libation/releases). Signing will not silence every Windows warning at once, because SmartScreen keeps warning about new downloads until they earn a reputation, signed or not.
 
 > [!WARNING] Turning Smart App Control off cannot be undone
-> Windows will not turn Smart App Control back on without a reset or reinstall. An earlier version of this page suggested disabling it temporarily and re-enabling it afterwards. That is not possible; ignore that advice if you saw it.
+> Windows will not turn Smart App Control back on without a reset or reinstall, so weigh that against simply waiting. An earlier version of this page suggested disabling it temporarily and re-enabling it afterwards. That is not possible; ignore that advice if you saw it.
 
 **If it is already Off**
 

--- a/docs/advanced/troubleshoot.md
+++ b/docs/advanced/troubleshoot.md
@@ -78,38 +78,63 @@ Platform-specific steps: [Windows](#hangover-windows) · [macOS](#hangover-macos
 
 ## Windows
 
-### Smart App Control and in-app upgrades {#windows-smart-app-control-and-in-app-upgrades}
+### Smart App Control blocks Libation {#windows-smart-app-control-and-in-app-upgrades}
 
-After accepting an in-app update, Libation may fail to restart with an error like:
+Libation fails to start, or fails part way through, with an error like:
 
 `An Application Control policy has blocked this file. (0x800711C7)`
 
-Windows **Smart App Control** (and similar Application Control policies on recent Windows 11 builds) can block DLLs that were just written when the in-app upgrader overlays a new release onto your existing install folder. The blocked path is usually under your **Libation install folder** (where `Libation.exe` lives), not your user data folder (`%UserProfile%\Libation`).
+**Cause:** Libation's Windows builds are not code-signed. Smart App Control runs code only when Microsoft's cloud reputation service recognises it or when it carries a signature from a trusted certificate authority, so it blocks Libation's files. The blocked path is a file in your **Libation install folder** (where `Libation.exe` lives), not your user data folder (`%UserProfile%\Libation`), and it is often a third-party library rather than a Libation one.
+
+An in-app upgrade frequently triggers the first block, because the upgrader writes fresh files that have no reputation yet.
 
 **Symptoms**
 
-- Fatal crash immediately after an in-app upgrade (Chardonnay / Avalonia).
+- Fatal crash on start, often right after an in-app upgrade (Chardonnay / Avalonia).
 - Classic may start but library import or database access fails with the same `0x800711C7` message on a `.dll` in the install folder.
 - Windows Security may also warn about an unsigned library.
 
-**Fix (recommended)**
+**Check which mode Smart App Control is in**
+
+Open **Settings** -> **Privacy & Security** -> **Windows Security** -> **App & browser control** -> **Smart App Control settings**.
+
+| Mode | Blocks Libation? |
+|------|------------------|
+| Off | No |
+| Evaluation | No. This mode observes only; it never blocks anything |
+| On | Yes |
+
+Windows can move itself from Evaluation to On on its own, which is why Libation can work one day and be blocked the next without you changing anything.
+
+**If it is On**
+
+Windows has no way to allow a single app through Smart App Control. Microsoft's guidance is to turn it off or to ask the developer to sign the app. Reinstalling, extracting to a different folder, and unblocking files all leave the signature missing, so none of them help.
+
+That leaves two real options: turn Smart App Control off, or run Libation on a machine that does not have it on.
+
+> [!WARNING] Turning Smart App Control off cannot be undone
+> Windows will not turn Smart App Control back on without a reset or reinstall. An earlier version of this page suggested disabling it temporarily and re-enabling it afterwards. That is not possible; ignore that advice if you saw it.
+
+**If it is already Off**
+
+Then the block comes from a different Application Control or Device Guard policy, normally one set by whoever manages the PC. Ask them to allow Libation.
+
+Reports: [#1873](https://github.com/rmcrackan/Libation/issues/1873), [#1876](https://github.com/rmcrackan/Libation/issues/1876), [#1967](https://github.com/rmcrackan/Libation/issues/1967).
+
+### Recover from an incomplete in-app upgrade {#windows-incomplete-in-app-upgrade}
+
+If Libation reports that an in-app upgrade did not replace every install file, or fails to load a component after an upgrade, the install folder holds a mix of old and new files. This is a different problem from a Smart App Control block, and reinstalling does fix it.
 
 1. Quit Libation completely.
-2. Download the latest [release zip](https://github.com/rmcrackan/Libation/releases/latest) from GitHub.
-3. Extract to a **new folder** (for example `C:\Apps\Libation`). Do **not** copy new files on top of the old install folder.
-4. Run `Libation.exe` from the new folder. Your library database, accounts, and settings in `%UserProfile%\Libation` (or the path in `appsettings.json` -> `LibationFiles`) are separate and should still work.
+2. Download the latest [release](https://github.com/rmcrackan/Libation/releases/latest) from GitHub. The `*-setup.exe` installer is the easiest option.
+3. If you use the zip instead, extract it to a **new folder** (for example `C:\Apps\Libation`). Do **not** copy new files on top of the old install folder.
+4. Run Libation from the new install. Your library database, accounts, and settings in `%UserProfile%\Libation` (or the path in `appsettings.json` -> `LibationFiles`) are separate and should still work.
 
-**If Windows still blocks the new install**
+### Libation installed in OneDrive or another synced folder {#windows-cloud-sync-install}
 
-1. Open **Windows Security** -> **App & browser control** and review **Smart App Control** (Evaluation or On modes are the usual trigger).
-2. In PowerShell, unblock the install folder (adjust the path):
+Install Libation to a normal local path, not inside OneDrive, Dropbox, or a similar synced folder. The `*-setup.exe` installer does this for you by installing under `%LocalAppData%`.
 
-   ```powershell
-   Unblock-File -Path 'C:\Apps\Libation\*' -Recurse
-   ```
-
-3. Avoid running Libation from cloud-sync folders (OneDrive, etc.) if you can; use a normal local path for the install folder.
-4. If needed, turn Smart App Control off temporarily, install from the [standalone setup](https://github.com/rmcrackan/Libation/releases/latest) (override Windows' "potentially unsafe" warning if prompted), and run Libation once. Some users report that Libation keeps working after turning Smart App Control back on. [#1876](https://github.com/rmcrackan/Libation/issues/1876), [#1873](https://github.com/rmcrackan/Libation/issues/1873).
+Sync clients replace files with placeholders, restore old copies, and leave conflict copies behind. In an install folder that breaks in-app upgrades and, when it happens to the search index, corrupts it.
 
 ### Hangover (Windows)
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -25,11 +25,14 @@ Nearly 100% of the difference is look and feel -- it's a matter of preference.
 
 Do not install to `Program Files`. Read-only install folders break configuration and in-app updates.
 
-**Portable (advanced):** download the `.zip` instead, extract to a folder you can write to, and run `Libation.exe` from that folder. Zips are also what the in-app updater uses when you choose to upgrade from inside Libation.
+**Portable (advanced):** download the `.zip` instead, extract to a folder you can write to, and run `Libation.exe` from that folder. Zips are also what the in-app updater uses when you choose to upgrade from inside Libation. Extract to a normal local path, not inside OneDrive or another synced folder - see [Troubleshooting](/docs/advanced/troubleshoot#windows-cloud-sync-install).
 
 Chardonnay is available for x64 and arm64. Classic is x64 only.
 
 Requires 64-bit Windows 10 or later. Older versions of Windows are not supported.
+
+> [!WARNING] Smart App Control blocks Libation
+> Libation's Windows builds are not code-signed, so Windows may warn that they are unsafe. If **Smart App Control** is turned on it blocks Libation outright, and Windows offers no way to allow a single app through. See [Troubleshooting](/docs/advanced/troubleshoot#windows-smart-app-control-and-in-app-upgrades).
 
 - [Linux](./installation/linux.md) (if you use **Snap**, read the [Snap](./installation/linux.md#snap) section after each refresh so `appsettings.json` and `LibationFiles` stay on the same revision)
 - [MacOS](./installation/mac.md)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Prompted by [#1967](https://github.com/rmcrackan/Libation/issues/1967), where the reporter followed our recovery instructions and got nowhere. Three separate pieces of the advice we ship were wrong, in both `docs/advanced/troubleshoot.md` and the `Libation blocked by Windows security` dialog that is generated from `GetApplicationControlBlockedMessage`.

This is text only. It does not attempt to fix the underlying problem, which is that the Windows builds are unsigned.

## What was wrong

**The PowerShell command does not run.** We printed `Unblock-File -Path '...\*' -Recurse`. `Unblock-File` has no `-Recurse` parameter - its only parameter sets are `-Path` and `-LiteralPath` plus `-WhatIf`/`-Confirm` - so it fails on parameter binding before touching a file.

**Unblocking cannot help anyway.** Smart App Control gates on signature and cloud reputation, not on Mark-of-the-Web, and Microsoft documents no way to bypass it for a single app. The command is removed rather than corrected.

**Evaluation mode was listed as a trigger.** Microsoft documents that Evaluation observes without blocking, so only enforcement (On) can produce `0x800711C7`. This matters because the mode a user reports is what tells you whether Smart App Control is even the cause.

**We told users to turn Smart App Control off temporarily.** The docs said that and added that users report it keeps working after turning it back on. Windows will not turn Smart App Control back on without a reset or reinstall. This is the line most likely to have caused real harm, so the replacement calls it out explicitly for anyone who already read it.

## What the pages say now

The docs section is split in three, because one section was serving two unrelated failures and the "extract to a new folder" fix only ever applied to one of them:

- `#windows-smart-app-control-and-in-app-upgrades` - the block itself. States that the Windows builds are unsigned, gives a table of what each Smart App Control mode does, and lists the options.
- `#windows-incomplete-in-app-upgrade` - new anchor, gets the reinstall steps, which do work for a mixed-version install folder. `TroubleshootIncompleteUpgradeUrl` now points here.
- `#windows-cloud-sync-install` - new anchor for OneDrive installs, which is how the reporter was set up.

The original anchor stays on the Smart App Control section so links baked into released builds still land somewhere useful. `docs/getting-started.md` gains a warning next to the Windows download links, since the install page is where people are before they hit this.

## Signing changes the emphasis

Libation has applied to the SignPath Foundation, so the docs now list waiting for signed builds as the first option rather than presenting an irreversible security change as one of only two ways out. The status is hedged on approval and carries no date.

The dialog deliberately says nothing about signing progress and defers to the docs instead, because a string that ships inside a build cannot be corrected if the application falls through. It no longer nudges toward turning Smart App Control off without pointing at the page that has the current options.

## Verification

All 673 tests in `LibationFileManager.Tests` pass (652 succeeded, 21 skipped as Windows-only), and `LibationAvalonia` and `LibationCli` build with no errors.

Three tests cover the message text, since the text is the entire deliverable. As a negative control I temporarily reinstated the `Unblock-File` line and confirmed the guard test fails, so it is not vacuous.

`npm run docs:build` succeeds, and all three anchors plus both cross-links from `getting-started.md` resolve in the generated HTML.

The dialog body below is real output from `StartupAssemblyBootstrap.GetStartupFailureMessage`, given a `FileLoadException` carrying the reporter's blocked path. The install folder line reads as a scratch directory only because it was rendered outside a real install.

[Rendered Smart App Control troubleshooting section showing the mode table, the three options including waiting for signed builds, the SignPath Foundation status, and the warning that turning Smart App Control off cannot be undone](https://cursor.com/agents/bc-99309e43-551e-4d2b-bb0f-622a596f3e8d/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdocs_smart_app_control_section_with_signing.webp)

[Getting started page showing the new Smart App Control warning beside the Windows install instructions](https://cursor.com/agents/bc-99309e43-551e-4d2b-bb0f-622a596f3e8d/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdocs_getting_started_windows_warning.webp)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-99309e43-551e-4d2b-bb0f-622a596f3e8d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-99309e43-551e-4d2b-bb0f-622a596f3e8d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

