### PR TITLE
Detect Application Control enforcement and stop upgrading into a broken install

### DIFF
--- a/Source/AppScaffolding/LibationScaffolding.cs
+++ b/Source/AppScaffolding/LibationScaffolding.cs
@@ -309,7 +309,7 @@ public static class LibationScaffolding
 			// of these three, and none of them is visible anywhere else in a bug report.
 			InstallFolder = Configuration.ProcessDirectory,
 			ApplicationControl = ApplicationControlPolicy.GetState(),
-			CloudSyncRoot = CloudSyncedFolders.FindSyncRootContaining(Configuration.ProcessDirectory),
+			InstallFolderCloudSync = CloudSyncedFolders.GetSyncStatus(Configuration.ProcessDirectory),
 			Mode = mode,
 			LogLevel_Verbose_Enabled = Log.Logger.IsVerboseEnabled(),
 			LogLevel_Debug_Enabled = Log.Logger.IsDebugEnabled(),

--- a/Source/AppScaffolding/LibationScaffolding.cs
+++ b/Source/AppScaffolding/LibationScaffolding.cs
@@ -305,6 +305,11 @@ public static class LibationScaffolding
 			Configuration.OS,
 			Environment.OSVersion,
 			InteropFactory.InteropFunctionsType,
+			// A file Windows refused to load, or a half-applied upgrade, is usually explained by one
+			// of these three, and none of them is visible anywhere else in a bug report.
+			InstallFolder = Configuration.ProcessDirectory,
+			ApplicationControl = ApplicationControlPolicy.GetState(),
+			CloudSyncRoot = CloudSyncedFolders.FindSyncRootContaining(Configuration.ProcessDirectory),
 			Mode = mode,
 			LogLevel_Verbose_Enabled = Log.Logger.IsVerboseEnabled(),
 			LogLevel_Debug_Enabled = Log.Logger.IsDebugEnabled(),

--- a/Source/LibationAvalonia/Dialogs/AboutDialog.axaml.cs
+++ b/Source/LibationAvalonia/Dialogs/AboutDialog.axaml.cs
@@ -44,7 +44,7 @@ public partial class AboutDialog : DialogWindow
 
 		async Task OnUpgradeAvailable(UpgradeEventArgs e)
 		{
-			var notificationResult = await new UpgradeNotificationDialog(e.UpgradeProperties, e.CapUpgrade).ShowDialogAsync(this);
+			var notificationResult = await new UpgradeNotificationDialog(e.UpgradeProperties, e.CapUpgrade, e.UpgradeUnavailableReason).ShowDialogAsync(this);
 
 			e.Ignore = notificationResult == DialogResult.Ignore;
 			e.InstallUpgrade = notificationResult == DialogResult.OK;

--- a/Source/LibationAvalonia/Dialogs/UpgradeNotificationDialog.axaml.cs
+++ b/Source/LibationAvalonia/Dialogs/UpgradeNotificationDialog.axaml.cs
@@ -30,13 +30,13 @@ public partial class UpgradeNotificationDialog : DialogWindow
 		ControlToFocusOnShow = btnYes;
 	}
 
-	public UpgradeNotificationDialog(UpgradeProperties upgradeProperties, bool canUpgrade) : this()
+	public UpgradeNotificationDialog(UpgradeProperties upgradeProperties, bool canUpgrade, string? upgradeUnavailableReason = null) : this()
 	{
 		Title = $"Libation version {upgradeProperties.LatestRelease.ToVersionString()} is now available.";
 		PackageUrl = upgradeProperties.ZipUrl;
 		DownloadLinkText = upgradeProperties.ZipName;
 		ReleaseNotes = upgradeProperties.Notes;
-		TopMessage = canUpgrade ? UpdateMessage : "";
+		TopMessage = canUpgrade ? UpdateMessage : upgradeUnavailableReason ?? "";
 		OkText = canUpgrade ? "Yes" : "OK";
 		DataContext = this;
 	}

--- a/Source/LibationAvalonia/Views/MainWindow.axaml.cs
+++ b/Source/LibationAvalonia/Views/MainWindow.axaml.cs
@@ -263,7 +263,7 @@ public partial class MainWindow : ReactiveWindow<MainVM>
 #pragma warning disable CS8321 // Local function is declared but never used
 		async Task upgradeAvailable(LibationUiBase.UpgradeEventArgs e)
 		{
-			var notificationResult = await new UpgradeNotificationDialog(e.UpgradeProperties, e.CapUpgrade).ShowDialogAsync(this);
+			var notificationResult = await new UpgradeNotificationDialog(e.UpgradeProperties, e.CapUpgrade, e.UpgradeUnavailableReason).ShowDialogAsync(this);
 
 			e.Ignore = notificationResult == DialogResult.Ignore;
 			e.InstallUpgrade = notificationResult == DialogResult.OK;

--- a/Source/LibationFileManager/ApplicationControlPolicy.cs
+++ b/Source/LibationFileManager/ApplicationControlPolicy.cs
@@ -1,0 +1,85 @@
+using Microsoft.Win32;
+using System;
+using System.Runtime.Versioning;
+
+namespace LibationFileManager;
+
+/// <summary>Enforcement state of Windows Application Control, which on consumer PCs is Smart App Control.</summary>
+public enum ApplicationControlState
+{
+	/// <summary>Not Windows, or the state could not be read or recognised.</summary>
+	Unknown,
+	Off,
+	/// <summary>Blocking unsigned code that the reputation service does not recognise.</summary>
+	Enforcing,
+	/// <summary>Observing only. This mode never blocks.</summary>
+	Evaluation,
+}
+
+/// <summary>
+/// Reads whether Windows is enforcing Application Control, so Libation can explain a blocked file
+/// and avoid an in-app upgrade that would leave the install unable to start.
+/// </summary>
+public static class ApplicationControlPolicy
+{
+	private const string PolicyKeyPath = @"SYSTEM\CurrentControlSet\Control\CI\Policy";
+	private const string PolicyValueName = "VerifiedAndReputablePolicyState";
+
+	private static ApplicationControlState? _state;
+
+	/// <summary>
+	/// Read once per process. Changing the setting requires a reboot, so the answer cannot go stale
+	/// while Libation runs.
+	/// </summary>
+	public static ApplicationControlState GetState()
+	{
+		if (_state is ApplicationControlState cached)
+			return cached;
+
+		var state = ApplicationControlState.Unknown;
+
+		if (OperatingSystem.IsWindows())
+		{
+			try
+			{
+				state = ReadWindowsState();
+			}
+			catch (Exception ex)
+			{
+				// Covers Windows blocking Microsoft.Win32.Registry.dll itself, which is exactly the
+				// situation this check describes, so it must not become a second failure.
+				Serilog.Log.Logger.Debug(ex, "Could not read the Application Control policy state");
+			}
+		}
+
+		_state = state;
+		return state;
+	}
+
+	/// <summary>
+	/// True only when Windows is actively blocking. Anything unreadable or unrecognised counts as not
+	/// blocking: the alternative is telling someone to turn Smart App Control off - which cannot be
+	/// undone - on a PC that was never blocking anything.
+	/// </summary>
+	public static bool IsEnforcing => GetState() is ApplicationControlState.Enforcing;
+
+	/// <summary>
+	/// Interprets the raw VerifiedAndReputablePolicyState value. Null covers both an absent key and an
+	/// absent value: Windows builds that never shipped Smart App Control have the key without the value.
+	/// </summary>
+	public static ApplicationControlState FromPolicyValue(int? policyValue)
+		=> policyValue switch
+		{
+			0 => ApplicationControlState.Off,
+			1 => ApplicationControlState.Enforcing,
+			2 => ApplicationControlState.Evaluation,
+			_ => ApplicationControlState.Unknown,
+		};
+
+	[SupportedOSPlatform("windows")]
+	private static ApplicationControlState ReadWindowsState()
+	{
+		using var key = Registry.LocalMachine.OpenSubKey(PolicyKeyPath);
+		return FromPolicyValue(key?.GetValue(PolicyValueName) as int?);
+	}
+}

--- a/Source/LibationFileManager/CloudSyncedFolders.cs
+++ b/Source/LibationFileManager/CloudSyncedFolders.cs
@@ -1,0 +1,70 @@
+using System;
+using System.IO;
+
+namespace LibationFileManager;
+
+/// <summary>
+/// Detects whether a path sits inside a cloud sync root. Sync clients dehydrate files into
+/// placeholders, restore old copies, and leave conflict copies behind, which breaks an install
+/// folder the upgrader rewrites in place and corrupts the search index.
+/// </summary>
+public static class CloudSyncedFolders
+{
+	private static readonly string[] SyncRootVariables =
+	[
+		"OneDrive",
+		"OneDriveConsumer",
+		"OneDriveCommercial",
+	];
+
+	/// <summary>The sync root containing <paramref name="path"/>, or null when it is not inside one.</summary>
+	public static string? FindSyncRootContaining(string? path)
+	{
+		if (!TryGetFullPath(path, out var fullPath))
+			return null;
+
+		foreach (var variable in SyncRootVariables)
+		{
+			if (!TryGetFullPath(Environment.GetEnvironmentVariable(variable), out var syncRoot))
+				continue;
+
+			if (IsSameOrUnder(fullPath, syncRoot))
+				return syncRoot;
+		}
+
+		return null;
+	}
+
+	public static bool IsInsideSyncRoot(string? path) => FindSyncRootContaining(path) is not null;
+
+	private static bool TryGetFullPath(string? path, out string fullPath)
+	{
+		fullPath = string.Empty;
+		if (string.IsNullOrWhiteSpace(path))
+			return false;
+
+		try
+		{
+			fullPath = Path.TrimEndingDirectorySeparator(Path.GetFullPath(path));
+			return fullPath.Length > 0;
+		}
+		catch
+		{
+			// Unparseable environment values are simply not sync roots.
+			return false;
+		}
+	}
+
+	private static bool IsSameOrUnder(string path, string root)
+	{
+		var comparison = OperatingSystem.IsWindows() ? StringComparison.OrdinalIgnoreCase : StringComparison.Ordinal;
+
+		if (!path.StartsWith(root, comparison))
+			return false;
+
+		// Without this, C:\OneDriveBackup would count as being inside C:\OneDrive.
+		return path.Length == root.Length
+			|| path[root.Length] == Path.DirectorySeparatorChar
+			|| path[root.Length] == Path.AltDirectorySeparatorChar;
+	}
+}

--- a/Source/LibationFileManager/CloudSyncedFolders.cs
+++ b/Source/LibationFileManager/CloudSyncedFolders.cs
@@ -1,70 +1,94 @@
 using System;
-using System.IO;
+using System.Runtime.InteropServices;
+using System.Text;
 
 namespace LibationFileManager;
 
+/// <summary>Whether a path is inside a cloud sync root, and which provider owns it if Windows says.</summary>
+public readonly record struct CloudSyncStatus(bool IsSynced, string? ProviderName)
+{
+	public static readonly CloudSyncStatus NotSynced = new(false, null);
+
+	/// <summary>The provider's own name where Windows reported one, otherwise a generic description.</summary>
+	public string Description => ProviderName is { Length: > 0 } name ? name : "a cloud sync folder";
+}
+
 /// <summary>
-/// Detects whether a path sits inside a cloud sync root. Sync clients dehydrate files into
-/// placeholders, restore old copies, and leave conflict copies behind, which breaks an install
-/// folder the upgrader rewrites in place and corrupts the search index.
+/// Asks Windows whether a path sits under a registered cloud sync root. Every sync engine that
+/// serves files on demand registers one, so this covers OneDrive, Dropbox, Google Drive, iCloud and
+/// the rest without naming any of them, and without inferring anything from folder names.
+///
+/// It matters because sync clients dehydrate files into placeholders, restore old copies, and leave
+/// conflict copies behind. Under an install folder that the upgrader rewrites in place, that undoes
+/// part of an upgrade.
 /// </summary>
 public static class CloudSyncedFolders
 {
-	private static readonly string[] SyncRootVariables =
-	[
-		"OneDrive",
-		"OneDriveConsumer",
-		"OneDriveCommercial",
-	];
+	// cfapi.h. BASIC returns only a file id, which is all that is needed to answer "is this in a
+	// sync root at all", and is a plain 8-byte value with no marshalling to get wrong.
+	private const int CF_SYNC_ROOT_INFO_BASIC = 0;
+	private const int CF_SYNC_ROOT_INFO_PROVIDER = 2;
 
-	/// <summary>The sync root containing <paramref name="path"/>, or null when it is not inside one.</summary>
-	public static string? FindSyncRootContaining(string? path)
+	private const int CF_MAX_PROVIDER_NAME_LENGTH = 255;
+	private const int CF_MAX_PROVIDER_VERSION_LENGTH = 255;
+
+	// CF_SYNC_ROOT_BASIC_INFO is a single LARGE_INTEGER.
+	private const int BasicInfoLength = 8;
+
+	// CF_SYNC_ROOT_PROVIDER_INFO is a 4-byte status enum, then two fixed WCHAR arrays.
+	private const int ProviderStatusLength = 4;
+	private const int ProviderNameLengthInBytes = CF_MAX_PROVIDER_NAME_LENGTH * 2;
+	private const int ProviderInfoLength = ProviderStatusLength + ProviderNameLengthInBytes + (CF_MAX_PROVIDER_VERSION_LENGTH * 2);
+
+	public static CloudSyncStatus GetSyncStatus(string? path)
 	{
-		if (!TryGetFullPath(path, out var fullPath))
-			return null;
-
-		foreach (var variable in SyncRootVariables)
-		{
-			if (!TryGetFullPath(Environment.GetEnvironmentVariable(variable), out var syncRoot))
-				continue;
-
-			if (IsSameOrUnder(fullPath, syncRoot))
-				return syncRoot;
-		}
-
-		return null;
-	}
-
-	public static bool IsInsideSyncRoot(string? path) => FindSyncRootContaining(path) is not null;
-
-	private static bool TryGetFullPath(string? path, out string fullPath)
-	{
-		fullPath = string.Empty;
-		if (string.IsNullOrWhiteSpace(path))
-			return false;
+		if (string.IsNullOrWhiteSpace(path) || !OperatingSystem.IsWindows())
+			return CloudSyncStatus.NotSynced;
 
 		try
 		{
-			fullPath = Path.TrimEndingDirectorySeparator(Path.GetFullPath(path));
-			return fullPath.Length > 0;
+			return ReadWindowsSyncStatus(path);
 		}
-		catch
+		catch (Exception ex)
 		{
-			// Unparseable environment values are simply not sync roots.
-			return false;
+			// cldapi.dll is absent before Windows 10 1709, where there are no sync roots to find.
+			Serilog.Log.Logger.Debug(ex, "Could not read cloud sync root information for {Path}", path);
+			return CloudSyncStatus.NotSynced;
 		}
 	}
 
-	private static bool IsSameOrUnder(string path, string root)
+	private static CloudSyncStatus ReadWindowsSyncStatus(string path)
 	{
-		var comparison = OperatingSystem.IsWindows() ? StringComparison.OrdinalIgnoreCase : StringComparison.Ordinal;
+		var basicInfo = new byte[BasicInfoLength];
+		if (CfGetSyncRootInfoByPath(path, CF_SYNC_ROOT_INFO_BASIC, basicInfo, basicInfo.Length, out _) < 0)
+			return CloudSyncStatus.NotSynced;
 
-		if (!path.StartsWith(root, comparison))
-			return false;
-
-		// Without this, C:\OneDriveBackup would count as being inside C:\OneDrive.
-		return path.Length == root.Length
-			|| path[root.Length] == Path.DirectorySeparatorChar
-			|| path[root.Length] == Path.AltDirectorySeparatorChar;
+		return new CloudSyncStatus(true, TryReadProviderName(path));
 	}
+
+	/// <summary>The provider's name, or null when only the fact of syncing could be established.</summary>
+	private static string? TryReadProviderName(string path)
+	{
+		var providerInfo = new byte[ProviderInfoLength];
+		if (CfGetSyncRootInfoByPath(path, CF_SYNC_ROOT_INFO_PROVIDER, providerInfo, providerInfo.Length, out var returnedLength) < 0
+			|| returnedLength < ProviderStatusLength + 2)
+			return null;
+
+		var available = Math.Min(ProviderNameLengthInBytes, returnedLength - ProviderStatusLength);
+		var name = Encoding.Unicode.GetString(providerInfo, ProviderStatusLength, available);
+
+		var terminator = name.IndexOf('\0');
+		if (terminator >= 0)
+			name = name[..terminator];
+
+		return string.IsNullOrWhiteSpace(name) ? null : name.Trim();
+	}
+
+	[DllImport("cldapi.dll", CharSet = CharSet.Unicode, ExactSpelling = true)]
+	private static extern int CfGetSyncRootInfoByPath(
+		string filePath,
+		int infoClass,
+		[Out] byte[] infoBuffer,
+		int infoBufferLength,
+		out int returnedLength);
 }

--- a/Source/LibationFileManager/StartupAssemblyBootstrap.cs
+++ b/Source/LibationFileManager/StartupAssemblyBootstrap.cs
@@ -277,7 +277,7 @@ public static class StartupAssemblyBootstrap
 
 			Install folder:
 			{Configuration.ProcessDirectory}
-			{DescribeCloudSyncedInstall()}
+			{DescribeCloudSyncedInstall(CloudSyncedFolders.GetSyncStatus(Configuration.ProcessDirectory))}
 			Your library database, accounts, and settings are stored separately and should be unaffected.
 
 			To recover:
@@ -295,12 +295,12 @@ public static class StartupAssemblyBootstrap
 	/// Blank unless the install sits in a cloud sync folder, where sync can undo part of an overlay
 	/// upgrade on its own. Carries its own blank lines so the surrounding message reads the same either way.
 	/// </summary>
-	private static string DescribeCloudSyncedInstall()
+	public static string DescribeCloudSyncedInstall(CloudSyncStatus syncStatus)
 	{
-		if (CloudSyncedFolders.FindSyncRootContaining(Configuration.ProcessDirectory) is not string syncRoot)
+		if (!syncStatus.IsSynced)
 			return string.Empty;
 
-		return $"{Environment.NewLine}This install is inside a cloud sync folder ({syncRoot}). Sync clients replace and restore files underneath Libation, which can undo part of an upgrade by itself. Install to an ordinary local folder instead.{Environment.NewLine}";
+		return $"{Environment.NewLine}This install is inside {syncStatus.Description}. Sync clients replace and restore files underneath Libation, which can undo part of an upgrade by itself. Install to an ordinary local folder instead.{Environment.NewLine}";
 	}
 
 	private static bool ContainsLibationUiBaseReference(string? text)

--- a/Source/LibationFileManager/StartupAssemblyBootstrap.cs
+++ b/Source/LibationFileManager/StartupAssemblyBootstrap.cs
@@ -13,7 +13,7 @@ public static class StartupAssemblyBootstrap
 {
 	public const string EntityFrameworkCoreSqliteAssemblyFileName = "Microsoft.EntityFrameworkCore.Sqlite.dll";
 	public const int ApplicationControlBlockedHResult = unchecked((int)0x800711C7);
-	private const string TroubleshootApplicationControlUrl = "https://getlibation.com/docs/advanced/troubleshoot#windows-smart-app-control-and-in-app-upgrades";
+	public const string TroubleshootApplicationControlUrl = "https://getlibation.com/docs/advanced/troubleshoot#windows-smart-app-control-and-in-app-upgrades";
 	internal const string TroubleshootIncompleteUpgradeUrl = "https://getlibation.com/docs/advanced/troubleshoot#windows-incomplete-in-app-upgrade";
 
 	/// <summary>
@@ -94,14 +94,41 @@ public static class StartupAssemblyBootstrap
 
 			Your library database, accounts, and settings are stored separately and should be unaffected.
 
-			To check whether this is Smart App Control, open Settings -> Privacy & Security -> Windows Security -> App & browser control -> Smart App Control settings. Only the On setting blocks anything; Evaluation observes without blocking.
-
-			If it is On, turning it off is one way out, but Windows cannot turn it back on again without a reset or reinstall. Check the page below for the current options before you change anything. If it is already off, the block comes from a policy set by whoever manages this PC.
+			{DescribeApplicationControlState(ApplicationControlPolicy.GetState())}
 
 			More help:
 			{TroubleshootApplicationControlUrl}
 			""";
 	}
+
+	/// <summary>
+	/// Says what Smart App Control is set to when we could read it, and how to look it up when we
+	/// could not. Only enforcement is worth acting on, so the other states point elsewhere rather
+	/// than inviting someone to turn off a setting that is not the cause.
+	/// </summary>
+	public static string DescribeApplicationControlState(ApplicationControlState state)
+		=> state switch
+		{
+			ApplicationControlState.Enforcing =>
+				"""
+				Smart App Control is On for this PC, which is what blocked the file.
+
+				Turning it off is one way out, but Windows cannot turn it back on again without a reset or reinstall. Check the page below for the current options before you change anything.
+				""",
+
+			ApplicationControlState.Evaluation =>
+				"Smart App Control is in Evaluation mode for this PC, and that mode never blocks anything, so the block is coming from another Application Control policy, normally one set by whoever manages this PC.",
+
+			ApplicationControlState.Off =>
+				"Smart App Control is off for this PC, so the block is coming from another Application Control policy, normally one set by whoever manages this PC.",
+
+			_ =>
+				"""
+				To check whether this is Smart App Control, open Settings -> Privacy & Security -> Windows Security -> App & browser control -> Smart App Control settings. Only the On setting blocks anything; Evaluation observes without blocking.
+
+				If it is On, turning it off is one way out, but Windows cannot turn it back on again without a reset or reinstall. Check the page below for the current options before you change anything. If it is already off, the block comes from a policy set by whoever manages this PC.
+				""",
+		};
 
 	public static bool IsApplicationControlBlockedAssembly(Exception ex)
 	{
@@ -250,7 +277,7 @@ public static class StartupAssemblyBootstrap
 
 			Install folder:
 			{Configuration.ProcessDirectory}
-
+			{DescribeCloudSyncedInstall()}
 			Your library database, accounts, and settings are stored separately and should be unaffected.
 
 			To recover:
@@ -262,6 +289,18 @@ public static class StartupAssemblyBootstrap
 			More help:
 			{TroubleshootIncompleteUpgradeUrl}
 			""";
+	}
+
+	/// <summary>
+	/// Blank unless the install sits in a cloud sync folder, where sync can undo part of an overlay
+	/// upgrade on its own. Carries its own blank lines so the surrounding message reads the same either way.
+	/// </summary>
+	private static string DescribeCloudSyncedInstall()
+	{
+		if (CloudSyncedFolders.FindSyncRootContaining(Configuration.ProcessDirectory) is not string syncRoot)
+			return string.Empty;
+
+		return $"{Environment.NewLine}This install is inside a cloud sync folder ({syncRoot}). Sync clients replace and restore files underneath Libation, which can undo part of an upgrade by itself. Install to an ordinary local folder instead.{Environment.NewLine}";
 	}
 
 	private static bool ContainsLibationUiBaseReference(string? text)

--- a/Source/LibationUiBase/Upgrader.cs
+++ b/Source/LibationUiBase/Upgrader.cs
@@ -12,6 +12,8 @@ public class UpgradeEventArgs
 {
 	public required UpgradeProperties UpgradeProperties { get; init; }
 	public bool CapUpgrade { get; internal init; }
+	/// <summary>Why Libation cannot install this upgrade itself, to show in place of the update prompt. Null when it can.</summary>
+	public string? UpgradeUnavailableReason { get; internal init; }
 	private bool _ignore = false;
 	private bool _installUpgrade = true;
 	public bool Ignore
@@ -182,6 +184,14 @@ public class MockUpgrader : UpgraderBase
 
 public abstract class UpgraderBase
 {
+	internal const string ApplicationControlUpgradeMessage =
+		$"""
+		A new version is available, but Libation cannot install it itself: Smart App Control is on for this PC, and it blocks files Windows does not recognise. Replacing Libation's files in place is what leaves it unable to start.
+
+		Download the release below and install it yourself. If Windows blocks that too, see:
+		{StartupAssemblyBootstrap.TroubleshootApplicationControlUrl}
+		""";
+
 	public event EventHandler? DownloadBegin;
 	public event EventHandler<DownloadProgress>? DownloadProgress;
 	public event EventHandler<bool>? DownloadCompleted;
@@ -192,6 +202,18 @@ public abstract class UpgraderBase
 		=> UpgradeFailed?.Invoke(this, (message + Environment.NewLine + Environment.NewLine + ex?.Message).Trim());
 	protected abstract Task<VersionCheckResult> CheckForUpgradeAsync();
 	protected abstract Task<string?> DownloadUpgradeAsync(UpgradeProperties upgradeProperties);
+
+	/// <summary>
+	/// Whether Libation may replace its own install files, and what to show instead of the update
+	/// prompt when it may not. An overlay upgrade writes files Windows has never seen, and
+	/// Application Control blocks unsigned files it does not recognise, so upgrading in place under
+	/// enforcement is what turns a working install into one that cannot start.
+	/// Kept separate from the upgrade flow so the enforcing case is testable away from Windows.
+	/// </summary>
+	internal static (bool CapUpgrade, string? UnavailableReason) ResolveUpgradeCapability(bool platformCanUpgrade, bool applicationControlEnforcing)
+		=> applicationControlEnforcing
+			? (false, ApplicationControlUpgradeMessage)
+			: (platformCanUpgrade, null);
 
 	/// <summary>Check for upgrade and invoke <paramref name="upgradeAvailableHandler"/> if an update is available. Returns the check outcome so the UI can show "up to date", "update available", or "unable to determine".</summary>
 	public async Task<VersionCheckResult> CheckForUpgradeAsync(Func<UpgradeEventArgs, Task> upgradeAvailableHandler)
@@ -214,10 +236,17 @@ public abstract class UpgraderBase
 			if (!interop.CanUpgrade)
 				Serilog.Log.Logger.Information("Can't perform upgrade automatically");
 
+			var applicationControlBlocksUpgrade = ApplicationControlPolicy.IsEnforcing;
+			if (applicationControlBlocksUpgrade)
+				Serilog.Log.Logger.Information("Windows Application Control is enforcing. Offering the download instead of an in-app upgrade.");
+
+			var (capUpgrade, unavailableReason) = ResolveUpgradeCapability(interop.CanUpgrade, applicationControlBlocksUpgrade);
+
 			var upgradeEventArgs = new UpgradeEventArgs
 			{
 				UpgradeProperties = upgradeProperties,
-				CapUpgrade = interop.CanUpgrade
+				CapUpgrade = capUpgrade,
+				UpgradeUnavailableReason = unavailableReason,
 			};
 
 			await upgradeAvailableHandler(upgradeEventArgs);
@@ -226,6 +255,14 @@ public abstract class UpgraderBase
 				config.SetString(upgradeProperties.LatestRelease.ToString(), ignoreUpgrade);
 
 			if (!upgradeEventArgs.InstallUpgrade) return result;
+
+			// A second stop, because a UI that ignores CapUpgrade must not be able to start an
+			// upgrade that ends with Libation unable to start.
+			if (applicationControlBlocksUpgrade)
+			{
+				Serilog.Log.Logger.Information("Skipped the in-app upgrade to {LatestRelease}: Windows Application Control is enforcing.", upgradeProperties.LatestRelease);
+				return result;
+			}
 
 			//Download the upgrade file in the background,
 			DownloadBegin?.Invoke(this, EventArgs.Empty);

--- a/Source/LibationUiBase/Upgrader.cs
+++ b/Source/LibationUiBase/Upgrader.cs
@@ -8,12 +8,20 @@ using System.Threading.Tasks;
 
 namespace LibationUiBase;
 
+/// <summary>Whether Libation may replace its own install files, and what to say when it may not.</summary>
+internal readonly record struct UpgradeCapability(bool CapUpgrade, string? Reason, string? Summary);
+
 public class UpgradeEventArgs
 {
 	public required UpgradeProperties UpgradeProperties { get; init; }
 	public bool CapUpgrade { get; internal init; }
 	/// <summary>Why Libation cannot install this upgrade itself, to show in place of the update prompt. Null when it can.</summary>
 	public string? UpgradeUnavailableReason { get; internal init; }
+	/// <summary>
+	/// The same thing in one line, for Classic, whose dialog has a single line of room above the
+	/// release notes. Null when Libation can install the upgrade.
+	/// </summary>
+	public string? UpgradeUnavailableSummary { get; internal init; }
 	private bool _ignore = false;
 	private bool _installUpgrade = true;
 	public bool Ignore
@@ -186,11 +194,14 @@ public abstract class UpgraderBase
 {
 	internal const string ApplicationControlUpgradeMessage =
 		$"""
-		A new version is available, but Libation cannot install it itself: Smart App Control is on for this PC, and it blocks files Windows does not recognise. Replacing Libation's files in place is what leaves it unable to start.
+		A new version is available, but Libation cannot install it itself: Smart App Control is On for this PC, and it blocks files Windows does not recognise. Replacing Libation's files in place is what leaves it unable to start.
 
 		Download the release below and install it yourself. If Windows blocks that too, see:
 		{StartupAssemblyBootstrap.TroubleshootApplicationControlUrl}
 		""";
+
+	internal const string ApplicationControlUpgradeSummary =
+		"Libation cannot install this update while Smart App Control is On.";
 
 	public event EventHandler? DownloadBegin;
 	public event EventHandler<DownloadProgress>? DownloadProgress;
@@ -210,10 +221,10 @@ public abstract class UpgraderBase
 	/// enforcement is what turns a working install into one that cannot start.
 	/// Kept separate from the upgrade flow so the enforcing case is testable away from Windows.
 	/// </summary>
-	internal static (bool CapUpgrade, string? UnavailableReason) ResolveUpgradeCapability(bool platformCanUpgrade, bool applicationControlEnforcing)
+	internal static UpgradeCapability ResolveUpgradeCapability(bool platformCanUpgrade, bool applicationControlEnforcing)
 		=> applicationControlEnforcing
-			? (false, ApplicationControlUpgradeMessage)
-			: (platformCanUpgrade, null);
+			? new(false, ApplicationControlUpgradeMessage, ApplicationControlUpgradeSummary)
+			: new(platformCanUpgrade, null, null);
 
 	/// <summary>Check for upgrade and invoke <paramref name="upgradeAvailableHandler"/> if an update is available. Returns the check outcome so the UI can show "up to date", "update available", or "unable to determine".</summary>
 	public async Task<VersionCheckResult> CheckForUpgradeAsync(Func<UpgradeEventArgs, Task> upgradeAvailableHandler)
@@ -240,13 +251,14 @@ public abstract class UpgraderBase
 			if (applicationControlBlocksUpgrade)
 				Serilog.Log.Logger.Information("Windows Application Control is enforcing. Offering the download instead of an in-app upgrade.");
 
-			var (capUpgrade, unavailableReason) = ResolveUpgradeCapability(interop.CanUpgrade, applicationControlBlocksUpgrade);
+			var capability = ResolveUpgradeCapability(interop.CanUpgrade, applicationControlBlocksUpgrade);
 
 			var upgradeEventArgs = new UpgradeEventArgs
 			{
 				UpgradeProperties = upgradeProperties,
-				CapUpgrade = capUpgrade,
-				UpgradeUnavailableReason = unavailableReason,
+				CapUpgrade = capability.CapUpgrade,
+				UpgradeUnavailableReason = capability.Reason,
+				UpgradeUnavailableSummary = capability.Summary,
 			};
 
 			await upgradeAvailableHandler(upgradeEventArgs);

--- a/Source/LibationWinForms/Dialogs/AboutDialog.cs
+++ b/Source/LibationWinForms/Dialogs/AboutDialog.cs
@@ -71,7 +71,7 @@ public partial class AboutDialog : Form
 
 		Task OnUpgradeAvailable(UpgradeEventArgs e)
 		{
-			var notificationResult = new UpgradeNotificationDialog(e.UpgradeProperties, e.CapUpgrade, e.UpgradeUnavailableReason).ShowDialog(this);
+			var notificationResult = new UpgradeNotificationDialog(e.UpgradeProperties, e.CapUpgrade, e.UpgradeUnavailableSummary).ShowDialog(this);
 
 			e.Ignore = notificationResult == DialogResult.Ignore;
 			e.InstallUpgrade = notificationResult == DialogResult.Yes;

--- a/Source/LibationWinForms/Dialogs/AboutDialog.cs
+++ b/Source/LibationWinForms/Dialogs/AboutDialog.cs
@@ -71,7 +71,7 @@ public partial class AboutDialog : Form
 
 		Task OnUpgradeAvailable(UpgradeEventArgs e)
 		{
-			var notificationResult = new UpgradeNotificationDialog(e.UpgradeProperties).ShowDialog(this);
+			var notificationResult = new UpgradeNotificationDialog(e.UpgradeProperties, e.CapUpgrade, e.UpgradeUnavailableReason).ShowDialog(this);
 
 			e.Ignore = notificationResult == DialogResult.Ignore;
 			e.InstallUpgrade = notificationResult == DialogResult.Yes;

--- a/Source/LibationWinForms/Dialogs/UpgradeNotificationDialog.Designer.cs
+++ b/Source/LibationWinForms/Dialogs/UpgradeNotificationDialog.Designer.cs
@@ -28,8 +28,6 @@
 		/// </summary>
 		private void InitializeComponent()
 		{
-			System.Windows.Forms.Label label1;
-			System.Windows.Forms.Label label2;
 			System.Windows.Forms.GroupBox groupBox1;
 			System.Windows.Forms.LinkLabel linkLabel3;
 			System.Windows.Forms.LinkLabel linkLabel2;
@@ -39,8 +37,8 @@
 			this.dontRemindBtn = new System.Windows.Forms.Button();
 			this.yesBtn = new System.Windows.Forms.Button();
 			this.noBtn = new System.Windows.Forms.Button();
-			label1 = new System.Windows.Forms.Label();
-			label2 = new System.Windows.Forms.Label();
+			this.promptLbl = new System.Windows.Forms.Label();
+			this.promptDetailLbl = new System.Windows.Forms.Label();
 			groupBox1 = new System.Windows.Forms.GroupBox();
 			linkLabel3 = new System.Windows.Forms.LinkLabel();
 			linkLabel2 = new System.Windows.Forms.LinkLabel();
@@ -48,25 +46,26 @@
 			groupBox1.SuspendLayout();
 			this.SuspendLayout();
 			// 
-			// label1
+			// promptLbl
 			// 
-			label1.AutoSize = true;
-			label1.Font = new System.Drawing.Font("Segoe UI", 12F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point);
-			label1.Location = new System.Drawing.Point(12, 9);
-			label1.Name = "label1";
-			label1.Size = new System.Drawing.Size(416, 21);
-			label1.TabIndex = 0;
-			label1.Text = "There is a new version available. Would you like to update?";
+			this.promptLbl.AutoSize = true;
+			this.promptLbl.Font = new System.Drawing.Font("Segoe UI", 12F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point);
+			this.promptLbl.Location = new System.Drawing.Point(12, 9);
+			this.promptLbl.Name = "promptLbl";
+			this.promptLbl.Size = new System.Drawing.Size(416, 21);
+			this.promptLbl.TabIndex = 0;
+			this.promptLbl.Text = "There is a new version available. Would you like to update?";
 			// 
-			// label2
+			// promptDetailLbl
 			// 
-			label2.AutoSize = true;
-			label2.Location = new System.Drawing.Point(12, 39);
-			label2.Name = "label2";
-			label2.Padding = new System.Windows.Forms.Padding(0, 0, 0, 10);
-			label2.Size = new System.Drawing.Size(327, 25);
-			label2.TabIndex = 1;
-			label2.Text = "After you close Libation, the upgrade will start automatically.";
+			this.promptDetailLbl.AutoSize = true;
+			this.promptDetailLbl.Location = new System.Drawing.Point(12, 39);
+			this.promptDetailLbl.MaximumSize = new System.Drawing.Size(531, 0);
+			this.promptDetailLbl.Name = "promptDetailLbl";
+			this.promptDetailLbl.Padding = new System.Windows.Forms.Padding(0, 0, 0, 10);
+			this.promptDetailLbl.Size = new System.Drawing.Size(327, 25);
+			this.promptDetailLbl.TabIndex = 1;
+			this.promptDetailLbl.Text = "After you close Libation, the upgrade will start automatically.";
 			// 
 			// groupBox1
 			// 
@@ -191,8 +190,8 @@
 			this.Controls.Add(this.yesBtn);
 			this.Controls.Add(this.dontRemindBtn);
 			this.Controls.Add(groupBox1);
-			this.Controls.Add(label2);
-			this.Controls.Add(label1);
+			this.Controls.Add(this.promptDetailLbl);
+			this.Controls.Add(this.promptLbl);
 			this.MaximizeBox = false;
 			this.MinimizeBox = false;
 			this.MinimumSize = new System.Drawing.Size(460, 420);
@@ -213,5 +212,7 @@
 		private System.Windows.Forms.Button dontRemindBtn;
 		private System.Windows.Forms.Button yesBtn;
 		private System.Windows.Forms.Button noBtn;
+		private System.Windows.Forms.Label promptLbl;
+		private System.Windows.Forms.Label promptDetailLbl;
 	}
 }

--- a/Source/LibationWinForms/Dialogs/UpgradeNotificationDialog.cs
+++ b/Source/LibationWinForms/Dialogs/UpgradeNotificationDialog.cs
@@ -16,7 +16,7 @@ public partial class UpgradeNotificationDialog : Form
 		this.SetLibationIcon();
 	}
 
-	public UpgradeNotificationDialog(UpgradeProperties upgradeProperties, bool canUpgrade = true, string? upgradeUnavailableReason = null) : this()
+	public UpgradeNotificationDialog(UpgradeProperties upgradeProperties, bool canUpgrade = true, string? upgradeUnavailableSummary = null) : this()
 	{
 		Text = $"Libation version {upgradeProperties.LatestRelease.ToVersionString()} is now available.";
 		PackageUrl = upgradeProperties.ZipUrl;
@@ -25,10 +25,11 @@ public partial class UpgradeNotificationDialog : Form
 
 		if (!canUpgrade)
 		{
-			// Without a Yes button the dialog is a notice, so it must not keep asking a question
-			// that no longer has an answer.
+			// Without a Yes button this is a notice, so it must stop asking a question that no
+			// longer has an answer. Both labels take one line before the release notes box begins,
+			// which is why this takes the one-line summary and not the full explanation.
 			promptLbl.Text = "There is a new version available.";
-			promptDetailLbl.Text = upgradeUnavailableReason ?? "Libation cannot install this upgrade itself.";
+			promptDetailLbl.Text = upgradeUnavailableSummary ?? "Libation cannot install this update itself. Use the download link below.";
 			yesBtn.Visible = false;
 			noBtn.Text = "OK";
 		}

--- a/Source/LibationWinForms/Dialogs/UpgradeNotificationDialog.cs
+++ b/Source/LibationWinForms/Dialogs/UpgradeNotificationDialog.cs
@@ -16,14 +16,24 @@ public partial class UpgradeNotificationDialog : Form
 		this.SetLibationIcon();
 	}
 
-	public UpgradeNotificationDialog(UpgradeProperties upgradeProperties) : this()
+	public UpgradeNotificationDialog(UpgradeProperties upgradeProperties, bool canUpgrade = true, string? upgradeUnavailableReason = null) : this()
 	{
 		Text = $"Libation version {upgradeProperties.LatestRelease.ToVersionString()} is now available.";
 		PackageUrl = upgradeProperties.ZipUrl;
 		packageDlLink.Text = upgradeProperties.ZipName;
 		releaseNotesTbox.Text = upgradeProperties.Notes;
 
-		Shown += (_, _) => yesBtn.Focus();
+		if (!canUpgrade)
+		{
+			// Without a Yes button the dialog is a notice, so it must not keep asking a question
+			// that no longer has an answer.
+			promptLbl.Text = "There is a new version available.";
+			promptDetailLbl.Text = upgradeUnavailableReason ?? "Libation cannot install this upgrade itself.";
+			yesBtn.Visible = false;
+			noBtn.Text = "OK";
+		}
+
+		Shown += (_, _) => (canUpgrade ? yesBtn : noBtn).Focus();
 	}
 
 	private void PackageDlLink_LinkClicked(object sender, LinkLabelLinkClickedEventArgs e)

--- a/Source/LibationWinForms/Form1.Upgrade.cs
+++ b/Source/LibationWinForms/Form1.Upgrade.cs
@@ -13,7 +13,7 @@ public partial class Form1
 #pragma warning disable CS8321 // Local function is declared but never used
 		async Task upgradeAvailable(UpgradeEventArgs e)
 		{
-			var notificationResult = await new UpgradeNotificationDialog(e.UpgradeProperties, e.CapUpgrade, e.UpgradeUnavailableReason).ShowDialogAsync(this);
+			var notificationResult = await new UpgradeNotificationDialog(e.UpgradeProperties, e.CapUpgrade, e.UpgradeUnavailableSummary).ShowDialogAsync(this);
 
 			e.Ignore = notificationResult == DialogResult.Ignore;
 			e.InstallUpgrade = notificationResult == DialogResult.Yes;

--- a/Source/LibationWinForms/Form1.Upgrade.cs
+++ b/Source/LibationWinForms/Form1.Upgrade.cs
@@ -13,7 +13,7 @@ public partial class Form1
 #pragma warning disable CS8321 // Local function is declared but never used
 		async Task upgradeAvailable(UpgradeEventArgs e)
 		{
-			var notificationResult = await new UpgradeNotificationDialog(e.UpgradeProperties).ShowDialogAsync(this);
+			var notificationResult = await new UpgradeNotificationDialog(e.UpgradeProperties, e.CapUpgrade, e.UpgradeUnavailableReason).ShowDialogAsync(this);
 
 			e.Ignore = notificationResult == DialogResult.Ignore;
 			e.InstallUpgrade = notificationResult == DialogResult.Yes;

--- a/Source/_Tests/LibationFileManager.Tests/ApplicationControlPolicyTests.cs
+++ b/Source/_Tests/LibationFileManager.Tests/ApplicationControlPolicyTests.cs
@@ -1,0 +1,64 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+
+namespace LibationFileManager.Tests;
+
+[TestClass]
+public class ApplicationControlPolicyTests
+{
+	[TestMethod]
+	[DataRow(0, ApplicationControlState.Off)]
+	[DataRow(1, ApplicationControlState.Enforcing)]
+	[DataRow(2, ApplicationControlState.Evaluation)]
+	public void FromPolicyValue_maps_the_documented_values(int policyValue, ApplicationControlState expected)
+		=> Assert.AreEqual(expected, ApplicationControlPolicy.FromPolicyValue(policyValue));
+
+	// The CI\Policy key exists without this value on Windows builds that never shipped Smart App
+	// Control. Reading that as enforcement tells people to make an irreversible change to a PC that
+	// was never blocking anything, which is how ludus shipped a false positive (ludus issue #410).
+	[TestMethod]
+	[DataRow(null)]
+	[DataRow(3)]
+	[DataRow(-1)]
+	public void FromPolicyValue_treats_anything_unrecognised_as_unknown(int? policyValue)
+	{
+		Assert.AreEqual(ApplicationControlState.Unknown, ApplicationControlPolicy.FromPolicyValue(policyValue));
+		Assert.AreNotEqual(ApplicationControlState.Enforcing, ApplicationControlPolicy.FromPolicyValue(policyValue));
+	}
+
+	[TestMethod]
+	public void GetState_is_unknown_and_not_enforcing_off_windows()
+	{
+		if (OperatingSystem.IsWindows())
+			Assert.Inconclusive("Skipped because the OS is Windows, where a real policy state is expected.");
+
+		Assert.AreEqual(ApplicationControlState.Unknown, ApplicationControlPolicy.GetState());
+		Assert.IsFalse(ApplicationControlPolicy.IsEnforcing);
+	}
+
+	[TestMethod]
+	public void Only_the_enforcing_message_tells_the_user_to_turn_smart_app_control_off()
+	{
+		var enforcing = StartupAssemblyBootstrap.DescribeApplicationControlState(ApplicationControlState.Enforcing);
+		StringAssert.Contains(enforcing, "On for this PC");
+		StringAssert.Contains(enforcing, "cannot turn it back on");
+
+		// Turning Smart App Control off cannot be undone, so a state that is not blocking must never
+		// be answered by suggesting it.
+		foreach (var state in new[] { ApplicationControlState.Off, ApplicationControlState.Evaluation })
+		{
+			var message = StartupAssemblyBootstrap.DescribeApplicationControlState(state);
+			StringAssert.Contains(message, "another Application Control policy");
+			Assert.IsFalse(message.Contains("turn", StringComparison.OrdinalIgnoreCase), $"The {state} message must not suggest changing the setting: {message}");
+		}
+	}
+
+	[TestMethod]
+	public void The_unknown_message_explains_how_to_look_the_setting_up()
+	{
+		var message = StartupAssemblyBootstrap.DescribeApplicationControlState(ApplicationControlState.Unknown);
+
+		StringAssert.Contains(message, "Smart App Control settings");
+		StringAssert.Contains(message, "Evaluation observes without blocking");
+	}
+}

--- a/Source/_Tests/LibationFileManager.Tests/CloudSyncedFoldersTests.cs
+++ b/Source/_Tests/LibationFileManager.Tests/CloudSyncedFoldersTests.cs
@@ -7,58 +7,52 @@ namespace LibationFileManager.Tests;
 [TestClass]
 public class CloudSyncedFoldersTests
 {
-	private const string SyncRootVariable = "OneDrive";
-	private string? _originalSyncRoot;
-	private string _syncRoot = null!;
-
-	[TestInitialize]
-	public void Setup()
+	// Sync roots are a Windows concept and the answer comes from cldapi.dll, so there is nothing
+	// here for CI on Linux to verify beyond the guards. The Windows path needs a machine with a
+	// sync client installed, which CI does not have either.
+	[TestMethod]
+	public void Nothing_is_synced_off_windows()
 	{
-		_originalSyncRoot = Environment.GetEnvironmentVariable(SyncRootVariable);
-		_syncRoot = Path.Combine(Path.GetTempPath(), "LibationSyncTests-" + Guid.NewGuid().ToString("N"));
-		Environment.SetEnvironmentVariable(SyncRootVariable, _syncRoot);
-	}
+		if (OperatingSystem.IsWindows())
+			Assert.Inconclusive("Skipped because the OS is Windows, where a real sync root may exist.");
 
-	[TestCleanup]
-	public void Cleanup() => Environment.SetEnvironmentVariable(SyncRootVariable, _originalSyncRoot);
+		var status = CloudSyncedFolders.GetSyncStatus(Path.GetTempPath());
 
-	[TestMethod]
-	public void Finds_the_sync_root_containing_an_install()
-	{
-		var install = Path.Combine(_syncRoot, "Documents", "Books", "Libation");
-
-		Assert.AreEqual(_syncRoot, CloudSyncedFolders.FindSyncRootContaining(install));
-		Assert.IsTrue(CloudSyncedFolders.IsInsideSyncRoot(install));
-	}
-
-	[TestMethod]
-	public void The_sync_root_itself_counts_as_inside()
-		=> Assert.IsTrue(CloudSyncedFolders.IsInsideSyncRoot(_syncRoot));
-
-	[TestMethod]
-	public void A_folder_merely_sharing_the_prefix_is_not_inside()
-	{
-		// Without a separator check, _syncRoot + "Backup" would look like a child of _syncRoot.
-		Assert.IsFalse(CloudSyncedFolders.IsInsideSyncRoot(_syncRoot + "Backup"));
-		Assert.IsFalse(CloudSyncedFolders.IsInsideSyncRoot(Path.Combine(_syncRoot + "Backup", "Libation")));
-	}
-
-	[TestMethod]
-	public void A_path_outside_every_sync_root_is_not_inside()
-		=> Assert.IsFalse(CloudSyncedFolders.IsInsideSyncRoot(Path.Combine(Path.GetTempPath(), "Libation")));
-
-	[TestMethod]
-	public void Nothing_is_inside_a_sync_root_that_is_not_configured()
-	{
-		Environment.SetEnvironmentVariable(SyncRootVariable, null);
-
-		Assert.IsNull(CloudSyncedFolders.FindSyncRootContaining(Path.Combine(_syncRoot, "Libation")));
+		Assert.IsFalse(status.IsSynced);
+		Assert.IsNull(status.ProviderName);
 	}
 
 	[TestMethod]
 	[DataRow(null)]
 	[DataRow("")]
 	[DataRow("   ")]
-	public void A_missing_path_is_not_inside(string? path)
-		=> Assert.IsFalse(CloudSyncedFolders.IsInsideSyncRoot(path));
+	public void A_missing_path_is_not_synced(string? path)
+		=> Assert.IsFalse(CloudSyncedFolders.GetSyncStatus(path).IsSynced);
+
+	[TestMethod]
+	public void The_description_names_the_provider_when_windows_reported_one()
+		=> Assert.AreEqual("OneDrive", new CloudSyncStatus(true, "OneDrive").Description);
+
+	// Windows reports the fact of syncing through one info class and the provider name through
+	// another, so the name can be missing while the folder really is synced.
+	[TestMethod]
+	[DataRow(null)]
+	[DataRow("")]
+	public void The_description_falls_back_when_no_provider_name_came_back(string? providerName)
+		=> Assert.AreEqual("a cloud sync folder", new CloudSyncStatus(true, providerName).Description);
+
+	[TestMethod]
+	public void An_unsynced_install_adds_nothing_to_the_upgrade_failure_message()
+		=> Assert.AreEqual(string.Empty, StartupAssemblyBootstrap.DescribeCloudSyncedInstall(CloudSyncStatus.NotSynced));
+
+	// The paragraph carries its own blank lines so the message around it reads the same either way.
+	[TestMethod]
+	public void A_synced_install_names_the_provider_and_keeps_its_own_spacing()
+	{
+		var paragraph = StartupAssemblyBootstrap.DescribeCloudSyncedInstall(new CloudSyncStatus(true, "Dropbox"));
+
+		StringAssert.Contains(paragraph, "inside Dropbox.");
+		StringAssert.StartsWith(paragraph, Environment.NewLine);
+		StringAssert.EndsWith(paragraph, Environment.NewLine);
+	}
 }

--- a/Source/_Tests/LibationFileManager.Tests/CloudSyncedFoldersTests.cs
+++ b/Source/_Tests/LibationFileManager.Tests/CloudSyncedFoldersTests.cs
@@ -1,0 +1,64 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.IO;
+
+namespace LibationFileManager.Tests;
+
+[TestClass]
+public class CloudSyncedFoldersTests
+{
+	private const string SyncRootVariable = "OneDrive";
+	private string? _originalSyncRoot;
+	private string _syncRoot = null!;
+
+	[TestInitialize]
+	public void Setup()
+	{
+		_originalSyncRoot = Environment.GetEnvironmentVariable(SyncRootVariable);
+		_syncRoot = Path.Combine(Path.GetTempPath(), "LibationSyncTests-" + Guid.NewGuid().ToString("N"));
+		Environment.SetEnvironmentVariable(SyncRootVariable, _syncRoot);
+	}
+
+	[TestCleanup]
+	public void Cleanup() => Environment.SetEnvironmentVariable(SyncRootVariable, _originalSyncRoot);
+
+	[TestMethod]
+	public void Finds_the_sync_root_containing_an_install()
+	{
+		var install = Path.Combine(_syncRoot, "Documents", "Books", "Libation");
+
+		Assert.AreEqual(_syncRoot, CloudSyncedFolders.FindSyncRootContaining(install));
+		Assert.IsTrue(CloudSyncedFolders.IsInsideSyncRoot(install));
+	}
+
+	[TestMethod]
+	public void The_sync_root_itself_counts_as_inside()
+		=> Assert.IsTrue(CloudSyncedFolders.IsInsideSyncRoot(_syncRoot));
+
+	[TestMethod]
+	public void A_folder_merely_sharing_the_prefix_is_not_inside()
+	{
+		// Without a separator check, _syncRoot + "Backup" would look like a child of _syncRoot.
+		Assert.IsFalse(CloudSyncedFolders.IsInsideSyncRoot(_syncRoot + "Backup"));
+		Assert.IsFalse(CloudSyncedFolders.IsInsideSyncRoot(Path.Combine(_syncRoot + "Backup", "Libation")));
+	}
+
+	[TestMethod]
+	public void A_path_outside_every_sync_root_is_not_inside()
+		=> Assert.IsFalse(CloudSyncedFolders.IsInsideSyncRoot(Path.Combine(Path.GetTempPath(), "Libation")));
+
+	[TestMethod]
+	public void Nothing_is_inside_a_sync_root_that_is_not_configured()
+	{
+		Environment.SetEnvironmentVariable(SyncRootVariable, null);
+
+		Assert.IsNull(CloudSyncedFolders.FindSyncRootContaining(Path.Combine(_syncRoot, "Libation")));
+	}
+
+	[TestMethod]
+	[DataRow(null)]
+	[DataRow("")]
+	[DataRow("   ")]
+	public void A_missing_path_is_not_inside(string? path)
+		=> Assert.IsFalse(CloudSyncedFolders.IsInsideSyncRoot(path));
+}

--- a/Source/_Tests/LibationUiBase.Tests/UpgradeCapabilityTests.cs
+++ b/Source/_Tests/LibationUiBase.Tests/UpgradeCapabilityTests.cs
@@ -1,0 +1,40 @@
+using LibationUiBase;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace LibationUiBase.Tests;
+
+[TestClass]
+public class UpgradeCapabilityTests
+{
+	[TestMethod]
+	public void An_ordinary_windows_install_can_still_upgrade_itself()
+	{
+		var (capUpgrade, reason) = UpgraderBase.ResolveUpgradeCapability(platformCanUpgrade: true, applicationControlEnforcing: false);
+
+		Assert.IsTrue(capUpgrade);
+		Assert.IsNull(reason);
+	}
+
+	// Overlaying new files while Application Control enforces is what leaves Libation unable to
+	// start, so the in-app upgrade has to be withdrawn rather than merely discouraged.
+	[TestMethod]
+	public void Application_control_withdraws_the_in_app_upgrade_and_explains_why()
+	{
+		var (capUpgrade, reason) = UpgraderBase.ResolveUpgradeCapability(platformCanUpgrade: true, applicationControlEnforcing: true);
+
+		Assert.IsFalse(capUpgrade);
+		Assert.IsNotNull(reason);
+		StringAssert.Contains(reason, "Smart App Control");
+		StringAssert.Contains(reason, "Download the release below");
+		StringAssert.Contains(reason, "troubleshoot#windows-smart-app-control-and-in-app-upgrades");
+	}
+
+	[TestMethod]
+	public void A_platform_that_cannot_upgrade_is_unchanged_and_gets_no_windows_explanation()
+	{
+		var (capUpgrade, reason) = UpgraderBase.ResolveUpgradeCapability(platformCanUpgrade: false, applicationControlEnforcing: false);
+
+		Assert.IsFalse(capUpgrade);
+		Assert.IsNull(reason);
+	}
+}

--- a/Source/_Tests/LibationUiBase.Tests/UpgradeCapabilityTests.cs
+++ b/Source/_Tests/LibationUiBase.Tests/UpgradeCapabilityTests.cs
@@ -9,10 +9,11 @@ public class UpgradeCapabilityTests
 	[TestMethod]
 	public void An_ordinary_windows_install_can_still_upgrade_itself()
 	{
-		var (capUpgrade, reason) = UpgraderBase.ResolveUpgradeCapability(platformCanUpgrade: true, applicationControlEnforcing: false);
+		var capability = UpgraderBase.ResolveUpgradeCapability(platformCanUpgrade: true, applicationControlEnforcing: false);
 
-		Assert.IsTrue(capUpgrade);
-		Assert.IsNull(reason);
+		Assert.IsTrue(capability.CapUpgrade);
+		Assert.IsNull(capability.Reason);
+		Assert.IsNull(capability.Summary);
 	}
 
 	// Overlaying new files while Application Control enforces is what leaves Libation unable to
@@ -20,21 +21,34 @@ public class UpgradeCapabilityTests
 	[TestMethod]
 	public void Application_control_withdraws_the_in_app_upgrade_and_explains_why()
 	{
-		var (capUpgrade, reason) = UpgraderBase.ResolveUpgradeCapability(platformCanUpgrade: true, applicationControlEnforcing: true);
+		var capability = UpgraderBase.ResolveUpgradeCapability(platformCanUpgrade: true, applicationControlEnforcing: true);
 
-		Assert.IsFalse(capUpgrade);
-		Assert.IsNotNull(reason);
-		StringAssert.Contains(reason, "Smart App Control");
-		StringAssert.Contains(reason, "Download the release below");
-		StringAssert.Contains(reason, "troubleshoot#windows-smart-app-control-and-in-app-upgrades");
+		Assert.IsFalse(capability.CapUpgrade);
+		Assert.IsNotNull(capability.Reason);
+		StringAssert.Contains(capability.Reason, "Smart App Control");
+		StringAssert.Contains(capability.Reason, "Download the release below");
+		StringAssert.Contains(capability.Reason, "troubleshoot#windows-smart-app-control-and-in-app-upgrades");
+	}
+
+	// Classic's dialog has one line above the release notes, so a summary that wraps would sit on
+	// top of them.
+	[TestMethod]
+	public void The_summary_for_classic_stays_on_one_line()
+	{
+		var capability = UpgraderBase.ResolveUpgradeCapability(platformCanUpgrade: true, applicationControlEnforcing: true);
+
+		Assert.IsNotNull(capability.Summary);
+		Assert.IsFalse(capability.Summary.Contains('\n'));
+		Assert.IsTrue(capability.Summary.Length <= 75, $"Summary is {capability.Summary.Length} characters and will wrap: {capability.Summary}");
 	}
 
 	[TestMethod]
 	public void A_platform_that_cannot_upgrade_is_unchanged_and_gets_no_windows_explanation()
 	{
-		var (capUpgrade, reason) = UpgraderBase.ResolveUpgradeCapability(platformCanUpgrade: false, applicationControlEnforcing: false);
+		var capability = UpgraderBase.ResolveUpgradeCapability(platformCanUpgrade: false, applicationControlEnforcing: false);
 
-		Assert.IsFalse(capUpgrade);
-		Assert.IsNull(reason);
+		Assert.IsFalse(capability.CapUpgrade);
+		Assert.IsNull(capability.Reason);
+		Assert.IsNull(capability.Summary);
 	}
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Now that [#1968](https://github.com/rmcrackan/libation/pull/1968) is merged, this targets `master` directly. It changes behaviour so Libation stops walking users into the state that [#1873](https://github.com/rmcrackan/Libation/issues/1873), [#1876](https://github.com/rmcrackan/Libation/issues/1876) and [#1967](https://github.com/rmcrackan/Libation/issues/1967) all describe.

## The problem

An in-app upgrade overlays files Windows has never seen. Smart App Control blocks unsigned files it does not recognise. So upgrading in place under enforcement is precisely how a working install becomes one that cannot start, and Libation was doing it without ever checking.

## Detecting Application Control

`ApplicationControlPolicy` reads `VerifiedAndReputablePolicyState` under `HKLM\SYSTEM\CurrentControlSet\Control\CI\Policy`.

That read needs no elevation and cannot raise a UAC prompt. UAC only fires on an explicit elevation request (a manifest, the `runas` verb, the COM elevation moniker, or installer-detection heuristics); a failed access check returns `ERROR_ACCESS_DENIED` rather than prompting, and the user's UAC slider does not change that. It will not even fail, since HKLM is readable by standard users. Libation's only real UAC surface remains `WinInterop.InstallUpgradeAsync`, which already elevates when the install folder is not writable. No new assembly ships either: the registry API is in the framework for `net10.0`.

**Only the value `1` counts as enforcing.** A missing key, a missing value, or anything unrecognised counts as not enforcing. The key exists without the value on Windows builds that never shipped Smart App Control, and reading that as enforcement is how [ludus told users to disable Smart App Control](https://github.com/jpvelasco/ludus/issues/410) on machines that were never blocking anything. Since that advice is irreversible, guessing wrong is expensive in one direction only.

## Acting on it

When enforcing, the upgrade notification becomes a notice carrying the download link instead of an update prompt, and the flow returns before downloading even if a UI ignores the flag.

Classic honoured no such flag at all, so its dialog now takes one. Its two prompt labels had to be promoted from designer locals to fields to carry the explanation, and because it has a single line of room above the release notes, it takes a one-line summary while Chardonnay takes the full text.

The blocked-file dialog now states the setting it found rather than telling the user to go and look, and only says anything about turning Smart App Control off in the one state where that is the cause. Startup logs the state, the install folder, and whether that folder is cloud-synced, so the next report answers these without a round trip.

## Detecting cloud sync, for any provider

`CloudSyncedFolders` calls `CfGetSyncRootInfoByPath` in `cldapi.dll`. Every sync engine that serves files on demand registers a sync root with the Cloud Files API, so this covers OneDrive, Dropbox, Google Drive, iCloud and Box without naming any of them.

It replaces code rather than adding to it: the environment-variable lookups, path canonicalisation and prefix matching are all gone, along with the guesswork in them. The provider info class also returns the provider's own name, so the message says "inside Dropbox" rather than a generic phrase, falling back to "a cloud sync folder" when only the fact of syncing comes back.

Detection cannot really produce a false positive, because the answer is Windows' own rather than an inference from a folder name. The *warning* still appears only inside the incomplete-upgrade message, where something has already gone wrong, so someone who deliberately keeps a synced folder fully downloaded is never prompted about it. The limitation is that a tool which merely mirrors a folder with no OS integration is not detected, but it also does not cause the placeholder and rehydration problems this is about.

## Verification

All 1467 tests pass, and `LibationAvalonia`, `LibationCli` and `LibationWinForms` all build clean. Classic compiles here via `-p:EnableWindowsTargeting=true`, so the designer edit is checked rather than assumed.

The enforcing decision is extracted into `UpgraderBase.ResolveUpgradeCapability` specifically so it can be tested away from Windows; `ApplicationControlPolicyTests` pins the value mapping, including the ludus case, and asserts that no non-blocking state suggests changing the setting.

The screenshot is the real `UpgradeNotificationDialog` rendered with the real production string, via `SetupWithoutStarting` (the same pattern `Program` uses for its crash dialog). Note the top paragraph, which was blank in this state before, and the button reading OK rather than Yes.

[The Libation upgrade dialog showing the Smart App Control explanation in place of the update prompt, with an OK button and no Yes button](https://cursor.com/agents/bc-99309e43-551e-4d2b-bb0f-622a596f3e8d/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fupgrade_dialog_blocked_by_app_control.webp)

Every message variant, rendered from the production code paths:

[messages_after_sync_root_detection.txt](https://cursor.com/agents/bc-99309e43-551e-4d2b-bb0f-622a596f3e8d/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fmessages_after_sync_root_detection.txt)

## Not covered

Three things cannot be exercised on Linux CI and want a look on a Windows box: the end-to-end enforcing path through `CheckForUpgradeAsync` (the pure decision is tested, the early return is three lines guarded by the same flag), Classic's dialog layout with the Yes button hidden, and the `cldapi.dll` call itself, which is why its buffers are plain byte arrays read by hand rather than marshalled structs.


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-99309e43-551e-4d2b-bb0f-622a596f3e8d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-99309e43-551e-4d2b-bb0f-622a596f3e8d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

