### PR TITLE
Guard removal against a failed scan; make the trash bin visible; explain the empty grid

### DIFF
--- a/.vitepress/config.js
+++ b/.vitepress/config.js
@@ -111,6 +111,7 @@ export default defineConfig({
             text: "Easy guide to searching",
             link: "/docs/features/lucene",
           },
+          { text: "Trash Bin", link: "/docs/features/trash-bin" },
         ],
       },
       {

--- a/Scripts/README.md
+++ b/Scripts/README.md
@@ -4,6 +4,7 @@ Developer utilities. None of these ship in a Libation install - they exist only 
 
 | Script | Purpose | Documented in |
 |--------|---------|---------------|
+| `seed-demo-accounts.cs` | Seed fake Audible accounts, to reach what is gated on having one without signing in | [Testing Changes](https://getlibation.com/docs/development/testing) |
 | `seed-demo-library.cs` | Seed a library covering every Liberate-column icon, for manual UI testing | [Testing Changes](https://getlibation.com/docs/development/testing) |
 | `seed-download-history.cs` | Seed completed downloads so the daily download limit can be tested without downloading | [Testing Changes](https://getlibation.com/docs/development/testing) |
 | `Bundle_Debian.sh` | Build the Linux `.deb` package | Used by `.github/workflows/build-linux.yml` |

--- a/Scripts/seed-demo-accounts.cs
+++ b/Scripts/seed-demo-accounts.cs
@@ -1,0 +1,222 @@
+#:package AudibleApi@11.0.3.1
+
+using AudibleApi;
+using AudibleApi.Authorization;
+using AudibleApi.Cryptography;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+
+// Adds fake Audible accounts to AccountsSettings.json, so the parts of Libation that only appear once an
+// account exists can be tested without signing in to Audible.
+//
+//   dotnet run Scripts/seed-demo-accounts.cs [--count 1] [--clean] [path-to-Libation-files-folder]
+//
+// Run Libation at least once first so AccountsSettings.json exists, and close it before seeding: the file is
+// read at startup and written back on save, so a running app would overwrite whatever this wrote.
+//
+// The accounts carry structurally valid but meaningless tokens. Libation will count them, list them and
+// enable everything that is gated on having an account, but any scan or download attempt fails at Audible.
+//
+// Real accounts in the file are left alone. --clean removes only the accounts this script added, which are
+// the ones whose AccountId matches demo*@example.com.
+//
+// Keep the package version above in step with AudibleApi in Source/AudibleUtilities/AudibleUtilities.csproj,
+// so the JSON this writes is the shape the app expects to read.
+
+// Fixture material. A syntactically valid RSA key and ADP token so the identity parses; neither authenticates.
+const string SamplePrivateKey = @"
+-----BEGIN RSA PRIVATE KEY-----
+MIIEpgIBAAKCAQEA5nPbGSVDmlEH2tJa6kz/P2HI8IeirhfPHdmi+X/nsb9i3WNf
+tmEdZxfK26IValQDXvBH17a1gr0HD6pYse1XsV2w0HxiW1RW+ZnjL8/fzPdkSOb+
+4xKlqRopCueBSdDGgAF06spZ3IeHLfEFOJX4dO1Y73pFBUkA0k53LT12L2Tjay/r
+buZHJqIzxmwja7/nkiWL0Xo7UySHtQACYsKEatu6yHBS+cPTlGR/qeUpeJTHwDLP
+7ZQ7kWzJGY1mfInYekjlZLsMsWswso3pg1vPyHgxzM2BWhY8m6mlXQ9G/USxBTib
+MNuMtpR73XsgamneFCc+Uv1cxw7ofZ41YOOAbQIDAQABAoIBAQDIre8HkKm0Aggj
+B7df/TjxCsgenR6PF/Cmf9UqC7XJ1W3UeCrq+NrP4aonZJfdhdeBnyAQuuyJMu6p
+N6ARISuSKpJEm2xTN7idluJ9yjmLlYtg6LbhKmXUQhGniz3M999DrQERTLDAF80h
+tpbjVcWMnPsrX4AnQBFVEjs5zCHU1hD+X463EmUHBWyT975jbZ8Fy7/fTzkdzLnn
+qE5lROALr2MCAAwQRFbRE6dd52vnXaBrVcAtRzjATts3WG3+SNi2Fm/OrYqQcY9e
+lBexNviT8VcldOAMrO10E2u0d+tvxFzwB3ABMvaVamrEZky4XSfB6aLzpD0JJj1s
+UHnIiVwJAoGBAPl8nLll/J9rud/N2HiAX2YkP0MC0HW4yM3KxLtXKyXrP5qBpaci
+wTDUmSWEEE3GUJMM1Z4d9tl9Lz2MhU2KqkEvLI3kQ7aUu33PYUBGMVcUzhFQ49lU
+Nzz8YB183iqo31o/DKk2Cr5gI7SykQZ0gn/urZkEJeErLzlhPXcyeY5jAoGBAOx4
+CGucVdv5MbdXZP8jVzxuvUlSp7BIQJ2phQXDFBNApFKnZn7yBYBx7dqzleymGm+R
+INZAurg3SNw4nvbQc3Z2dJ8I+n5ErjFCKp1IedVxx1eMEfecTwrQZuUwLISIyjqF
+czSJNwcNqzCx67z397/Cg5K/0pu6uIe0r7xozcbvAoGBAOOvZ9CDVPOg+rdXQvFm
+Jqou9lUPonNtOkUlgjl+qfAnK5q0KxvHSgxoWYO1bLOuAybQlbuBmSCPcKd5MMa9
+f/eRN9YetfVQ83Mz6YshBDJ22EFRUz+p7eeIY6dFp/PCvmO8Gq/qlA996dglBtmf
+RuG+T0vQT0mZgbWaGuBHfkwFAoGBAMOLg1MRxgKRMKavk6pU3EfyP3+J5XemWCDI
+1WLtbgV5uClNmzmxBBGypQHs7jbzKPtHpULn5kB+HzdVb0clG8ZDsK7u6s5OF0pO
+sBS+oVl7rF/eSeFcFhUYP26ZhsbWo3z/bERuj926VO2AxDPRTsP5o3pQPGZhY0V9
+irGgbUJrAoGBAOseS3J4BqYM4R3Hr7cRAhvzSjIkeTcDF1zTOa4FZDHBxZ6g2PNq
+8ekhtfn1zPczsPTF1vNuqEISKLxaPkVPiw0mtaZQjVwpF/IOxMNjWVLp6oJf8Mm2
+BxlXqPnQ4mG66oqSFQgDEmFdMhRb2of6xL1gYYL62C80G2T7QtmPfSab
+-----END RSA PRIVATE KEY-----
+";
+
+const string SampleAdpToken = "{enc:abcdefg}{key:1234}{iv:56789}{name:QURQVG9rZW5FbmNyeXB0aW9uS2V5}{serial:Mg==}";
+
+const string DemoAccountSuffix = "@example.com";
+const string DemoAccountPrefix = "demo";
+
+var clean = args.Contains("--clean", StringComparer.OrdinalIgnoreCase);
+var count = IntArg("--count") ?? 1;
+var pathArg = args.FirstOrDefault(a => !a.StartsWith("--") && !int.TryParse(a, out _));
+
+if (count < 1)
+{
+	Console.Error.WriteLine("--count must be at least 1.");
+	return 1;
+}
+
+if (FindLibationFiles(pathArg) is not string libationFiles)
+{
+	Console.Error.WriteLine("Could not find a Libation accounts file.");
+	Console.Error.WriteLine("Run Libation once to create it, then pass its folder, e.g.:");
+	Console.Error.WriteLine(@"  dotnet run Scripts/seed-demo-accounts.cs C:\Users\me\AppData\Local\Libation");
+	return 1;
+}
+
+var accountsPath = Path.Combine(libationFiles, "AccountsSettings.json");
+Console.WriteLine($"Accounts file: {accountsPath}");
+
+var root = JObject.Parse(File.ReadAllText(accountsPath));
+if (root["Accounts"] is not JArray accounts)
+{
+	accounts = [];
+	root["Accounts"] = accounts;
+}
+
+static bool IsDemo(JToken account)
+	=> account["AccountId"]?.Value<string>() is string id
+	&& id.StartsWith(DemoAccountPrefix, StringComparison.OrdinalIgnoreCase)
+	&& id.EndsWith(DemoAccountSuffix, StringComparison.OrdinalIgnoreCase);
+
+if (clean)
+{
+	var removed = accounts.Where(IsDemo).ToList();
+	foreach (var account in removed)
+		account.Remove();
+
+	File.WriteAllText(accountsPath, root.ToString(Formatting.Indented));
+	Console.WriteLine($"Removed {removed.Count} demo account(s). {accounts.Count} account(s) remain.");
+	return 0;
+}
+
+var realAccounts = accounts.Count(a => !IsDemo(a));
+if (realAccounts > 0)
+	Console.WriteLine($"Leaving {realAccounts} real account(s) untouched.");
+
+var added = 0;
+foreach (var accountId in DemoAccountIds(count))
+{
+	if (accounts.Any(a => string.Equals(a["AccountId"]?.Value<string>(), accountId, StringComparison.OrdinalIgnoreCase)))
+	{
+		Console.WriteLine($"  {accountId} already present, skipping");
+		continue;
+	}
+
+	accounts.Add(BuildAccount(accountId));
+	added++;
+}
+
+File.WriteAllText(accountsPath, root.ToString(Formatting.Indented));
+
+Console.WriteLine($"Added {added} demo account(s). Libation will now see {accounts.Count} account(s).");
+Console.WriteLine();
+Console.WriteLine("Start Libation. What the account count changes:");
+Console.WriteLine("  1 account   Import > Scan Library, Import > Remove Library Books");
+Console.WriteLine("  2 or more   Import > Scan Library of All / Some Accounts, and the matching Remove items");
+Console.WriteLine("  any         an empty library offers 'Scan Library' rather than 'Add Account'");
+Console.WriteLine();
+Console.WriteLine("Do not scan or download: these accounts have meaningless tokens and Audible will refuse them.");
+return 0;
+
+/// <summary>
+/// The first account matches the one seed-demo-library.cs assigns its books to, so seeded books and a
+/// seeded account describe the same library rather than two unrelated ones.
+/// </summary>
+static IEnumerable<string> DemoAccountIds(int count)
+{
+	yield return $"{DemoAccountPrefix}{DemoAccountSuffix}";
+
+	for (var n = 2; n <= count; n++)
+		yield return $"{DemoAccountPrefix}{n}{DemoAccountSuffix}";
+}
+
+/// <summary>
+/// An account entry carrying a registered-looking identity. The values are fixture material, the same shape
+/// AudibleApi writes after a real registration, so the file parses and the account loads.
+/// </summary>
+static JObject BuildAccount(string accountId)
+{
+	var identity = new Identity(Localization.Get("us"));
+	identity.Update(
+		new PrivateKey(SamplePrivateKey),
+		new AdpToken(SampleAdpToken),
+		new AccessToken($"Atna|_DEMO_ACCESS_{accountId}", new DateTime(2200, 1, 1, 12, 0, 0, DateTimeKind.Utc)),
+		new RefreshToken($"Atnr|_DEMO_REFRESH_{accountId}"),
+		[new KeyValuePair<string, Dinah.Core.Security.SecretString>("session-id", "demo-cookie-value")],
+		deviceSerialNumber: "demo-device-serial",
+		deviceType: "demo-device-type",
+		amazonAccountId: "demo-amazon-account",
+		deviceName: "Demo Device",
+		storeAuthenticationCookie: "demo-store-auth-cookie");
+
+	// Write the tokens as plaintext rather than reaching for the OS secret store, which this script has no
+	// business touching. Libation reads either, whatever its own Token storage preference is set to.
+	IdentityTokenStorage.Configure(TokenStorageMethod.Plaintext, protector: null);
+
+	return new JObject
+	{
+		["AccountId"] = accountId,
+		["AccountName"] = $"Demo ({accountId})",
+		["LibraryScan"] = true,
+		["DecryptKey"] = "",
+		["IdentityTokens"] = JObject.Parse(JsonConvert.SerializeObject(identity, Identity.GetJsonSerializerSettings()))
+	};
+}
+
+int? IntArg(string name)
+{
+	var i = Array.FindIndex(args, a => a.Equals(name, StringComparison.OrdinalIgnoreCase));
+	return i >= 0 && i + 1 < args.Length && int.TryParse(args[i + 1], out var value) ? value : null;
+}
+
+/// <summary>Locate the Libation files folder the same way Libation itself does.</summary>
+static string? FindLibationFiles(string? explicitPath)
+{
+	var candidates = new List<string>();
+
+	if (explicitPath is not null)
+		candidates.Add(explicitPath);
+
+	foreach (var folder in KnownLibationFolders())
+	{
+		candidates.Add(folder);
+
+		// appsettings.json may redirect the files folder somewhere else entirely.
+		var appSettings = Path.Combine(folder, "appsettings.json");
+		if (!File.Exists(appSettings))
+			continue;
+
+		try
+		{
+			if (System.Text.Json.JsonDocument.Parse(File.ReadAllText(appSettings)).RootElement
+				.TryGetProperty("LibationFiles", out var redirect) && redirect.GetString() is string path)
+				candidates.Add(path);
+		}
+		catch (System.Text.Json.JsonException) { }
+	}
+
+	return candidates.FirstOrDefault(c => File.Exists(Path.Combine(c, "AccountsSettings.json")));
+}
+
+static IEnumerable<string> KnownLibationFolders()
+{
+	yield return Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "Libation");
+	yield return Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), "Libation");
+	yield return Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), "Libation");
+	yield return Path.Combine(Path.GetTempPath(), $"Libation-{Environment.UserName}");
+	yield return AppContext.BaseDirectory;
+}

--- a/Scripts/seed-demo-accounts.cs
+++ b/Scripts/seed-demo-accounts.cs
@@ -87,6 +87,20 @@ if (root["Accounts"] is not JArray accounts)
 	root["Accounts"] = accounts;
 }
 
+/// <summary>
+/// Whether this script wrote the account, decided from its id rather than a marker property.
+/// </summary>
+/// <remarks>
+/// A property would be tidier but does not survive: AudibleUtilities.Account serializes exactly five members
+/// and has no [JsonExtensionData], so Newtonsoft ignores an extra property on the way in and never writes it
+/// back out. Verified by adding one and renaming the account in the app - the save dropped it. Anything that
+/// dirties an account does the same, including a token refresh during a scan, and --clean would then leave
+/// demo accounts behind with no way to find them. Giving the shipping Account class a demo flag to serve a
+/// dev script is not a trade worth making.
+///
+/// The id is the right anchor instead: it is immutable, always persisted, and example.com is reserved by
+/// RFC 2606, so no real Audible login can collide with it.
+/// </remarks>
 static bool IsDemo(JToken account)
 	=> account["AccountId"]?.Value<string>() is string id
 	&& id.StartsWith(DemoAccountPrefix, StringComparison.OrdinalIgnoreCase)

--- a/Scripts/seed-demo-library.cs
+++ b/Scripts/seed-demo-library.cs
@@ -97,12 +97,13 @@ foreach (var book in books)
 	Execute(
 		"""
 		insert into LibraryBooks (BookId, AbsentFromLastScan, Account, DateAdded, IncludedUntil, IsAudiblePlus, IsDeleted)
-		values ($bookId, $isAbsent, 'demo@example.com', '2026-08-13 00:00:00', $includedUntil, $isPlus, 0)
+		values ($bookId, $isAbsent, 'demo@example.com', '2026-08-13 00:00:00', $includedUntil, $isPlus, $isDeleted)
 		""",
 		("$bookId", bookId),
 		("$isAbsent", book.IsAbsent ? 1 : 0),
 		("$includedUntil", book.IsPlus ? "2027-01-31 00:00:00" : (object)DBNull.Value),
-		("$isPlus", book.IsPlus ? 1 : 0));
+		("$isPlus", book.IsPlus ? 1 : 0),
+		("$isDeleted", book.IsDeleted ? 1 : 0));
 
 	Execute(
 		"insert into BookContributor (BookId, ContributorId, Role, [Order]) values ($bookId, $contributorId, 1, 0)",
@@ -148,8 +149,22 @@ if (partials.Count > 0)
 
 Console.WriteLine();
 Console.WriteLine("Start Libation and sort by Title. Expected Liberate column, top to bottom:");
-foreach (var book in books)
+foreach (var book in books.Where(b => !b.IsDeleted))
 	Console.WriteLine($"  {book.Title,-46} {book.Expectation}");
+
+var trashed = books.Where(b => b.IsDeleted).ToList();
+if (trashed.Count > 0)
+{
+	Console.WriteLine();
+	Console.WriteLine($"{trashed.Count} seeded book(s) are in the trash, so they are NOT in the grid:");
+	foreach (var book in trashed)
+		Console.WriteLine($"  {book.Title,-46} {book.Expectation}");
+	Console.WriteLine();
+	Console.WriteLine("  - the status bar should end with a clickable \"N in trash\"");
+	Console.WriteLine("  - Settings > Trash Bin should carry the same count");
+	Console.WriteLine("  - filtering for  Trashed  should find nothing and offer to open the trash bin");
+}
+
 Console.WriteLine();
 Console.WriteLine("Do not click the stoplights: these books are not real and cannot be downloaded.");
 return 0;
@@ -263,6 +278,42 @@ static List<DemoBook> BuildDemoBooks()
 			NeedsPartialDownload: false,
 			Expectation: expectation,
 			IsAbsent: true));
+
+	// Books in the trash. Removal is a soft delete, and a trashed book is filtered out of the grid, the
+	// search index and every status count at once, so nothing on screen distinguishes one from a book that
+	// was never imported. These rows are how that is checked: they must stay out of the grid while the
+	// status bar, the Settings > Trash Bin menu item and the empty-search hint all account for them.
+	foreach (var (label, bookStatus, isPlus, expectation) in new (string, int, bool, string)[]
+	{
+		("purchased", NotLiberated, false, "in the trash bin only, red lamp there"),
+		("PLUS", Liberated, true, "in the trash bin only, green lamp with badge there"),
+	})
+		books.Add(new DemoBook(
+			Asin: $"{AsinPrefix}{++n:000}",
+			Title: $"{n:00} Trashed | {label}",
+			ContentType: Product,
+			BookStatus: bookStatus,
+			PdfStatus: null,
+			IsPlus: isPlus,
+			NeedsPartialDownload: false,
+			Expectation: expectation,
+			IsDeleted: true));
+
+	// A trashed episode whose parent is still in the library. The trash bin asks for every parent, not just
+	// deleted ones, so this should appear nested under the series there while the series keeps its other
+	// episodes in the main grid.
+	books.Add(new DemoBook(
+		Asin: $"{AsinPrefix}{++n:000}",
+		Title: $"{n:00} Demo Series - episode 3 (trashed)",
+		ContentType: Episode,
+		BookStatus: NotLiberated,
+		PdfStatus: null,
+		IsPlus: false,
+		NeedsPartialDownload: false,
+		Expectation: "nested under Demo Series in the trash bin, absent from the grid",
+		SeriesAsin: seriesAsin,
+		SeriesOrder: "3",
+		IsDeleted: true));
 
 	// Titles that subtitle removal changes. <title short> stops at the first colon, so it cuts a colon in
 	// Audible's own title just as readily as it drops Audible's subtitle field, and the grid's Title column
@@ -396,4 +447,5 @@ record DemoBook(
 	string? SeriesAsin = null,
 	string? SeriesOrder = null,
 	bool IsAbsent = false,
-	string Subtitle = "");
+	string Subtitle = "",
+	bool IsDeleted = false);

--- a/Source/ApplicationServices/DbContexts.cs
+++ b/Source/ApplicationServices/DbContexts.cs
@@ -132,6 +132,16 @@ public static class DbContexts
 		return context.GetDeletedLibraryBooks();
 	}
 
+	/// <summary>
+	/// How many <see cref="LibraryBook"/> rows are in the trash. A row count only; no entities are loaded,
+	/// so this is cheap enough to refresh whenever the library changes.
+	/// </summary>
+	public static int GetTrashedBookCount()
+	{
+		using var context = GetContext();
+		return context.GetLibraryBookCountsByTrashFlag().InTrash;
+	}
+
 	public static LibraryBook? GetLibraryBook_Flat_NoTracking(string productId, bool caseSensative = true, string? account = null)
 	{
 		using var context = GetContext();

--- a/Source/ApplicationServices/LibraryCommands.cs
+++ b/Source/ApplicationServices/LibraryCommands.cs
@@ -442,13 +442,39 @@ public static class LibraryCommands
 	#endregion
 
 	#region remove/restore books
+
+	/// <summary>
+	/// Record every change to the trash. Removal is a soft delete, so a book can leave the library and sit
+	/// out of sight indefinitely; without this the log cannot say when that happened or how much is in there.
+	/// </summary>
+	private static void logTrashChange(string action, int qtyChanges)
+	{
+		if (qtyChanges < 1)
+			return;
+
+		try
+		{
+			Log.Logger.Information("Trash bin changed. {@DebugInfo}", new
+			{
+				Action = action,
+				Books = qtyChanges,
+				BooksInTrash = DbContexts.GetTrashedBookCount()
+			});
+		}
+		catch (Exception ex)
+		{
+			//The change itself already succeeded. Never fail it over a log line.
+			Log.Logger.Warning(ex, "Trash bin changed ({action}, {qtyChanges}) but the trash count could not be read", action, qtyChanges);
+		}
+	}
+
 	public static Task<int> RemoveBooksAsync(this IEnumerable<LibraryBook?>? idsToRemove) => Task.Run(() => removeBooks(idsToRemove));
 	private static int removeBooks(IEnumerable<LibraryBook?>? removeLibraryBooks)
 	{
 		if (removeLibraryBooks is null || !removeLibraryBooks.Any())
 			return 0;
 
-		return DoDbSizeChangeOperation(ctx =>
+		var qtyChanges = DoDbSizeChangeOperation(ctx =>
 		{
 			// Entry() NoTracking entities before SaveChanges()
 			foreach (var lb in removeLibraryBooks.OfType<LibraryBook>())
@@ -457,6 +483,9 @@ public static class LibraryCommands
 				ctx.Entry(lb).State = Microsoft.EntityFrameworkCore.EntityState.Modified;
 			}
 		});
+
+		logTrashChange("Moved to trash", qtyChanges);
+		return qtyChanges;
 	}
 
 	public static Task<int> RestoreBooksAsync(this IEnumerable<LibraryBook> idsToRemove) => Task.Run(() => restoreBooks(idsToRemove));
@@ -466,7 +495,7 @@ public static class LibraryCommands
 			return 0;
 		try
 		{
-			return DoDbSizeChangeOperation(ctx =>
+			var qtyChanges = DoDbSizeChangeOperation(ctx =>
 			{
 				// Entry() NoTracking entities before SaveChanges()
 				foreach (var lb in libraryBooks)
@@ -475,6 +504,9 @@ public static class LibraryCommands
 					ctx.Entry(lb).State = Microsoft.EntityFrameworkCore.EntityState.Modified;
 				}
 			});
+
+			logTrashChange("Restored from trash", qtyChanges);
+			return qtyChanges;
 		}
 		catch (Exception ex)
 		{
@@ -490,11 +522,14 @@ public static class LibraryCommands
 			return 0;
 		try
 		{
-			return DoDbSizeChangeOperation(ctx =>
+			var qtyChanges = DoDbSizeChangeOperation(ctx =>
 				{
 					ctx.LibraryBooks.RemoveRange(libraryBooks.OfType<LibraryBook>());
 					ctx.Books.RemoveRange(libraryBooks.OfType<LibraryBook>().Select(lb => lb.Book));
 				});
+
+			logTrashChange("Permanently deleted", qtyChanges);
+			return qtyChanges;
 		}
 		catch (Exception ex)
 		{

--- a/Source/ApplicationServices/LibraryCommands.cs
+++ b/Source/ApplicationServices/LibraryCommands.cs
@@ -62,13 +62,24 @@ public static class LibraryCommands
 			try
 			{
 				logTime($"pre {nameof(scanAccountsAsync)} all");
-				var libraryItems = await scanAccountsAsync(accounts, libraryOptions, allowInteractiveLogin: true);
+				var scan = await scanAccountsAsync(accounts, libraryOptions, allowInteractiveLogin: true);
 				logTime($"post {nameof(scanAccountsAsync)} all");
 
+				var libraryItems = scan.Items;
 				var totalCount = libraryItems.Count;
 				Log.Logger.Information($"GetAllLibraryItems: Total count {totalCount}");
 
-				return existingLibrary.Where(b => !libraryItems.Any(i => i.DtoItem.Asin == b.Book.AudibleProductId)).ToList();
+				var existing = existingLibrary?.ToList() ?? [];
+
+				EnsureScanCanIdentifyInactiveBooks(totalCount, existing.Count, scan.FailedAccounts);
+
+				var inactive = existing.Where(b => !libraryItems.Any(i => i.DtoItem.Asin == b.Book.AudibleProductId)).ToList();
+
+				Log.Logger.Information(
+					"Books absent from the library scan. {@DebugInfo}",
+					new { InactiveCount = inactive.Count, CandidateCount = existing.Count, ScannedCount = totalCount });
+
+				return inactive;
 			}
 			catch (AudibleApi.Authentication.LoginFailedException lfEx)
 			{
@@ -107,6 +118,22 @@ public static class LibraryCommands
 		}
 	}
 
+	/// <summary>
+	/// Refuse to call anything "no longer in your library" from a scan that could not see the whole library.
+	/// Importing tolerates a partial scan because it only adds and updates; removal cannot, because a book
+	/// missing from one bad scan is indistinguishable from a book the user no longer owns.
+	/// </summary>
+	/// <exception cref="LibraryScanIncompleteException">The scan cannot support that decision.</exception>
+	public static void EnsureScanCanIdentifyInactiveBooks(int scannedItemCount, int existingBookCount, IReadOnlyCollection<string>? failedAccounts)
+	{
+		if (failedAccounts?.Count > 0)
+			throw LibraryScanIncompleteException.ForFailedAccounts(failedAccounts);
+
+		// An account whose every book vanished at once is a broken scan, not an emptied library.
+		if (scannedItemCount == 0 && existingBookCount > 0)
+			throw LibraryScanIncompleteException.ForEmptyScan(existingBookCount);
+	}
+
 	#region FULL LIBRARY scan and import
 	public static Task<(int totalCount, int newCount)> ImportAccountAsync(params Account[]? accounts)
 		=> ImportAccountAsync(accounts, allowInteractiveLogin: true);
@@ -139,7 +166,8 @@ public static class LibraryCommands
 						| LibraryOptions.ResponseGroupOptions.IsFinished,
 					ImageSizes = LibraryOptions.ImageSizeOptions._500 | LibraryOptions.ImageSizeOptions._1215
 				};
-				var importItems = await scanAccountsAsync(accounts, libraryOptions, allowInteractiveLogin);
+				//Importing only adds and updates, so a partially scanned library is still worth importing.
+				var importItems = (await scanAccountsAsync(accounts, libraryOptions, allowInteractiveLogin)).Items;
 				logTime($"post {nameof(scanAccountsAsync)} all");
 
 				var totalCount = importItems.Count;
@@ -275,9 +303,18 @@ public static class LibraryCommands
 		return null;
 	}
 
-	private static async Task<List<ImportItem>> scanAccountsAsync(Account[] accounts, LibraryOptions libraryOptions, bool allowInteractiveLogin)
+	/// <summary>Outcome of scanning one or more accounts.</summary>
+	/// <param name="Items">Everything the accounts that did scan returned.</param>
+	/// <param name="FailedAccounts">
+	/// Accounts that could not be scanned. Their books are absent from <paramref name="Items"/> for that reason
+	/// alone, so a caller deciding what to remove must not treat the result as the whole library.
+	/// </param>
+	private sealed record ScanResult(List<ImportItem> Items, IReadOnlyCollection<string> FailedAccounts);
+
+	private static async Task<ScanResult> scanAccountsAsync(Account[] accounts, LibraryOptions libraryOptions, bool allowInteractiveLogin)
 	{
 		var tasks = new List<Task<List<ImportItem>>>();
+		var failedAccounts = new List<string>();
 
 		await using LogArchiver? archiver
 			 = Log.Logger.IsDebugEnabled()
@@ -304,13 +341,14 @@ public static class LibraryCommands
 			{
 				//Catch to allow other accounts to continue scanning.
 				Log.Logger.Error(ex, "Failed to scan account");
+				failedAccounts.Add(account.MaskedLogEntry ?? account.AccountId ?? "[unknown account]");
 			}
 		}
 
 		// import library in parallel
 		var arrayOfLists = await Task.WhenAll(tasks);
 		var importItems = arrayOfLists.SelectMany(a => a).ToList();
-		return importItems;
+		return new ScanResult(importItems, failedAccounts);
 	}
 
 	private static async Task<List<ImportItem>> scanAccountAsync(ApiExtended apiExtended, Account account, LibraryOptions libraryOptions, LogArchiver? archiver)

--- a/Source/ApplicationServices/LibraryScanIncompleteException.cs
+++ b/Source/ApplicationServices/LibraryScanIncompleteException.cs
@@ -1,0 +1,30 @@
+using Dinah.Core;
+using System;
+using System.Collections.Generic;
+
+namespace ApplicationServices;
+
+/// <summary>
+/// A library scan finished without throwing but cannot be trusted to say what is no longer in the account.
+/// Deciding "inactive" from such a scan would offer to remove books the user still owns.
+/// </summary>
+public class LibraryScanIncompleteException : Exception
+{
+	/// <summary>Accounts that could not be scanned, if that is why the scan is untrustworthy.</summary>
+	public IReadOnlyCollection<string> FailedAccounts { get; }
+
+	public LibraryScanIncompleteException(string message, IReadOnlyCollection<string>? failedAccounts = null)
+		: base(message)
+		=> FailedAccounts = failedAccounts ?? [];
+
+	internal static LibraryScanIncompleteException ForFailedAccounts(IReadOnlyCollection<string> failedAccounts)
+		=> new(
+			$"{"account".PluralizeWithCount(failedAccounts.Count)} could not be scanned, so Libation cannot tell which books are no longer in your library: "
+			+ string.Join(", ", failedAccounts),
+			failedAccounts);
+
+	internal static LibraryScanIncompleteException ForEmptyScan(int existingBookCount)
+		=> new(
+			$"The library scan returned no books while Libation still holds {"book".PluralizeWithCount(existingBookCount)}. "
+			+ "Treating that as an empty Audible library would offer to remove books you still own.");
+}

--- a/Source/ApplicationServices/TrashBinSearch.cs
+++ b/Source/ApplicationServices/TrashBinSearch.cs
@@ -1,0 +1,53 @@
+using DataLayer;
+using Serilog;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace ApplicationServices;
+
+/// <summary>
+/// Answers "is the book you searched for in the trash?".
+/// A trashed book is filtered out of the library and out of the search index, so searching for one returns
+/// nothing at all and looks exactly like a book that was never imported (issue #1925).
+/// </summary>
+public static class TrashBinSearch
+{
+	/// <summary>
+	/// Books in the trash matching <paramref name="searchString"/>, using the same query syntax as the
+	/// library search so a fielded query means the same thing in both places.
+	/// </summary>
+	/// <remarks>
+	/// Indexes the trash on the spot rather than keeping an index in step with it. Call only once a library
+	/// search has already come back empty: that happens on Enter, at human speed, so the work is rare.
+	/// Returns nothing rather than throwing; this only ever powers a hint.
+	/// </remarks>
+	public static List<LibraryBook> Search(string? searchString)
+	{
+		if (string.IsNullOrWhiteSpace(searchString))
+			return [];
+
+		try
+		{
+			//GetDeletedLibraryBooks also returns parents so the trash grid can nest episodes; only the
+			//genuinely deleted are candidates here.
+			var trashed = DbContexts.GetDeletedLibraryBooks().Where(lb => lb.IsDeleted).ToList();
+			if (trashed.Count == 0)
+				return [];
+
+			var searchEngine = new TempSearchEngine();
+			if (!searchEngine.ReindexSearchEngine(trashed))
+				return [];
+
+			if (searchEngine.GetSearchResultSet(searchString) is not { } results)
+				return [];
+
+			var matchedIds = results.Docs.Select(d => d.ProductId).ToHashSet();
+			return trashed.Where(lb => matchedIds.Contains(lb.Book.AudibleProductId)).ToList();
+		}
+		catch (System.Exception ex)
+		{
+			Log.Logger.Error(ex, "Failed to search the trash bin for {searchString}", searchString);
+			return [];
+		}
+	}
+}

--- a/Source/AudibleUtilities/Account.cs
+++ b/Source/AudibleUtilities/Account.cs
@@ -101,6 +101,8 @@ public class Account : IUpdatable, ILogMasked
 	/// </summary>
 	public override string ToString() => MaskedLogEntry;
 
+	/// <summary>Derived from the fields above, so persisting it would only add a stale copy of them.</summary>
+	[JsonIgnore]
 	public string MaskedLogEntry => @$"AccountId={mask(AccountId)}|AccountName={mask(AccountName)}|Locale={Locale?.Name ?? "[empty]"}";
 	private static string mask(string? str)
 		=> str is null ? "[null]"

--- a/Source/LibationAvalonia/ViewModels/MainVM.BackupCounts.cs
+++ b/Source/LibationAvalonia/ViewModels/MainVM.BackupCounts.cs
@@ -74,6 +74,9 @@ partial class MainVM
 
 			this.RaisePropertyChanged(nameof(BookBackupsToolStripText));
 			this.RaisePropertyChanged(nameof(PdfBackupsToolStripText));
+
+			//Whether the library is empty is only known once these counts have been taken.
+			RaiseGettingStartedChanged();
 		}
 	}
 

--- a/Source/LibationAvalonia/ViewModels/MainVM.BackupCounts.cs
+++ b/Source/LibationAvalonia/ViewModels/MainVM.BackupCounts.cs
@@ -28,6 +28,7 @@ partial class MainVM
 			this.RaisePropertyChanged(nameof(TrashBinMenuText));
 			this.RaisePropertyChanged(nameof(TrashBinStatusText));
 			this.RaisePropertyChanged(nameof(TrashBinStatusVisible));
+			RaiseGettingStartedChanged();
 		}
 	}
 

--- a/Source/LibationAvalonia/ViewModels/MainVM.BackupCounts.cs
+++ b/Source/LibationAvalonia/ViewModels/MainVM.BackupCounts.cs
@@ -2,6 +2,7 @@
 using Avalonia.Threading;
 using DataLayer;
 using LibationFileManager;
+using LibationUiBase;
 using ReactiveUI;
 using System.Collections.Generic;
 using System.Threading.Tasks;
@@ -16,6 +17,42 @@ partial class MainVM
 	public string BookBackupsToolStripText { get; private set; } = "Begin Book and PDF Backups: 0";
 	/// <summary> The "Begin PDF Only Backup" menu item header text </summary>
 	public string PdfBackupsToolStripText { get; private set; } = "Begin PDF Only Backups: 0";
+
+	/// <summary> How many books are in the trash, where nothing else on screen would reveal them </summary>
+	public int BooksInTrash
+	{
+		get => field;
+		private set
+		{
+			this.RaiseAndSetIfChanged(ref field, value);
+			this.RaisePropertyChanged(nameof(TrashBinMenuText));
+			this.RaisePropertyChanged(nameof(TrashBinStatusText));
+			this.RaisePropertyChanged(nameof(TrashBinStatusVisible));
+		}
+	}
+
+	public string TrashBinMenuText => TrashBinUi.MenuText(BooksInTrash);
+	public string TrashBinStatusText => TrashBinUi.StatusText(BooksInTrash);
+	public bool TrashBinStatusVisible => TrashBinUi.ShowStatus(BooksInTrash);
+	public string TrashBinStatusToolTip => TrashBinUi.StatusToolTip;
+
+	/// <summary>
+	/// Re-read the trash count. Kept off <see cref="LibraryCommands.GetCounts"/> on purpose: that also runs
+	/// against the visible subset on every filter change, where a database round trip would be wasted work.
+	/// </summary>
+	public async Task RefreshBooksInTrashAsync()
+	{
+		try
+		{
+			var count = await Task.Run(DbContexts.GetTrashedBookCount);
+			await Dispatcher.UIThread.InvokeAsync(() => BooksInTrash = count);
+		}
+		catch (System.Exception ex)
+		{
+			//A stale count must not take down the window that displays it.
+			Serilog.Log.Logger.Error(ex, "Failed to count books in the trash");
+		}
+	}
 
 	/// <summary> The user's library statistics </summary>
 	public LibraryCommands.LibraryStats? LibraryStats

--- a/Source/LibationAvalonia/ViewModels/MainVM.Filters.cs
+++ b/Source/LibationAvalonia/ViewModels/MainVM.Filters.cs
@@ -105,10 +105,11 @@ partial class MainVM
 	/// </summary>
 	private async Task RefreshNoMatchesStateAsync(string? searchString)
 	{
-		NoMatchesText = TrashBinUi.NoMatchesText(searchString);
+		NoMatchesText = GridEmptyStateUi.NoMatchesText(searchString);
 
-		//Only meaningful once the library itself has come up empty.
-		if (_visibleCount > 0 || string.IsNullOrWhiteSpace(searchString))
+		//Only meaningful once the grid has come up empty for a filter, and not when the library is empty:
+		//"no books match" is true but useless when there are no books at all.
+		if (_visibleCount > 0 || string.IsNullOrWhiteSpace(searchString) || GettingStartedVisible)
 		{
 			NoMatchesTrashHintVisible = false;
 			return;
@@ -116,7 +117,7 @@ partial class MainVM
 
 		var matches = await Task.Run(() => TrashBinSearch.Search(searchString));
 
-		NoMatchesTrashHintText = TrashBinUi.NoMatchesTrashHintText(matches.Count);
+		NoMatchesTrashHintText = GridEmptyStateUi.NoMatchesTrashHintText(matches.Count);
 		NoMatchesTrashHintVisible = matches.Count > 0;
 	}
 
@@ -127,6 +128,41 @@ partial class MainVM
 	public bool NoMatchesTrashHintVisible { get => field; private set => this.RaiseAndSetIfChanged(ref field, value); }
 	/// <summary> The grid is empty because of a filter, not because the library is empty </summary>
 	public bool NoMatchesVisible { get => field; private set => this.RaiseAndSetIfChanged(ref field, value); }
+
+	#region Getting started
+
+	/// <summary>
+	/// The grid is empty because there is nothing in the library at all. Held back until
+	/// <see cref="LibraryStats"/> has been counted at least once, which is what keeps "Add your Audible
+	/// account" off the screen during the moment between the window appearing and a full library loading.
+	/// Also held back mid-scan, where "no books yet" would be answering a question already being answered.
+	/// </summary>
+	public bool GettingStartedVisible => !ActivelyScanning && LibraryStats is { HasBookResults: false };
+
+	public string GettingStartedHeadline => GridEmptyStateUi.EmptyLibraryHeadline(AnyAccounts);
+	public string GettingStartedDetail => GridEmptyStateUi.EmptyLibraryDetail(AnyAccounts);
+
+	/// <summary>Adding an account comes first; telling someone without one to scan is a dead end.</summary>
+	public bool GettingStartedAddAccountVisible => !AnyAccounts;
+	public bool GettingStartedScanVisible => AnyAccounts;
+
+	internal void RaiseGettingStartedChanged()
+	{
+		this.RaisePropertyChanged(nameof(GettingStartedVisible));
+		this.RaisePropertyChanged(nameof(GettingStartedHeadline));
+		this.RaisePropertyChanged(nameof(GettingStartedDetail));
+		this.RaisePropertyChanged(nameof(GettingStartedAddAccountVisible));
+		this.RaisePropertyChanged(nameof(GettingStartedScanVisible));
+		updateNoMatchesVisible();
+	}
+
+	/// <summary>
+	/// Scan whatever accounts exist. The button only shows when there is at least one, and an empty library
+	/// is a case where every account is worth scanning, so this does not need the menu's one/many split.
+	/// </summary>
+	public async Task GettingStartedScanAsync() => await ScanAllAccountsAsync();
+
+	#endregion
 
 	private void updateFiltersMenu(object? _ = null, object? __ = null)
 	{

--- a/Source/LibationAvalonia/ViewModels/MainVM.Filters.cs
+++ b/Source/LibationAvalonia/ViewModels/MainVM.Filters.cs
@@ -20,7 +20,17 @@ partial class MainVM
 	private QuickFilters.NamedFilter? lastGoodFilter => new(lastGoodSearch, null);
 
 	/// <summary> Library filterting query </summary>
-	public QuickFilters.NamedFilter? SelectedNamedFilter { get => field; set => this.RaiseAndSetIfChanged(ref field, value); } = new(string.Empty, null);
+	public QuickFilters.NamedFilter? SelectedNamedFilter
+	{
+		get => field;
+		set
+		{
+			this.RaiseAndSetIfChanged(ref field, value);
+			//Which explanation the empty grid carries depends on whether a filter is applied.
+			this.RaisePropertyChanged(nameof(HasActiveFilter));
+			RaiseGettingStartedChanged();
+		}
+	} = new(string.Empty, null);
 	public AvaloniaList<Control> QuickFilterMenuItems { get; } = new();
 	/// <summary> Indicates if the first quick filter is the default filter </summary>
 	public bool FirstFilterIsDefault { get => field; set => QuickFilters.UseDefault = this.RaiseAndSetIfChanged(ref field, value); }
@@ -107,9 +117,9 @@ partial class MainVM
 	{
 		NoMatchesText = GridEmptyStateUi.NoMatchesText(searchString);
 
-		//Only meaningful once the grid has come up empty for a filter, and not when the library is empty:
-		//"no books match" is true but useless when there are no books at all.
-		if (_visibleCount > 0 || string.IsNullOrWhiteSpace(searchString) || GettingStartedVisible)
+		//Search the trash whenever a filter emptied the grid, including when the library itself is empty:
+		//someone who trashed everything and then searched for one of those books is exactly who needs telling.
+		if (_visibleCount > 0 || string.IsNullOrWhiteSpace(searchString))
 		{
 			NoMatchesTrashHintVisible = false;
 			return;
@@ -131,13 +141,20 @@ partial class MainVM
 
 	#region Getting started
 
+	/// <summary>A filter is applied, so an empty grid is the filter's doing rather than the library's.</summary>
+	public bool HasActiveFilter => !string.IsNullOrWhiteSpace(SelectedNamedFilter?.Filter);
+
 	/// <summary>
 	/// The grid is empty because there is nothing in the library at all. Held back until
 	/// <see cref="LibraryStats"/> has been counted at least once, which is what keeps "Add your Audible
 	/// account" off the screen during the moment between the window appearing and a full library loading.
-	/// Also held back mid-scan, where "no books yet" would be answering a question already being answered.
+	/// Also held back mid-scan, where "no books yet" would be answering a question already being answered,
+	/// and while a filter is applied, because someone searching is not someone getting started.
 	/// </summary>
-	public bool GettingStartedVisible => !ActivelyScanning && LibraryStats is { HasBookResults: false };
+	public bool GettingStartedVisible
+		=> !ActivelyScanning
+		&& !HasActiveFilter
+		&& LibraryStats is { HasBookResults: false };
 
 	public string GettingStartedHeadline => GridEmptyStateUi.EmptyLibraryHeadline(AnyAccounts);
 	public string GettingStartedDetail => GridEmptyStateUi.EmptyLibraryDetail(AnyAccounts);
@@ -146,6 +163,13 @@ partial class MainVM
 	public bool GettingStartedAddAccountVisible => !AnyAccounts;
 	public bool GettingStartedScanVisible => AnyAccounts;
 
+	/// <summary>
+	/// An empty library whose books are all in the trash. "Libation is empty" would be wrong on its own:
+	/// the books are not gone, they are one click away.
+	/// </summary>
+	public bool GettingStartedTrashVisible => BooksInTrash > 0;
+	public string GettingStartedTrashText => GridEmptyStateUi.EmptyLibraryTrashHintText(BooksInTrash);
+
 	internal void RaiseGettingStartedChanged()
 	{
 		this.RaisePropertyChanged(nameof(GettingStartedVisible));
@@ -153,6 +177,8 @@ partial class MainVM
 		this.RaisePropertyChanged(nameof(GettingStartedDetail));
 		this.RaisePropertyChanged(nameof(GettingStartedAddAccountVisible));
 		this.RaisePropertyChanged(nameof(GettingStartedScanVisible));
+		this.RaisePropertyChanged(nameof(GettingStartedTrashVisible));
+		this.RaisePropertyChanged(nameof(GettingStartedTrashText));
 		updateNoMatchesVisible();
 	}
 

--- a/Source/LibationAvalonia/ViewModels/MainVM.Filters.cs
+++ b/Source/LibationAvalonia/ViewModels/MainVM.Filters.cs
@@ -1,3 +1,4 @@
+using ApplicationServices;
 using Avalonia;
 using Avalonia.Collections;
 using Avalonia.Controls;
@@ -88,6 +89,7 @@ partial class MainVM
 		{
 			await ProductsDisplay.Filter(namedFilter?.Filter);
 			lastGoodSearch = namedFilter?.Filter ?? "";
+			await RefreshNoMatchesStateAsync(namedFilter?.Filter);
 			return null;
 		}
 		catch (Exception ex)
@@ -95,6 +97,36 @@ partial class MainVM
 			return ex;
 		}
 	}
+
+	/// <summary>
+	/// A trashed book is filtered out of the library and out of the search index, so searching for one looks
+	/// exactly like searching for a book that was never imported. When a filter matches nothing, say whether
+	/// the thing being looked for is sitting in the trash.
+	/// </summary>
+	private async Task RefreshNoMatchesStateAsync(string? searchString)
+	{
+		NoMatchesText = TrashBinUi.NoMatchesText(searchString);
+
+		//Only meaningful once the library itself has come up empty.
+		if (_visibleCount > 0 || string.IsNullOrWhiteSpace(searchString))
+		{
+			NoMatchesTrashHintVisible = false;
+			return;
+		}
+
+		var matches = await Task.Run(() => TrashBinSearch.Search(searchString));
+
+		NoMatchesTrashHintText = TrashBinUi.NoMatchesTrashHintText(matches.Count);
+		NoMatchesTrashHintVisible = matches.Count > 0;
+	}
+
+	/// <summary> Shown over the grid when a filter matches nothing </summary>
+	public string NoMatchesText { get => field; private set => this.RaiseAndSetIfChanged(ref field, value); } = "";
+	/// <summary> Follow-up naming matches that are in the trash </summary>
+	public string NoMatchesTrashHintText { get => field; private set => this.RaiseAndSetIfChanged(ref field, value); } = "";
+	public bool NoMatchesTrashHintVisible { get => field; private set => this.RaiseAndSetIfChanged(ref field, value); }
+	/// <summary> The grid is empty because of a filter, not because the library is empty </summary>
+	public bool NoMatchesVisible { get => field; private set => this.RaiseAndSetIfChanged(ref field, value); }
 
 	private void updateFiltersMenu(object? _ = null, object? __ = null)
 	{

--- a/Source/LibationAvalonia/ViewModels/MainVM.Import.cs
+++ b/Source/LibationAvalonia/ViewModels/MainVM.Import.cs
@@ -56,6 +56,7 @@ public partial class MainVM
 			this.RaisePropertyChanged(nameof(AnyAccounts));
 			this.RaisePropertyChanged(nameof(OneAccount));
 			this.RaisePropertyChanged(nameof(MultipleAccounts));
+			RaiseGettingStartedChanged();
 		}
 	}
 
@@ -191,6 +192,7 @@ public partial class MainVM
 		this.RaisePropertyChanged(nameof(ActivelyScanning));
 		this.RaisePropertyChanged(nameof(RemoveMenuItemsEnabled));
 		this.RaisePropertyChanged(nameof(ScanningText));
+		RaiseGettingStartedChanged();
 	}
 
 	private async Task scanLibrariesRemovedBooks(params Account[] accounts)

--- a/Source/LibationAvalonia/ViewModels/MainVM.Settings.cs
+++ b/Source/LibationAvalonia/ViewModels/MainVM.Settings.cs
@@ -26,7 +26,12 @@ partial class MainVM
 	public Task ShowAboutAsync() => new LibationAvalonia.Dialogs.AboutDialog().ShowDialog(MainWindow);
 	public Task ShowAccountsAsync() => new LibationAvalonia.Dialogs.AccountsDialog().ShowDialog(MainWindow);
 	public Task ShowSettingsAsync() => new LibationAvalonia.Dialogs.SettingsDialog().ShowDialog(MainWindow);
-	public Task ShowTrashBinAsync() => new LibationAvalonia.Dialogs.TrashBinDialog().ShowDialog(MainWindow);
+	public async Task ShowTrashBinAsync()
+	{
+		await new LibationAvalonia.Dialogs.TrashBinDialog().ShowDialog(MainWindow);
+		//Restoring or permanently deleting inside the dialog changes the count behind it.
+		await RefreshBooksInTrashAsync();
+	}
 	public Task ShowFindBetterQualityBooksAsync() => new LibationAvalonia.Dialogs.FindBetterQualityBooksDialog().ShowDialog(MainWindow);
 
 	private async Task LaunchHangoverAsync()

--- a/Source/LibationAvalonia/ViewModels/MainVM.VisibleBooks.cs
+++ b/Source/LibationAvalonia/ViewModels/MainVM.VisibleBooks.cs
@@ -41,14 +41,11 @@ partial class MainVM
 	}
 
 	/// <summary>
-	/// An empty grid only needs explaining when a filter emptied it. An empty library speaks for itself
-	/// through the getting-started panel, which takes precedence.
+	/// An empty grid only needs explaining when a filter emptied it. Mutually exclusive with the
+	/// getting-started panel, which stands down while a filter is applied.
 	/// </summary>
 	private void updateNoMatchesVisible()
-		=> NoMatchesVisible
-			= _visibleCount == 0
-			&& !string.IsNullOrWhiteSpace(SelectedNamedFilter?.Filter)
-			&& !GettingStartedVisible;
+		=> NoMatchesVisible = _visibleCount == 0 && HasActiveFilter;
 
 	private void setVisibleNotLiberatedCount(int visibleNotLiberated)
 	{

--- a/Source/LibationAvalonia/ViewModels/MainVM.VisibleBooks.cs
+++ b/Source/LibationAvalonia/ViewModels/MainVM.VisibleBooks.cs
@@ -41,11 +41,14 @@ partial class MainVM
 	}
 
 	/// <summary>
-	/// An empty grid only needs explaining when a filter emptied it. With no filter the status bar already
-	/// says the library itself is empty.
+	/// An empty grid only needs explaining when a filter emptied it. An empty library speaks for itself
+	/// through the getting-started panel, which takes precedence.
 	/// </summary>
 	private void updateNoMatchesVisible()
-		=> NoMatchesVisible = _visibleCount == 0 && !string.IsNullOrWhiteSpace(SelectedNamedFilter?.Filter);
+		=> NoMatchesVisible
+			= _visibleCount == 0
+			&& !string.IsNullOrWhiteSpace(SelectedNamedFilter?.Filter)
+			&& !GettingStartedVisible;
 
 	private void setVisibleNotLiberatedCount(int visibleNotLiberated)
 	{

--- a/Source/LibationAvalonia/ViewModels/MainVM.VisibleBooks.cs
+++ b/Source/LibationAvalonia/ViewModels/MainVM.VisibleBooks.cs
@@ -37,7 +37,15 @@ partial class MainVM
 		_visibleCount = visibleCount;
 		this.RaisePropertyChanged(nameof(VisibleCountText));
 		this.RaisePropertyChanged(nameof(VisibleCountMenuItemText));
+		updateNoMatchesVisible();
 	}
+
+	/// <summary>
+	/// An empty grid only needs explaining when a filter emptied it. With no filter the status bar already
+	/// says the library itself is empty.
+	/// </summary>
+	private void updateNoMatchesVisible()
+		=> NoMatchesVisible = _visibleCount == 0 && !string.IsNullOrWhiteSpace(SelectedNamedFilter?.Filter);
 
 	private void setVisibleNotLiberatedCount(int visibleNotLiberated)
 	{

--- a/Source/LibationAvalonia/ViewModels/MainVM.cs
+++ b/Source/LibationAvalonia/ViewModels/MainVM.cs
@@ -52,6 +52,7 @@ public partial class MainVM : ViewModelBase
 
 			await Task.WhenAll(
 				SetBackupCountsAsync(fullLibrary),
+				RefreshBooksInTrashAsync(),
 				Task.Run(() => ProductsDisplay.UpdateGridAsync(fullLibrary)));
 		}
 		catch (System.Exception ex)

--- a/Source/LibationAvalonia/Views/MainWindow.axaml
+++ b/Source/LibationAvalonia/Views/MainWindow.axaml
@@ -64,7 +64,7 @@
 					<NativeMenuItem Command="{Binding ShowAccountsAsync}" Header="Accounts..." Gesture="{OnPlatform macOS='⌘+.'}" />
 					<NativeMenuItem Command="{Binding ShowSettingsAsync}" Header="Settings..." Gesture="{OnPlatform macOS='⌘+,'}" />
 					<NativeMenuItemSeparator />
-					<NativeMenuItem Command="{Binding ShowTrashBinAsync}" Header="Trash Bin" Gesture="{OnPlatform macOS='alt+⌘+T'}" />
+					<NativeMenuItem Command="{Binding ShowTrashBinAsync}" Header="{Binding TrashBinMenuText}" Gesture="{OnPlatform macOS='alt+⌘+T'}" />
 					<NativeMenuItem Command="{Binding LaunchHangover}" Header="Launch Hangover" />
 					<NativeMenuItemSeparator />
 					<NativeMenuItem Command="{Binding StartWalkthroughAsync}" Header="Take a Guided Tour of Libation" />
@@ -151,7 +151,7 @@
 					<MenuItem Name="accountsToolStripMenuItem" Command="{Binding ShowAccountsAsync}" Header="_Accounts..." InputGesture="ctrl+shift+A"/>
 					<MenuItem Name="basicSettingsToolStripMenuItem" Command="{Binding ShowSettingsAsync}" Header="_Settings..." InputGesture="ctrl+P" />
 					<Separator />
-					<MenuItem Command="{Binding ShowTrashBinAsync}" Header="Trash Bin" />
+					<MenuItem Command="{Binding ShowTrashBinAsync}" Header="{Binding TrashBinMenuText}" />
 					<MenuItem Command="{Binding LaunchHangover}" Header="Launch _Hangover" />
 					<Separator />
 					<MenuItem Command="{Binding ShowFindBetterQualityBooksAsync}" Header="Scan for Better Quality Audiobooks"  ToolTip.Tip="{Binding FindBetterQualityBooksTip}"/>
@@ -252,7 +252,7 @@
 		</Border>
 			
 		<!-- Bottom Status Strip -->
-		<Grid Grid.Row="3" Margin="8" VerticalAlignment="Bottom" ColumnDefinitions="Auto,Auto,*,Auto">
+		<Grid Grid.Row="3" Margin="8" VerticalAlignment="Bottom" ColumnDefinitions="Auto,Auto,*,Auto,Auto">
 			<Grid.Styles>
 				<Style Selector="ProgressBar:horizontal">
 					<Setter Property="MinWidth" Value="100" />
@@ -261,7 +261,12 @@
 			<TextBlock FontSize="14" Grid.Column="0" Text="Upgrading:" VerticalAlignment="Center" IsVisible="{Binding DownloadProgress, Converter={x:Static ObjectConverters.IsNotNull}}" />
 			<ProgressBar Grid.Column="1" Margin="5,0,10,0" VerticalAlignment="Stretch" Width="100" Value="{Binding DownloadProgress, TargetNullValue=0}" IsVisible="{Binding DownloadProgress, Converter={x:Static ObjectConverters.IsNotNull}}"/>
 			<TextBlock FontSize="14" Grid.Column="2" Text="{Binding VisibleCountText}" VerticalAlignment="Center" />
-			<TextBlock FontSize="14" Grid.Column="3" Text="{Binding LibraryStats?.StatusString}" VerticalAlignment="Center" />		
+			<Button FontSize="14" Grid.Column="3" Margin="0,0,16,0" Padding="8,2" VerticalAlignment="Center"
+					Command="{Binding ShowTrashBinAsync}"
+					Content="{Binding TrashBinStatusText}"
+					ToolTip.Tip="{Binding TrashBinStatusToolTip}"
+					IsVisible="{Binding TrashBinStatusVisible}" />
+			<TextBlock FontSize="14" Grid.Column="4" Text="{Binding LibraryStats?.StatusString}" VerticalAlignment="Center" />		
 		</Grid>
 	</Grid>
 </Window>

--- a/Source/LibationAvalonia/Views/MainWindow.axaml
+++ b/Source/LibationAvalonia/Views/MainWindow.axaml
@@ -279,6 +279,43 @@
 								Content="Open Trash Bin" />
 						</StackPanel>
 					</StackPanel>
+
+					<!-- Nothing in the library at all. An empty library has two causes with different next
+					     steps, so this offers the one that applies rather than the same advice to everybody. -->
+					<StackPanel
+						IsVisible="{Binding GettingStartedVisible}"
+						HorizontalAlignment="Center"
+						VerticalAlignment="Center"
+						Spacing="10">
+						<TextBlock
+							FontSize="18"
+							HorizontalAlignment="Center"
+							Text="{Binding GettingStartedHeadline}" />
+						<TextBlock
+							FontSize="14"
+							HorizontalAlignment="Center"
+							Foreground="{DynamicResource SystemBaseMediumColor}"
+							Text="{Binding GettingStartedDetail}" />
+						<StackPanel
+							Orientation="Horizontal"
+							HorizontalAlignment="Center"
+							Spacing="10">
+							<Button
+								Padding="14,5"
+								IsVisible="{Binding GettingStartedAddAccountVisible}"
+								Command="{Binding AddAccountsAsync}"
+								Content="Add Account" />
+							<Button
+								Padding="14,5"
+								IsVisible="{Binding GettingStartedScanVisible}"
+								Command="{Binding GettingStartedScanAsync}"
+								Content="Scan Library" />
+							<Button
+								Padding="14,5"
+								Command="{Binding StartWalkthroughAsync}"
+								Content="Take a Guided Tour" />
+						</StackPanel>
+					</StackPanel>
 				</Panel>
 			</SplitView>
 		</Border>

--- a/Source/LibationAvalonia/Views/MainWindow.axaml
+++ b/Source/LibationAvalonia/Views/MainWindow.axaml
@@ -241,13 +241,45 @@
 				</SplitView.Pane>
 
 				<!-- Product Display Grid -->
-				<views:ProductsDisplay
-					Name="productsDisplay"
-					DataContext="{Binding ProductsDisplay, Mode=OneTime}"						
-					LiberateClicked="ProductsDisplay_LiberateClicked"
-					TagsButtonClicked="ProductsDisplay_TagsButtonClicked"
-					LiberateSeriesClicked="ProductsDisplay_LiberateSeriesClicked"
-					ConvertToMp3Clicked="ProductsDisplay_ConvertToMp3Clicked" />				
+				<Panel>
+					<views:ProductsDisplay
+						Name="productsDisplay"
+						DataContext="{Binding ProductsDisplay, Mode=OneTime}"						
+						LiberateClicked="ProductsDisplay_LiberateClicked"
+						TagsButtonClicked="ProductsDisplay_TagsButtonClicked"
+						LiberateSeriesClicked="ProductsDisplay_LiberateSeriesClicked"
+						ConvertToMp3Clicked="ProductsDisplay_ConvertToMp3Clicked" />
+
+					<!-- A filter that matched nothing. A trashed book is filtered out of the library and out of
+					     the search index, so searching for one looks the same as searching for a book that was
+					     never imported. Say so here rather than leaving the grid silently blank. -->
+					<StackPanel
+						IsVisible="{Binding NoMatchesVisible}"
+						HorizontalAlignment="Center"
+						VerticalAlignment="Center"
+						Spacing="10">
+						<TextBlock
+							FontSize="16"
+							HorizontalAlignment="Center"
+							Foreground="{DynamicResource SystemBaseMediumColor}"
+							Text="{Binding NoMatchesText}" />
+						<StackPanel
+							IsVisible="{Binding NoMatchesTrashHintVisible}"
+							Orientation="Horizontal"
+							HorizontalAlignment="Center"
+							Spacing="10">
+							<TextBlock
+								FontSize="16"
+								VerticalAlignment="Center"
+								Text="{Binding NoMatchesTrashHintText}" />
+							<Button
+								Padding="10,4"
+								VerticalAlignment="Center"
+								Command="{Binding ShowTrashBinAsync}"
+								Content="Open Trash Bin" />
+						</StackPanel>
+					</StackPanel>
+				</Panel>
 			</SplitView>
 		</Border>
 			

--- a/Source/LibationAvalonia/Views/MainWindow.axaml
+++ b/Source/LibationAvalonia/Views/MainWindow.axaml
@@ -315,6 +315,24 @@
 								Command="{Binding StartWalkthroughAsync}"
 								Content="Take a Guided Tour" />
 						</StackPanel>
+
+						<!-- The books are not gone, they are in the trash. Saying so keeps the headline above
+						     from reading as though they were never there. -->
+						<StackPanel
+							IsVisible="{Binding GettingStartedTrashVisible}"
+							Orientation="Horizontal"
+							HorizontalAlignment="Center"
+							Spacing="10">
+							<TextBlock
+								FontSize="14"
+								VerticalAlignment="Center"
+								Text="{Binding GettingStartedTrashText}" />
+							<Button
+								Padding="10,4"
+								VerticalAlignment="Center"
+								Command="{Binding ShowTrashBinAsync}"
+								Content="Open Trash Bin" />
+						</StackPanel>
 					</StackPanel>
 				</Panel>
 			</SplitView>

--- a/Source/LibationAvalonia/Views/MainWindow.axaml.cs
+++ b/Source/LibationAvalonia/Views/MainWindow.axaml.cs
@@ -215,6 +215,7 @@ public partial class MainWindow : ReactiveWindow<MainVM>
 
 		vm.BindToGridTask = Task.WhenAll(
 			vm.SetBackupCountsAsync(initialLibrary),
+			vm.RefreshBooksInTrashAsync(),
 			Task.Run(() => vm.ProductsDisplay.BindToGridAsync(initialLibrary)));
 
 		await vm.BindToGridTask;

--- a/Source/LibationUiBase/GridEmptyStateUi.cs
+++ b/Source/LibationUiBase/GridEmptyStateUi.cs
@@ -1,0 +1,56 @@
+namespace LibationUiBase;
+
+/// <summary>
+/// What to show in the middle of the grid when it has no rows to draw. Shared so both frontends word it
+/// identically, and kept in one place so a third empty state does not become a third scattered set of strings.
+/// </summary>
+public static class GridEmptyStateUi
+{
+	#region A filter matched nothing
+
+	/// <summary>Headline for a filter that matched nothing in the library.</summary>
+	public static string NoMatchesText(string? searchString)
+		=> string.IsNullOrWhiteSpace(searchString)
+			? "No books match the current filter."
+			: $"No books match \"{searchString.Trim()}\".";
+
+	/// <summary>
+	/// Follow-up naming matches hiding in the trash. Only worth saying when the filter matched something in
+	/// there; "nothing here, and by the way the trash has things in it" would just be noise.
+	/// </summary>
+	public static string NoMatchesTrashHintText(int matchesInTrash)
+		=> matchesInTrash == 1
+			? "1 matching book is in the trash."
+			: $"{matchesInTrash} matching books are in the trash.";
+
+	public const string OpenTrashBinButton = "Open Trash Bin";
+
+	#endregion
+
+	#region The library itself is empty
+
+	/// <summary>
+	/// An empty library has two causes with different next steps, and telling someone with no account to scan
+	/// their library is a dead end. <paramref name="anyAccounts"/> is what tells them apart.
+	/// </summary>
+	public static string EmptyLibraryHeadline(bool anyAccounts)
+		=> anyAccounts
+			? "No books in your library yet."
+			: "Libation is empty.";
+
+	public static string EmptyLibraryDetail(bool anyAccounts)
+		=> anyAccounts
+			? "Scan your Audible account to bring your books in."
+			: "Add your Audible account, then scan your library to bring your books in.";
+
+	public const string AddAccountButton = "Add Account";
+	public const string ScanLibraryButton = "Scan Library";
+
+	/// <summary>
+	/// The walkthrough is offered once, on first launch, and never again once that is declined. A permanent
+	/// way back in costs one button and is the only one a new user is likely to find.
+	/// </summary>
+	public const string TakeTheTourButton = "Take a Guided Tour";
+
+	#endregion
+}

--- a/Source/LibationUiBase/GridEmptyStateUi.cs
+++ b/Source/LibationUiBase/GridEmptyStateUi.cs
@@ -43,6 +43,15 @@ public static class GridEmptyStateUi
 			? "Scan your Audible account to bring your books in."
 			: "Add your Audible account, then scan your library to bring your books in.";
 
+	/// <summary>
+	/// Books in the trash while the library itself is empty. Without this the headline above reads as though
+	/// the books were never there, when in fact they are one click away.
+	/// </summary>
+	public static string EmptyLibraryTrashHintText(int booksInTrash)
+		=> booksInTrash == 1
+			? "1 book is in the trash."
+			: $"{booksInTrash} books are in the trash.";
+
 	public const string AddAccountButton = "Add Account";
 	public const string ScanLibraryButton = "Scan Library";
 

--- a/Source/LibationUiBase/TrashBinUi.cs
+++ b/Source/LibationUiBase/TrashBinUi.cs
@@ -1,0 +1,24 @@
+using Dinah.Core;
+
+namespace LibationUiBase;
+
+/// <summary>
+/// Wording for the trash bin affordances, shared so both frontends say the same thing.
+/// Removal is a soft delete, so a book can sit in the trash indefinitely with nothing on screen
+/// suggesting it exists. These make a non-empty trash visible without nagging about an empty one.
+/// </summary>
+public static class TrashBinUi
+{
+	/// <summary>Menu item text, carrying the count only when there is something in the trash.</summary>
+	public static string MenuText(int booksInTrash)
+		=> booksInTrash > 0 ? $"Trash Bin ({booksInTrash})" : "Trash Bin";
+
+	/// <summary>Status bar text. Only meaningful when <see cref="ShowStatus"/> is true.</summary>
+	public static string StatusText(int booksInTrash)
+		=> $"{"book".PluralizeWithCount(booksInTrash)} in trash";
+
+	/// <summary>An empty trash is the normal case and says nothing useful, so it stays off screen.</summary>
+	public static bool ShowStatus(int booksInTrash) => booksInTrash > 0;
+
+	public const string StatusToolTip = "These books are hidden from your library. Open the trash bin to restore them.";
+}

--- a/Source/LibationUiBase/TrashBinUi.cs
+++ b/Source/LibationUiBase/TrashBinUi.cs
@@ -21,19 +21,4 @@ public static class TrashBinUi
 	public static bool ShowStatus(int booksInTrash) => booksInTrash > 0;
 
 	public const string StatusToolTip = "These books are hidden from your library. Open the trash bin to restore them.";
-
-	/// <summary>Headline for a filter that matched nothing in the library.</summary>
-	public static string NoMatchesText(string? searchString)
-		=> string.IsNullOrWhiteSpace(searchString)
-			? "No books match the current filter."
-			: $"No books match \"{searchString.Trim()}\".";
-
-	/// <summary>
-	/// Follow-up naming matches hiding in the trash. Only worth saying when the filter matched something in
-	/// there; "nothing here, and by the way the trash has things in it" would just be noise.
-	/// </summary>
-	public static string NoMatchesTrashHintText(int matchesInTrash)
-		=> matchesInTrash == 1
-			? "1 matching book is in the trash."
-			: $"{matchesInTrash} matching books are in the trash.";
 }

--- a/Source/LibationUiBase/TrashBinUi.cs
+++ b/Source/LibationUiBase/TrashBinUi.cs
@@ -21,4 +21,19 @@ public static class TrashBinUi
 	public static bool ShowStatus(int booksInTrash) => booksInTrash > 0;
 
 	public const string StatusToolTip = "These books are hidden from your library. Open the trash bin to restore them.";
+
+	/// <summary>Headline for a filter that matched nothing in the library.</summary>
+	public static string NoMatchesText(string? searchString)
+		=> string.IsNullOrWhiteSpace(searchString)
+			? "No books match the current filter."
+			: $"No books match \"{searchString.Trim()}\".";
+
+	/// <summary>
+	/// Follow-up naming matches hiding in the trash. Only worth saying when the filter matched something in
+	/// there; "nothing here, and by the way the trash has things in it" would just be noise.
+	/// </summary>
+	public static string NoMatchesTrashHintText(int matchesInTrash)
+		=> matchesInTrash == 1
+			? "1 matching book is in the trash."
+			: $"{matchesInTrash} matching books are in the trash.";
 }

--- a/Source/LibationWinForms/Form1.BackupCounts.cs
+++ b/Source/LibationWinForms/Form1.BackupCounts.cs
@@ -16,9 +16,15 @@ public partial class Form1
 		beginPdfBackupsToolStripMenuItem.Format(0);
 
 		LibraryCommands.LibrarySizeChanged += setBackupCounts;
+		LibraryCommands.LibrarySizeChanged += (_, _) => refreshBooksInTrash();
 		//Pass null to the runner to get the whole library.
 		LibraryCommands.BookUserDefinedItemCommitted += (_, _)
 			=> setBackupCounts(null, null);
+
+		trashBinLbl.Text = "";
+		trashBinLbl.Visible = false;
+		trashBinLbl.ToolTipText = LibationUiBase.TrashBinUi.StatusToolTip;
+		refreshBooksInTrash();
 
 		updateCountsBw.DoWork += UpdateCountsBw_DoWork;
 		// Register the error logger first so a failed count is logged exactly once, before the
@@ -28,6 +34,33 @@ public partial class Form1
 		updateCountsBw.RunWorkerCompleted += updateBottomStats;
 		updateCountsBw.RunWorkerCompleted += update_BeginBookBackups_menuItem;
 		updateCountsBw.RunWorkerCompleted += udpate_BeginPdfOnlyBackups_menuItem;
+	}
+
+	/// <summary>
+	/// Re-read the trash count and show it only when there is something in there. Kept off
+	/// <see cref="LibraryCommands.GetCounts"/> on purpose: that also runs against the visible subset on
+	/// every filter change, where a database round trip would be wasted work.
+	/// </summary>
+	private async void refreshBooksInTrash()
+	{
+		int booksInTrash;
+		try
+		{
+			booksInTrash = await System.Threading.Tasks.Task.Run(DbContexts.GetTrashedBookCount);
+		}
+		catch (System.Exception ex)
+		{
+			//A stale count must not take down the window that displays it.
+			Serilog.Log.Logger.Error(ex, "Failed to count books in the trash");
+			return;
+		}
+
+		statusStrip1.UIThreadAsync(() =>
+		{
+			trashBinLbl.Text = LibationUiBase.TrashBinUi.StatusText(booksInTrash);
+			trashBinLbl.Visible = LibationUiBase.TrashBinUi.ShowStatus(booksInTrash);
+			openTrashBinToolStripMenuItem.Text = LibationUiBase.TrashBinUi.MenuText(booksInTrash);
+		});
 	}
 
 	/// <summary>

--- a/Source/LibationWinForms/Form1.BackupCounts.cs
+++ b/Source/LibationWinForms/Form1.BackupCounts.cs
@@ -60,6 +60,7 @@ public partial class Form1
 			trashBinLbl.Text = LibationUiBase.TrashBinUi.StatusText(booksInTrash);
 			trashBinLbl.Visible = LibationUiBase.TrashBinUi.ShowStatus(booksInTrash);
 			openTrashBinToolStripMenuItem.Text = LibationUiBase.TrashBinUi.MenuText(booksInTrash);
+			setBooksInTrash(booksInTrash);
 		});
 	}
 

--- a/Source/LibationWinForms/Form1.BackupCounts.cs
+++ b/Source/LibationWinForms/Form1.BackupCounts.cs
@@ -107,6 +107,11 @@ public partial class Form1
 	{
 		var libraryStats = getLibraryStats(e);
 		statusStrip1.UIThreadAsync(() => backupsCountsLbl.Text = libraryStats?.StatusString ?? "ERROR GETTING STATUS");
+
+		//Whether the library is empty is only known once these counts have been taken, which is also what
+		//keeps the getting-started panel off screen while a full library is still loading.
+		if (libraryStats is not null)
+			this.UIThreadAsync(() => setLibraryIsEmpty(!libraryStats.HasBookResults));
 	}
 
 	// update 'begin book and pdf backups' menu item

--- a/Source/LibationWinForms/Form1.Designer.cs
+++ b/Source/LibationWinForms/Form1.Designer.cs
@@ -85,6 +85,9 @@
             this.splitContainer1 = new System.Windows.Forms.SplitContainer();
             this.panel1 = new System.Windows.Forms.Panel();
             this.productsDisplay = new LibationWinForms.GridView.ProductsDisplay();
+            this.noMatchesPanel = new System.Windows.Forms.Panel();
+            this.noMatchesLbl = new System.Windows.Forms.Label();
+            this.noMatchesTrashLink = new System.Windows.Forms.LinkLabel();
             this.toggleQueueHideBtn = new System.Windows.Forms.Button();
             this.doneRemovingBtn = new System.Windows.Forms.Button();
             this.removeBooksBtn = new System.Windows.Forms.Button();
@@ -96,6 +99,7 @@
             this.splitContainer1.Panel2.SuspendLayout();
             this.splitContainer1.SuspendLayout();
             this.panel1.SuspendLayout();
+            this.noMatchesPanel.SuspendLayout();
             this.SuspendLayout();
             // 
             // filterHelpBtn
@@ -530,6 +534,7 @@
             // panel1
             // 
             this.panel1.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink;
+            this.panel1.Controls.Add(this.noMatchesPanel);
             this.panel1.Controls.Add(this.productsDisplay);
             this.panel1.Controls.Add(this.toggleQueueHideBtn);
             this.panel1.Controls.Add(this.doneRemovingBtn);
@@ -562,6 +567,38 @@
             this.productsDisplay.LiberateSeriesClicked += new System.EventHandler<LibationUiBase.GridView.SeriesEntry>(this.ProductsDisplay_LiberateSeriesClicked);
             this.productsDisplay.ConvertToMp3Clicked += ProductsDisplay_ConvertToMp3Clicked;
             this.productsDisplay.InitialLoaded += new System.EventHandler(this.productsDisplay_InitialLoaded);
+            // 
+            // noMatchesPanel
+            // 
+            this.noMatchesPanel.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
+            | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
+            this.noMatchesPanel.Controls.Add(this.noMatchesTrashLink);
+            this.noMatchesPanel.Controls.Add(this.noMatchesLbl);
+            this.noMatchesPanel.Location = new System.Drawing.Point(15, 36);
+            this.noMatchesPanel.Name = "noMatchesPanel";
+            this.noMatchesPanel.Padding = new System.Windows.Forms.Padding(0, 90, 0, 0);
+            this.noMatchesPanel.Size = new System.Drawing.Size(999, 555);
+            this.noMatchesPanel.TabIndex = 10;
+            this.noMatchesPanel.Visible = false;
+            // 
+            // noMatchesLbl
+            // 
+            this.noMatchesLbl.Dock = System.Windows.Forms.DockStyle.Top;
+            this.noMatchesLbl.Name = "noMatchesLbl";
+            this.noMatchesLbl.Size = new System.Drawing.Size(999, 32);
+            this.noMatchesLbl.TabIndex = 0;
+            this.noMatchesLbl.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
+            // 
+            // noMatchesTrashLink
+            // 
+            this.noMatchesTrashLink.Dock = System.Windows.Forms.DockStyle.Top;
+            this.noMatchesTrashLink.Name = "noMatchesTrashLink";
+            this.noMatchesTrashLink.Size = new System.Drawing.Size(999, 28);
+            this.noMatchesTrashLink.TabIndex = 1;
+            this.noMatchesTrashLink.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
+            this.noMatchesTrashLink.Visible = false;
+            this.noMatchesTrashLink.LinkClicked += new System.Windows.Forms.LinkLabelLinkClickedEventHandler(this.noMatchesTrashLink_LinkClicked);
             // 
             // toggleQueueHideBtn
             // 
@@ -657,6 +694,7 @@
             this.splitContainer1.Panel2.ResumeLayout(false);
             ((System.ComponentModel.ISupportInitialize)(this.splitContainer1)).EndInit();
             this.splitContainer1.ResumeLayout(false);
+            this.noMatchesPanel.ResumeLayout(false);
             this.panel1.ResumeLayout(false);
             this.panel1.PerformLayout();
             this.ResumeLayout(false);
@@ -717,6 +755,9 @@
 		private System.Windows.Forms.SplitContainer splitContainer1;
 		private LibationWinForms.ProcessQueue.ProcessQueueControl processBookQueue1;
 		private System.Windows.Forms.Panel panel1;
+		private System.Windows.Forms.Panel noMatchesPanel;
+		private System.Windows.Forms.Label noMatchesLbl;
+		private System.Windows.Forms.LinkLabel noMatchesTrashLink;
 		private System.Windows.Forms.Button toggleQueueHideBtn;
 		public LibationWinForms.GridView.ProductsDisplay productsDisplay;
 		private System.Windows.Forms.Button removeBooksBtn;

--- a/Source/LibationWinForms/Form1.Designer.cs
+++ b/Source/LibationWinForms/Form1.Designer.cs
@@ -79,6 +79,7 @@
 			this.upgradeLbl = new System.Windows.Forms.ToolStripStatusLabel();
 			this.visibleCountLbl = new LibationWinForms.FormattableToolStripStatusLabel();
             this.springLbl = new System.Windows.Forms.ToolStripStatusLabel();
+            this.trashBinLbl = new System.Windows.Forms.ToolStripStatusLabel();
             this.backupsCountsLbl = new System.Windows.Forms.ToolStripStatusLabel();
             this.addQuickFilterBtn = new System.Windows.Forms.Button();
             this.splitContainer1 = new System.Windows.Forms.SplitContainer();
@@ -446,6 +447,7 @@
             this.upgradePb,
 			this.visibleCountLbl,
             this.springLbl,
+            this.trashBinLbl,
             this.backupsCountsLbl});
             this.statusStrip1.Location = new System.Drawing.Point(0, 618);
             this.statusStrip1.Name = "statusStrip1";
@@ -478,6 +480,14 @@
             this.springLbl.Name = "springLbl";
             this.springLbl.Size = new System.Drawing.Size(511, 17);
             this.springLbl.Spring = true;
+            // 
+            // trashBinLbl
+            // 
+            this.trashBinLbl.Name = "trashBinLbl";
+            this.trashBinLbl.IsLink = true;
+            this.trashBinLbl.Margin = new System.Windows.Forms.Padding(0, 3, 16, 2);
+            this.trashBinLbl.Visible = false;
+            this.trashBinLbl.Click += new System.EventHandler(this.trashBinLbl_Click);
             // 
             // backupsCountsLbl
             // 
@@ -660,6 +670,7 @@
 		private System.Windows.Forms.ToolStripStatusLabel springLbl;
 		private LibationWinForms.FormattableToolStripStatusLabel visibleCountLbl;
 		private System.Windows.Forms.ToolStripMenuItem liberateToolStripMenuItem;
+		private System.Windows.Forms.ToolStripStatusLabel trashBinLbl;
 		private System.Windows.Forms.ToolStripStatusLabel backupsCountsLbl;
 		private LibationWinForms.FormattableToolStripMenuItem beginBookBackupsToolStripMenuItem;
 		private LibationWinForms.FormattableToolStripMenuItem beginPdfBackupsToolStripMenuItem;

--- a/Source/LibationWinForms/Form1.Designer.cs
+++ b/Source/LibationWinForms/Form1.Designer.cs
@@ -88,6 +88,9 @@
             this.noMatchesPanel = new System.Windows.Forms.Panel();
             this.noMatchesLbl = new System.Windows.Forms.Label();
             this.noMatchesTrashLink = new System.Windows.Forms.LinkLabel();
+            this.emptyLibraryLbl = new System.Windows.Forms.Label();
+            this.emptyLibraryActionLink = new System.Windows.Forms.LinkLabel();
+            this.emptyLibraryTourLink = new System.Windows.Forms.LinkLabel();
             this.toggleQueueHideBtn = new System.Windows.Forms.Button();
             this.doneRemovingBtn = new System.Windows.Forms.Button();
             this.removeBooksBtn = new System.Windows.Forms.Button();
@@ -573,6 +576,9 @@
             this.noMatchesPanel.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
             | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
+            this.noMatchesPanel.Controls.Add(this.emptyLibraryTourLink);
+            this.noMatchesPanel.Controls.Add(this.emptyLibraryActionLink);
+            this.noMatchesPanel.Controls.Add(this.emptyLibraryLbl);
             this.noMatchesPanel.Controls.Add(this.noMatchesTrashLink);
             this.noMatchesPanel.Controls.Add(this.noMatchesLbl);
             this.noMatchesPanel.Location = new System.Drawing.Point(15, 36);
@@ -599,6 +605,35 @@
             this.noMatchesTrashLink.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
             this.noMatchesTrashLink.Visible = false;
             this.noMatchesTrashLink.LinkClicked += new System.Windows.Forms.LinkLabelLinkClickedEventHandler(this.noMatchesTrashLink_LinkClicked);
+            // 
+            // emptyLibraryLbl
+            // 
+            this.emptyLibraryLbl.Dock = System.Windows.Forms.DockStyle.Top;
+            this.emptyLibraryLbl.Name = "emptyLibraryLbl";
+            this.emptyLibraryLbl.Size = new System.Drawing.Size(999, 56);
+            this.emptyLibraryLbl.TabIndex = 2;
+            this.emptyLibraryLbl.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
+            this.emptyLibraryLbl.Visible = false;
+            // 
+            // emptyLibraryActionLink
+            // 
+            this.emptyLibraryActionLink.Dock = System.Windows.Forms.DockStyle.Top;
+            this.emptyLibraryActionLink.Name = "emptyLibraryActionLink";
+            this.emptyLibraryActionLink.Size = new System.Drawing.Size(999, 28);
+            this.emptyLibraryActionLink.TabIndex = 3;
+            this.emptyLibraryActionLink.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
+            this.emptyLibraryActionLink.Visible = false;
+            this.emptyLibraryActionLink.LinkClicked += new System.Windows.Forms.LinkLabelLinkClickedEventHandler(this.emptyLibraryActionLink_LinkClicked);
+            // 
+            // emptyLibraryTourLink
+            // 
+            this.emptyLibraryTourLink.Dock = System.Windows.Forms.DockStyle.Top;
+            this.emptyLibraryTourLink.Name = "emptyLibraryTourLink";
+            this.emptyLibraryTourLink.Size = new System.Drawing.Size(999, 28);
+            this.emptyLibraryTourLink.TabIndex = 4;
+            this.emptyLibraryTourLink.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
+            this.emptyLibraryTourLink.Visible = false;
+            this.emptyLibraryTourLink.LinkClicked += new System.Windows.Forms.LinkLabelLinkClickedEventHandler(this.emptyLibraryTourLink_LinkClicked);
             // 
             // toggleQueueHideBtn
             // 
@@ -758,6 +793,9 @@
 		private System.Windows.Forms.Panel noMatchesPanel;
 		private System.Windows.Forms.Label noMatchesLbl;
 		private System.Windows.Forms.LinkLabel noMatchesTrashLink;
+		private System.Windows.Forms.Label emptyLibraryLbl;
+		private System.Windows.Forms.LinkLabel emptyLibraryActionLink;
+		private System.Windows.Forms.LinkLabel emptyLibraryTourLink;
 		private System.Windows.Forms.Button toggleQueueHideBtn;
 		public LibationWinForms.GridView.ProductsDisplay productsDisplay;
 		private System.Windows.Forms.Button removeBooksBtn;

--- a/Source/LibationWinForms/Form1.Designer.cs
+++ b/Source/LibationWinForms/Form1.Designer.cs
@@ -91,6 +91,7 @@
             this.emptyLibraryLbl = new System.Windows.Forms.Label();
             this.emptyLibraryActionLink = new System.Windows.Forms.LinkLabel();
             this.emptyLibraryTourLink = new System.Windows.Forms.LinkLabel();
+            this.emptyLibraryTrashLink = new System.Windows.Forms.LinkLabel();
             this.toggleQueueHideBtn = new System.Windows.Forms.Button();
             this.doneRemovingBtn = new System.Windows.Forms.Button();
             this.removeBooksBtn = new System.Windows.Forms.Button();
@@ -576,6 +577,7 @@
             this.noMatchesPanel.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
             | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
+            this.noMatchesPanel.Controls.Add(this.emptyLibraryTrashLink);
             this.noMatchesPanel.Controls.Add(this.emptyLibraryTourLink);
             this.noMatchesPanel.Controls.Add(this.emptyLibraryActionLink);
             this.noMatchesPanel.Controls.Add(this.emptyLibraryLbl);
@@ -634,6 +636,16 @@
             this.emptyLibraryTourLink.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
             this.emptyLibraryTourLink.Visible = false;
             this.emptyLibraryTourLink.LinkClicked += new System.Windows.Forms.LinkLabelLinkClickedEventHandler(this.emptyLibraryTourLink_LinkClicked);
+            // 
+            // emptyLibraryTrashLink
+            // 
+            this.emptyLibraryTrashLink.Dock = System.Windows.Forms.DockStyle.Top;
+            this.emptyLibraryTrashLink.Name = "emptyLibraryTrashLink";
+            this.emptyLibraryTrashLink.Size = new System.Drawing.Size(999, 28);
+            this.emptyLibraryTrashLink.TabIndex = 5;
+            this.emptyLibraryTrashLink.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
+            this.emptyLibraryTrashLink.Visible = false;
+            this.emptyLibraryTrashLink.LinkClicked += new System.Windows.Forms.LinkLabelLinkClickedEventHandler(this.emptyLibraryTrashLink_LinkClicked);
             // 
             // toggleQueueHideBtn
             // 
@@ -796,6 +808,7 @@
 		private System.Windows.Forms.Label emptyLibraryLbl;
 		private System.Windows.Forms.LinkLabel emptyLibraryActionLink;
 		private System.Windows.Forms.LinkLabel emptyLibraryTourLink;
+		private System.Windows.Forms.LinkLabel emptyLibraryTrashLink;
 		private System.Windows.Forms.Button toggleQueueHideBtn;
 		public LibationWinForms.GridView.ProductsDisplay productsDisplay;
 		private System.Windows.Forms.Button removeBooksBtn;

--- a/Source/LibationWinForms/Form1.Filter.cs
+++ b/Source/LibationWinForms/Form1.Filter.cs
@@ -74,6 +74,7 @@ public partial class Form1
 	private int visibleCount;
 	private bool libraryIsEmpty;
 	private bool anyAccounts;
+	private int booksInTrash;
 
 	/// <summary>
 	/// Decide which explanation the empty grid should carry, if any. An empty library takes precedence over
@@ -81,8 +82,10 @@ public partial class Form1
 	/// </summary>
 	private async void refreshGridEmptyState(string? filterString)
 	{
-		var gettingStarted = libraryIsEmpty && !LibraryCommands.Scanning;
-		var noMatches = !gettingStarted && visibleCount == 0 && !string.IsNullOrWhiteSpace(filterString);
+		// Someone searching is not someone getting started, so a filter always answers for itself.
+		var hasFilter = !string.IsNullOrWhiteSpace(filterString);
+		var gettingStarted = libraryIsEmpty && !hasFilter && !LibraryCommands.Scanning;
+		var noMatches = hasFilter && visibleCount == 0;
 
 		this.UIThreadSync(() =>
 		{
@@ -92,6 +95,12 @@ public partial class Form1
 			emptyLibraryLbl.Visible = gettingStarted;
 			emptyLibraryActionLink.Visible = gettingStarted;
 			emptyLibraryTourLink.Visible = gettingStarted;
+
+			// The books are not gone, they are in the trash. Saying so keeps the headline above from
+			// reading as though they were never there.
+			emptyLibraryTrashLink.Visible = gettingStarted && booksInTrash > 0;
+			if (emptyLibraryTrashLink.Visible)
+				SetTrashLink(emptyLibraryTrashLink, GridEmptyStateUi.EmptyLibraryTrashHintText(booksInTrash));
 
 			noMatchesLbl.Text = GridEmptyStateUi.NoMatchesText(filterString);
 			noMatchesLbl.Visible = noMatches;
@@ -113,12 +122,18 @@ public partial class Form1
 
 		this.UIThreadSync(() =>
 		{
-			noMatchesTrashLink.Text = $"{GridEmptyStateUi.NoMatchesTrashHintText(matches.Count)}  {GridEmptyStateUi.OpenTrashBinButton}";
-			noMatchesTrashLink.LinkArea = new LinkArea(
-				noMatchesTrashLink.Text.Length - GridEmptyStateUi.OpenTrashBinButton.Length,
-				GridEmptyStateUi.OpenTrashBinButton.Length);
+			SetTrashLink(noMatchesTrashLink, GridEmptyStateUi.NoMatchesTrashHintText(matches.Count));
 			noMatchesTrashLink.Visible = true;
 		});
+	}
+
+	/// <summary>Sentence plus a trailing "Open Trash Bin" link, which is the clickable part.</summary>
+	private static void SetTrashLink(LinkLabel link, string sentence)
+	{
+		link.Text = $"{sentence}  {GridEmptyStateUi.OpenTrashBinButton}";
+		link.LinkArea = new LinkArea(
+			link.Text.Length - GridEmptyStateUi.OpenTrashBinButton.Length,
+			GridEmptyStateUi.OpenTrashBinButton.Length);
 	}
 
 	private void noMatchesTrashLink_LinkClicked(object sender, LinkLabelLinkClickedEventArgs e)
@@ -151,6 +166,15 @@ public partial class Form1
 		anyAccounts = any;
 		refreshGridEmptyState();
 	}
+
+	private void setBooksInTrash(int count)
+	{
+		booksInTrash = count;
+		refreshGridEmptyState();
+	}
+
+	private void emptyLibraryTrashLink_LinkClicked(object sender, LinkLabelLinkClickedEventArgs e)
+		=> openTrashBinToolStripMenuItem_Click(sender, e);
 
 	public SearchSyntaxDialog ShowSearchSyntaxDialog()
 	{

--- a/Source/LibationWinForms/Form1.Filter.cs
+++ b/Source/LibationWinForms/Form1.Filter.cs
@@ -1,6 +1,9 @@
-﻿using LibationUiBase;
+﻿using ApplicationServices;
+using Dinah.Core.Threading;
+using LibationUiBase;
 using LibationWinForms.Dialogs;
 using System;
+using System.Threading.Tasks;
 using System.Windows.Forms;
 
 namespace LibationWinForms;
@@ -59,6 +62,7 @@ public partial class Form1
 		{
 			productsDisplay.Filter(filterString);
 			lastGoodFilter = filterString;
+			refreshNoMatchesState(filterString);
 			return null;
 		}
 		catch (Exception ex)
@@ -66,6 +70,46 @@ public partial class Form1
 			return ex;
 		}
 	}
+
+	private int visibleCount;
+
+	/// <summary>
+	/// A trashed book is filtered out of the library and out of the search index, so searching for one looks
+	/// exactly like searching for a book that was never imported. When a filter matches nothing, say whether
+	/// the thing being looked for is sitting in the trash.
+	/// </summary>
+	private async void refreshNoMatchesState(string? filterString)
+	{
+		var noMatches = visibleCount == 0 && !string.IsNullOrWhiteSpace(filterString);
+
+		this.UIThreadSync(() =>
+		{
+			noMatchesLbl.Text = TrashBinUi.NoMatchesText(filterString);
+			noMatchesTrashLink.Visible = false;
+			noMatchesPanel.Visible = noMatches;
+			if (noMatches)
+				noMatchesPanel.BringToFront();
+		});
+
+		if (!noMatches)
+			return;
+
+		var matches = await Task.Run(() => TrashBinSearch.Search(filterString));
+		if (matches.Count == 0)
+			return;
+
+		this.UIThreadSync(() =>
+		{
+			noMatchesTrashLink.Text = $"{TrashBinUi.NoMatchesTrashHintText(matches.Count)}  Open Trash Bin";
+			noMatchesTrashLink.LinkArea = new LinkArea(
+				noMatchesTrashLink.Text.Length - "Open Trash Bin".Length,
+				"Open Trash Bin".Length);
+			noMatchesTrashLink.Visible = true;
+		});
+	}
+
+	private void noMatchesTrashLink_LinkClicked(object sender, LinkLabelLinkClickedEventArgs e)
+		=> openTrashBinToolStripMenuItem_Click(sender, e);
 
 	public SearchSyntaxDialog ShowSearchSyntaxDialog()
 	{

--- a/Source/LibationWinForms/Form1.Filter.cs
+++ b/Source/LibationWinForms/Form1.Filter.cs
@@ -62,7 +62,7 @@ public partial class Form1
 		{
 			productsDisplay.Filter(filterString);
 			lastGoodFilter = filterString;
-			refreshNoMatchesState(filterString);
+			refreshGridEmptyState(filterString);
 			return null;
 		}
 		catch (Exception ex)
@@ -72,44 +72,85 @@ public partial class Form1
 	}
 
 	private int visibleCount;
+	private bool libraryIsEmpty;
+	private bool anyAccounts;
 
 	/// <summary>
-	/// A trashed book is filtered out of the library and out of the search index, so searching for one looks
-	/// exactly like searching for a book that was never imported. When a filter matches nothing, say whether
-	/// the thing being looked for is sitting in the trash.
+	/// Decide which explanation the empty grid should carry, if any. An empty library takes precedence over
+	/// an empty filter result: "no books match" is true but useless when there are no books at all.
 	/// </summary>
-	private async void refreshNoMatchesState(string? filterString)
+	private async void refreshGridEmptyState(string? filterString)
 	{
-		var noMatches = visibleCount == 0 && !string.IsNullOrWhiteSpace(filterString);
+		var gettingStarted = libraryIsEmpty && !LibraryCommands.Scanning;
+		var noMatches = !gettingStarted && visibleCount == 0 && !string.IsNullOrWhiteSpace(filterString);
 
 		this.UIThreadSync(() =>
 		{
-			noMatchesLbl.Text = TrashBinUi.NoMatchesText(filterString);
+			emptyLibraryLbl.Text = $"{GridEmptyStateUi.EmptyLibraryHeadline(anyAccounts)}\r\n{GridEmptyStateUi.EmptyLibraryDetail(anyAccounts)}";
+			emptyLibraryActionLink.Text = anyAccounts ? GridEmptyStateUi.ScanLibraryButton : GridEmptyStateUi.AddAccountButton;
+			emptyLibraryTourLink.Text = GridEmptyStateUi.TakeTheTourButton;
+			emptyLibraryLbl.Visible = gettingStarted;
+			emptyLibraryActionLink.Visible = gettingStarted;
+			emptyLibraryTourLink.Visible = gettingStarted;
+
+			noMatchesLbl.Text = GridEmptyStateUi.NoMatchesText(filterString);
+			noMatchesLbl.Visible = noMatches;
 			noMatchesTrashLink.Visible = false;
-			noMatchesPanel.Visible = noMatches;
-			if (noMatches)
+
+			noMatchesPanel.Visible = gettingStarted || noMatches;
+			if (noMatchesPanel.Visible)
 				noMatchesPanel.BringToFront();
 		});
 
 		if (!noMatches)
 			return;
 
+		// A trashed book is filtered out of the library and out of the search index, so searching for one
+		// looks exactly like searching for a book that was never imported. Say when that is what happened.
 		var matches = await Task.Run(() => TrashBinSearch.Search(filterString));
 		if (matches.Count == 0)
 			return;
 
 		this.UIThreadSync(() =>
 		{
-			noMatchesTrashLink.Text = $"{TrashBinUi.NoMatchesTrashHintText(matches.Count)}  Open Trash Bin";
+			noMatchesTrashLink.Text = $"{GridEmptyStateUi.NoMatchesTrashHintText(matches.Count)}  {GridEmptyStateUi.OpenTrashBinButton}";
 			noMatchesTrashLink.LinkArea = new LinkArea(
-				noMatchesTrashLink.Text.Length - "Open Trash Bin".Length,
-				"Open Trash Bin".Length);
+				noMatchesTrashLink.Text.Length - GridEmptyStateUi.OpenTrashBinButton.Length,
+				GridEmptyStateUi.OpenTrashBinButton.Length);
 			noMatchesTrashLink.Visible = true;
 		});
 	}
 
 	private void noMatchesTrashLink_LinkClicked(object sender, LinkLabelLinkClickedEventArgs e)
 		=> openTrashBinToolStripMenuItem_Click(sender, e);
+
+	private void emptyLibraryActionLink_LinkClicked(object sender, LinkLabelLinkClickedEventArgs e)
+	{
+		// Adding an account comes first; telling someone without one to scan is a dead end.
+		if (anyAccounts)
+			scanLibraryOfAllAccountsToolStripMenuItem_Click(sender, e);
+		else
+			noAccountsYetAddAccountToolStripMenuItem_Click(sender, e);
+	}
+
+	private void emptyLibraryTourLink_LinkClicked(object sender, LinkLabelLinkClickedEventArgs e)
+		=> tourToolStripMenuItem_Click(sender, e);
+
+	/// <summary>Re-evaluate against the filter already applied, for changes that came from somewhere else.</summary>
+	private void refreshGridEmptyState() => refreshGridEmptyState(lastGoodFilter);
+
+	/// <summary>Whether the library has any books at all, from the counts that were just taken.</summary>
+	private void setLibraryIsEmpty(bool isEmpty)
+	{
+		libraryIsEmpty = isEmpty;
+		refreshGridEmptyState();
+	}
+
+	private void setAnyAccounts(bool any)
+	{
+		anyAccounts = any;
+		refreshGridEmptyState();
+	}
 
 	public SearchSyntaxDialog ShowSearchSyntaxDialog()
 	{

--- a/Source/LibationWinForms/Form1.RemoveBooks.cs
+++ b/Source/LibationWinForms/Form1.RemoveBooks.cs
@@ -14,7 +14,14 @@ public partial class Form1
 		=> await productsDisplay.RemoveCheckedBooksAsync();
 
 	private void openTrashBinToolStripMenuItem_Click(object sender, EventArgs e)
-		=> new TrashBinDialog().ShowDialog(this);
+	{
+		new TrashBinDialog().ShowDialog(this);
+		//Restoring or permanently deleting inside the dialog changes the count behind it.
+		refreshBooksInTrash();
+	}
+
+	private void trashBinLbl_Click(object sender, EventArgs e)
+		=> openTrashBinToolStripMenuItem_Click(sender, e);
 
 	private void doneRemovingBtn_Click(object sender, EventArgs e)
 	{

--- a/Source/LibationWinForms/Form1.ScanManual.cs
+++ b/Source/LibationWinForms/Form1.ScanManual.cs
@@ -33,6 +33,8 @@ public partial class Form1
 		scanLibraryOfAllAccountsToolStripMenuItem.Visible = count > 1;
 		scanLibraryOfSomeAccountsToolStripMenuItem.Visible = count > 1;
 
+		setAnyAccounts(count > 0);
+
 		removeLibraryBooksToolStripMenuItem.Visible = count > 0;
 		removeSomeAccountsToolStripMenuItem.Visible = count > 1;
 		removeAllAccountsToolStripMenuItem.Visible = count > 1;

--- a/Source/LibationWinForms/Form1.ScanNotification.cs
+++ b/Source/LibationWinForms/Form1.ScanNotification.cs
@@ -33,6 +33,8 @@ public partial class Form1
 			= (accountsLength == 1)
 			? "Scanning..."
 			: $"Scanning {accountsLength} accounts...";
+
+		refreshGridEmptyState();
 	}
 
 	private void LibraryCommands_ScanEnd(object? sender, int newCount)
@@ -51,5 +53,8 @@ public partial class Form1
 		scanLibraryOfSomeAccountsToolStripMenuItem.Enabled = true;
 
 		this.scanningToolStripMenuItem.Visible = false;
+
+		//"No books yet" would be answering a question the scan was already answering.
+		refreshGridEmptyState();
 	}
 }

--- a/Source/LibationWinForms/Form1.VisibleBooks.cs
+++ b/Source/LibationWinForms/Form1.VisibleBooks.cs
@@ -172,6 +172,8 @@ public partial class Form1
 
 	private async void productsDisplay_VisibleCountChanged(object sender, int qty)
 	{
+		visibleCount = qty;
+
 		// bottom-left visible count
 		visibleCountLbl.Format(qty);
 

--- a/Source/_Tests/ApplicationServices.Tests/EnsureScanCanIdentifyInactiveBooksTests.cs
+++ b/Source/_Tests/ApplicationServices.Tests/EnsureScanCanIdentifyInactiveBooksTests.cs
@@ -1,0 +1,68 @@
+using ApplicationServices;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.Linq;
+
+namespace EnsureScanCanIdentifyInactiveBooksTests;
+
+/// <summary>
+/// "Remove books no longer in your account" decides from a single scan. A scan that could not see the whole
+/// library would flag books the user still owns, so it has to be rejected rather than believed.
+/// </summary>
+[TestClass]
+public class EnsureScanCanIdentifyInactiveBooks
+{
+	[TestMethod]
+	public void a_complete_scan_is_accepted()
+		=> LibraryCommands.EnsureScanCanIdentifyInactiveBooks(scannedItemCount: 434, existingBookCount: 12, failedAccounts: []);
+
+	[TestMethod]
+	public void a_null_failed_account_list_is_treated_as_no_failures()
+		=> LibraryCommands.EnsureScanCanIdentifyInactiveBooks(scannedItemCount: 434, existingBookCount: 12, failedAccounts: null);
+
+	[TestMethod]
+	public void an_account_that_failed_to_scan_is_rejected()
+	{
+		var ex = Assert.ThrowsExactly<LibraryScanIncompleteException>(
+			() => LibraryCommands.EnsureScanCanIdentifyInactiveBooks(434, 12, ["me@example.com"]));
+
+		CollectionAssert.AreEqual(new[] { "me@example.com" }, ex.FailedAccounts.ToArray());
+		StringAssert.Contains(ex.Message, "me@example.com");
+	}
+
+	[TestMethod]
+	public void a_failed_account_is_rejected_even_when_other_accounts_returned_books()
+	{
+		// The books that did arrive prove nothing about the account that never answered.
+		var ex = Assert.ThrowsExactly<LibraryScanIncompleteException>(
+			() => LibraryCommands.EnsureScanCanIdentifyInactiveBooks(5000, 12, ["second@example.com"]));
+
+		CollectionAssert.AreEqual(new[] { "second@example.com" }, ex.FailedAccounts.ToArray());
+	}
+
+	[TestMethod]
+	public void every_failed_account_is_named()
+	{
+		var ex = Assert.ThrowsExactly<LibraryScanIncompleteException>(
+			() => LibraryCommands.EnsureScanCanIdentifyInactiveBooks(0, 12, ["a@example.com", "b@example.com"]));
+
+		CollectionAssert.AreEquivalent(new[] { "a@example.com", "b@example.com" }, ex.FailedAccounts.ToArray());
+	}
+
+	[TestMethod]
+	public void a_scan_returning_nothing_is_rejected_when_books_are_at_stake()
+	{
+		var ex = Assert.ThrowsExactly<LibraryScanIncompleteException>(
+			() => LibraryCommands.EnsureScanCanIdentifyInactiveBooks(0, 300, []));
+
+		Assert.AreEqual(0, ex.FailedAccounts.Count);
+		StringAssert.Contains(ex.Message, "300");
+	}
+
+	[TestMethod]
+	public void a_scan_returning_nothing_is_fine_when_no_books_are_at_stake()
+		=> LibraryCommands.EnsureScanCanIdentifyInactiveBooks(scannedItemCount: 0, existingBookCount: 0, failedAccounts: []);
+
+	[TestMethod]
+	public void a_single_scanned_item_is_enough_to_proceed()
+		=> LibraryCommands.EnsureScanCanIdentifyInactiveBooks(scannedItemCount: 1, existingBookCount: 300, failedAccounts: []);
+}

--- a/Source/_Tests/AudibleUtilities.Tests/AccountTests.cs
+++ b/Source/_Tests/AudibleUtilities.Tests/AccountTests.cs
@@ -768,5 +768,67 @@ BxlXqPnQ4mG66oqSFQgDEmFdMhRb2of6xL1gYYL62C80G2T7QtmPfSab
 		tokens.RefreshToken.Value.Should().Be(SampleRefreshToken);
 	}
 }
+
+/// <summary>
+/// AccountsSettings.json should hold an account's state and nothing derived from it. A computed property
+/// without <see cref="JsonIgnore"/> is written out silently, and then sits in the file going stale.
+/// </summary>
+[TestClass]
+public class SerializedShape : AccountsTestBase
+{
+	private static JObject SerializeOneAccount()
+	{
+		var settings = new AccountsSettings();
+		settings.Add(new Account("user@example.com") { AccountName = "Main" });
+
+		return (JObject)JObject.Parse(settings.ToJson())["Accounts"]![0]!;
+	}
+
+	[TestMethod]
+	public void MaskedLogEntry_is_not_persisted()
+		=> SerializeOneAccount().ContainsKey(nameof(Account.MaskedLogEntry)).Should().BeFalse();
+
+	[TestMethod]
+	public void Locale_is_not_persisted()
+		=> SerializeOneAccount().ContainsKey(nameof(Account.Locale)).Should().BeFalse();
+
+	[TestMethod]
+	public void only_an_accounts_own_state_is_persisted()
+	{
+		// Fails when a property is added without deciding whether it belongs in the file.
+		CollectionAssert.AreEquivalent(
+			new[] { "AccountId", "AccountName", "LibraryScan", "DecryptKey", "IdentityTokens" },
+			SerializeOneAccount().Properties().Select(p => p.Name).ToArray());
+	}
+
+	[TestMethod]
+	public void a_stray_property_from_an_older_file_is_dropped_on_the_next_save()
+	{
+		// Files written before MaskedLogEntry was ignored still carry it. Loading must not choke on it,
+		// and saving must not preserve it.
+		var withStray = """
+			{
+			  "Accounts": [
+			    {
+			      "AccountId": "user@example.com",
+			      "AccountName": "Main",
+			      "LibraryScan": true,
+			      "DecryptKey": "",
+			      "IdentityTokens": null,
+			      "MaskedLogEntry": "AccountId=u**r|AccountName=M**n|Locale=[empty]"
+			    }
+			  ],
+			  "Cdm": null
+			}
+			""";
+
+		var loaded = AccountsSettings.FromJson(withStray);
+		loaded.BeNotNull();
+		loaded.Accounts.Count.Should().Be(1);
+		loaded.Accounts[0].AccountId.Should().Be("user@example.com");
+
+		JObject.Parse(loaded.ToJson())["Accounts"]![0]!["MaskedLogEntry"].Should().BeNull();
+	}
+}
 #pragma warning restore CS8981
 

--- a/docs/advanced/troubleshoot.md
+++ b/docs/advanced/troubleshoot.md
@@ -34,6 +34,38 @@ Audible returned an HTML page instead of JSON. Common causes: transient outage, 
 3. Disable VPN/proxy and scan again.
 4. Remove and re-add the account in Libation.
 
+## A book in my Audible library is missing from Libation
+
+Work down this list. The first two account for most reports, and neither leaves any trace in the log.
+
+1. **Check the trash bin.** Removing a book from Libation hides it from the grid, from search results and
+   from the status bar counts, so it looks exactly like a book that was never imported. The status bar shows
+   a count when the trash is not empty, and **Settings > Trash Bin** has a search box. See
+   [Trash Bin](/docs/features/trash-bin).
+2. **Clear any filter.** A Quick Filter set as the default is applied at startup, so the grid can open
+   already filtered. Empty the search box and click **Filter**.
+3. **Check what you are importing.** In **Settings > Import**, "Import episodes" and "Import Audible Plus
+   books" each exclude titles from every scan. Both are recorded near the top of the log:
+   `"ImportEpisodes":true,"ImportPlusTitles":true`.
+4. **Scan again.** Audible occasionally leaves titles out of a scan. Libation re-requests what it notices
+   missing, but a title absent from the library listing itself cannot be recovered until Audible sends it.
+5. **Read the scan summary in the log.** Every scan ends with a tally, and anything Libation dropped is named
+   just above it:
+
+```
+Library scan tally. {"LibraryItems":434,"EpisodesFetched":1724,"OrphanedEpisodesDropped":15,
+                     "ImportEpisodes":true,"EpisodeItemsExcluded":0,
+                     "ImportPlusTitles":true,"PlusTitlesExcluded":0,"ItemsToImport":2143}
+```
+
+`PlusTitlesExcluded` or `EpisodeItemsExcluded` above zero means a setting from step 3 is dropping titles.
+An `Audible did not return ... catalog products` warning means Audible sent an incomplete response even after
+Libation asked again. `podcast episodes were not imported because their series parent was missing` names each
+episode that was dropped.
+
+If the title is still missing after all of that, open a bug report with the log and say which title it is -
+the ASIN if you have it, from the book's Audible URL.
+
 ## Failed to decrypt ExistingAccessToken (Docker finds no new books)
 
 **Symptoms:** The Windows (or other desktop) app shows your full library and new titles, but Docker / Linux finds no new books after you copy `AccountsSettings.json` from that machine. Container or `Libation.log` output includes `Failed to decrypt ExistingAccessToken`.

--- a/docs/development/testing.md
+++ b/docs/development/testing.md
@@ -116,6 +116,61 @@ Two of the Liberate icons are not stored in the database at all, which is worth 
 
 One more trap, in the grid rather than the database: a podcast's series is identified by the **parent book's own ASIN**, not by an arbitrary series id, and `SeriesEntry.GetAllSeriesEntriesAsync` discards any series whose children it cannot match. Point the episodes at a different series id and the parent row disappears from the grid with no error.
 
+### seed-demo-accounts.cs
+
+Adds fake Audible accounts to `AccountsSettings.json`, so the parts of Libation that only appear once an
+account exists can be reached without signing in to Audible.
+
+Quite a lot is gated on the account count, and it is not one switch but two - nothing, one, or several:
+
+| Accounts | What appears |
+|----------|--------------|
+| none | **Import > No accounts yet. Add Account...**, and an empty library offers **Add Account** |
+| one | **Import > Scan Library** and **Remove Library Books**, and an empty library offers **Scan Library** |
+| two or more | **Scan Library of All / Some Accounts** and the matching **Remove Books from...** items |
+
+Run Libation once first so the file exists, and close it before seeding - Libation reads the file at startup
+and writes it back on save, so a running app would overwrite whatever the script wrote.
+
+```bash
+# one account
+dotnet run Scripts/seed-demo-accounts.cs
+```
+
+```bash
+# three, for the multi-account menus
+dotnet run Scripts/seed-demo-accounts.cs -- --count 3
+```
+
+Remove them again:
+
+```bash
+dotnet run Scripts/seed-demo-accounts.cs -- --clean
+```
+
+The first seeded account is `demo@example.com`, which is deliberately the same account
+`seed-demo-library.cs` assigns its books to, so seeding both describes one library rather than two unrelated
+ones.
+
+::: warning
+The tokens are structurally valid but meaningless. Libation will count these accounts, list them and enable
+everything gated on having one, but any scan or download attempt is refused by Audible. Do not use them to
+test scanning.
+:::
+
+Real accounts in the file are left alone, and `--clean` only removes the accounts the script added - the ones
+whose id matches `demo*@example.com`. Even so, this writes to the file holding your Audible tokens, so on a
+machine with a real account signed in, back that file up first.
+
+The tokens are written as plaintext rather than reaching for the OS secret store, which a test script has no
+business touching. Libation reads either, whatever **Settings > Important > Token storage** is set to.
+
+::: tip
+The `#:package AudibleApi@...` version at the top of the script needs to stay in step with the `AudibleApi`
+reference in `Source/AudibleUtilities/AudibleUtilities.csproj`, so the JSON it writes stays the shape the app
+expects to read.
+:::
+
 ### seed-download-history.cs
 
 Fills the `DownloadHistory` table with fake completed downloads, so the [daily download limit](/docs/features/daily-download-limit) can be tested without downloading anything. Start Libation once first so the table exists.

--- a/docs/development/testing.md
+++ b/docs/development/testing.md
@@ -162,6 +162,12 @@ Real accounts in the file are left alone, and `--clean` only removes the account
 whose id matches `demo*@example.com`. Even so, this writes to the file holding your Audible tokens, so on a
 machine with a real account signed in, back that file up first.
 
+The id is what identifies them, rather than a marker property, because a marker does not survive. `Account`
+serializes a fixed set of members and has no `[JsonExtensionData]`, so anything that dirties an account -
+renaming it, or a token refresh during a scan - rewrites the file without the extra property, and `--clean`
+would no longer recognize its own accounts. An id is immutable and always persisted, and `example.com` is
+reserved by RFC 2606 so no real Audible login can collide with it.
+
 The tokens are written as plaintext rather than reaching for the OS secret store, which a test script has no
 business touching. Libation reads either, whatever **Settings > Important > Token storage** is set to.
 

--- a/docs/development/testing.md
+++ b/docs/development/testing.md
@@ -59,7 +59,7 @@ Forgetting the `--` is the usual reason a flag appears to be ignored.
 
 Fills a Libation library with fake books covering every icon the grid's **Liberate** column can draw, so a change to those icons can be checked at a glance instead of by hunting for a real book in the right state.
 
-It seeds the full stoplight matrix - each lamp color, each PDF state, purchased and Audible Plus - plus both error icons and a podcast series with episodes. On success it prints a row-by-row list of what each seeded row should look like, so sort the grid by **Title** and read down.
+It seeds the full stoplight matrix - each lamp color, each PDF state, purchased and Audible Plus - plus both error icons, a podcast series with episodes, books missing from the last scan, and books in the trash. On success it prints a row-by-row list of what each seeded row should look like, so sort the grid by **Title** and read down.
 
 Run Libation once first so the database exists, and close it before seeding:
 
@@ -84,6 +84,28 @@ Both commands are safe to re-run. Seeding skips books that are already present, 
 ::: warning
 The seeded books are not real, so do not click their stoplights - that queues a download which cannot succeed. Expanding a seeded series row is fine.
 :::
+
+#### Books in the trash
+
+Three of the seeded books are in the trash, and they are the only ones that will not be in the grid. Removal is a soft delete: `GetLibrary()` filters `IsDeleted` out, which takes a trashed book out of the grid, out of the search index and out of every status count at once. Nothing then distinguishes it from a book that was never imported, which is what made [#1925](https://github.com/rmcrackan/Libation/issues/1925) take a week to answer. These rows are how the affordances that fixed that are checked.
+
+The script prints them under their own heading, along with what should account for them:
+
+```
+3 seeded book(s) are in the trash, so they are NOT in the grid:
+  28 Trashed | purchased                         in the trash bin only, red lamp there
+  29 Trashed | PLUS                              in the trash bin only, green lamp with badge there
+  30 Demo Series - episode 3 (trashed)           nested under Demo Series in the trash bin, absent from the grid
+```
+
+Four things to check, none of which needs a real Audible account:
+
+- The status bar ends with a clickable **3 in trash**, which opens the trash bin. It disappears entirely once the trash is empty.
+- **Settings > Trash Bin** reads `Trash Bin (3)`.
+- Filtering for `Trashed` matches nothing in the library, so the grid says so and offers to open the trash bin. That hint only appears when the same filter matches something in the trash, so filtering for a word that is in neither place gives the plain "no books match" message.
+- The trashed episode is nested under **Demo Series** inside the trash bin, even though the series itself is not deleted. `GetDeletedLibraryBooks` asks for every parent rather than only deleted ones, so an episode can still be shown beneath its series there. The series keeps its other two episodes in the main grid.
+
+Restoring a book from the trash puts it straight back in the grid and drops the count, so the same three rows can be used more than once. Re-run the script to put them back.
 
 #### Why some states cannot be seeded with SQL alone
 

--- a/docs/features/trash-bin.md
+++ b/docs/features/trash-bin.md
@@ -1,0 +1,85 @@
+# Trash bin
+
+Removing a book from Libation does not throw it away. The book moves to a trash bin, where it stays until you
+restore it or delete it for good.
+
+Removing a book never touches your audio files. Everything on this page is about Libation's own record of a
+book, not the files it has downloaded.
+
+## Removing books
+
+Three ways, depending on how many books you mean:
+
+- **Right-click one or more rows > Remove from library.** The usual way to remove a specific book.
+- **Visible Books > Remove from library...** Removes everything the current filter is showing, so you can
+  [search](/docs/features/searching-and-filtering) for what you want gone and remove the result in one go.
+- **Import > Remove Library Books.** Scans your account first and pre-checks the books it did not find, which
+  is how you clear out titles you no longer own. Nothing is removed until you click **Remove N Books from
+  Libation** and confirm, and the confirmation lists every title.
+
+A removed book disappears from the grid, from search results, and from the counts in the status bar. That is
+the whole point, but it also means nothing about the main window will remind you the book exists.
+
+## Finding what you removed
+
+The status bar shows how many books are in the trash, and clicking it opens the trash bin:
+
+```
+Visible: 2,488          29 in trash          All 2,488 books backed up
+```
+
+The count is also on the **Settings > Trash Bin** menu item. Neither appears when the trash is empty.
+
+If you search for a book that turns out to be in the trash, Libation says so rather than leaving you with an
+empty grid:
+
+> No books match "Epicenter".
+> 1 matching book is in the trash. **[Open Trash Bin]**
+
+## Restoring a book
+
+Open **Settings > Trash Bin**, tick the books you want, and click **Restore**. They reappear in the grid
+immediately, with their download status and tags intact.
+
+The trash bin has its own search box, which is worth knowing if you have removed a lot over the years. The
+**Everything** and **Audible Plus Books** checkboxes at the bottom tick whole groups at once.
+
+Podcast episodes are listed under their series, even when the series itself is not in the trash.
+
+## Removing a book for good
+
+**Permanently Delete from Libation**, in the same dialog, deletes Libation's record of the book instead of
+keeping it in the trash.
+
+This is worth understanding before you use it, because it does *less* to keep a book away than the trash does:
+
+| | Book in the grid | Comes back on the next scan | Your audio files |
+|-|-|-|-|
+| **Removed** (in the trash) | No | No | Untouched |
+| **Permanently deleted** | No, until the next scan | Yes, if it is still in your Audible account | Untouched |
+
+Libation recognizes a removed book on the next scan and leaves it in the trash. A permanently deleted book is
+one it has never seen before, so it is imported again like any other new title.
+
+So if you want a book gone from Libation and to stay gone, leave it in the trash. Permanently deleting is for
+reclaiming space in Libation's database, or for starting a title over from scratch.
+
+## Not the same as removing from Audible
+
+The context menu also offers **Remove Plus Books from Audible Library** for Audible Plus titles. That one
+reaches into your actual Audible account and returns the title, which is why it asks for confirmation and
+warns that the only way back is through the Audible website or app. It is not undoable from Libation, and the
+book is not put in the trash afterwards - it is gone from your Audible library, so there is nothing for a scan
+to find.
+
+## In the log
+
+Libation records the size of the trash at startup, and every change to it afterwards:
+
+```
+Initial database statistics. {"LibraryBooksNotInTrash":2508,"LibraryBooksInTrash":29,"BookRecords":2537}
+Trash bin changed. {"Action":"Moved to trash","Books":1,"BooksInTrash":30}
+Trash bin changed. {"Action":"Restored from trash","Books":1,"BooksInTrash":29}
+```
+
+Useful if a book has gone missing and you want to know whether, and when, it was removed.

--- a/docs/index.md
+++ b/docs/index.md
@@ -25,6 +25,7 @@ Learn about Libation's powerful features:
 - **[Naming Templates](/docs/features/naming-templates)** - Customize how your audiobook files are named
 - **[Searching & Filtering](/docs/features/searching-and-filtering)** - Find and organize your audiobooks
 - **[Easy guide to searching](/docs/features/lucene)** - Tutorial for search queries
+- **[Trash Bin](/docs/features/trash-bin)** - Restore a removed book, and what "permanently delete" really does
 
 ## Advanced
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
From #1925, which turned out to be a book sitting in the trash bin that neither the reporter nor I found for a week. Everything here addresses how a book can end up hidden with nothing pointing at it, and then what the blank grid should say instead of nothing.

---

## 1. Don't offer to remove books based on a scan that failed

`scanAccountsAsync` deliberately swallows a per-account failure so the remaining accounts can still scan. That is correct for importing, which only adds and updates. `FindInactiveBooks` is the opposite kind of operation and used the same result, treating whatever came back as the whole library. For a single-account user, a login or network failure therefore produces an empty `libraryItems` and **the entire un-liberated library gets pre-checked for removal**. The confirmation dialog still lists the titles, but that is the difference between "Remove 1 Book" and "Remove 300 Books".

`ImportAccountAsync` already protects itself with `if (totalCount == 0) return default;`. This path had no equivalent.

- `scanAccountsAsync` returns a `ScanResult` carrying the items plus the accounts that failed.
- `ImportAccountAsync` takes `.Items` and behaves exactly as before.
- `FindInactiveBooks` calls a new `EnsureScanCanIdentifyInactiveBooks`, which throws `LibraryScanIncompleteException` when any account failed, or when a scan returns nothing while books are at stake.

Throwing is deliberate: both grids already report a failure with "Error scanning library. You may still manually select books to remove from Libation's library." The guard lands in handling that already exists and leaves nothing checked. The empty-scan rule is strict rather than proportional; "returned suspiciously few" is a heuristic I cannot justify from evidence and could block legitimate removals.

## 2. Show when the trash is not empty

`GetLibrary()` filters `!IsDeleted`, so a trashed book leaves the grid, the search index and every status count at once, with nothing indicating it still exists.

A status bar segment reading "29 in trash" that opens the trash bin when clicked, plus the same count on the `Settings > Trash Bin` menu item. Both hide themselves when the trash is empty. The count is a separate query rather than part of `LibraryStats`, because `GetCounts` also runs against the visible subset on every filter change, where a database round trip would be wasted work.

[trash_bin_count_discoverable_and_restores.mp4](https://cursor.com/agents/bc-6ff1bfc7-305d-4d52-ab87-f69c83e07ce7/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Ftrash_bin_count_discoverable_and_restores.mp4)

## 3. Log every change to the trash

Startup already reported `LibraryBooksInTrash` as part of `Initial database statistics`. Now moving to trash, restoring, and permanently deleting each log the action, the number of books, and the resulting trash total.

```
Trash bin changed. {"Action":"Moved to trash","Books":1,"BooksInTrash":29}
```

## 4. Explain an empty grid

The blank grid said nothing at all. Now it answers the question the user is actually asking, which depends on why it is blank.

**A filter matched nothing.** Searching for a trashed book returns nothing and looks exactly like searching for a book that was never imported - precisely how #1925 stayed open for a week.

[empty_search_reveals_book_in_trash.mp4](https://cursor.com/agents/bc-6ff1bfc7-305d-4d52-ab87-f69c83e07ce7/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fempty_search_reveals_book_in_trash.mp4)

The trash is indexed on demand rather than kept in step with an index. Filtering runs on Enter or the Filter button, never per keystroke, so the work happens at human speed and only once the library has already come up empty. `TrashBinSearch` reuses the library's query syntax so a fielded query means the same thing in both places.

**The library is empty.** The only pointer used to be the status bar's "No books. Begin by importing your library" - wrong advice for someone who has not added an account, since Import has nothing to scan. An empty library has two causes with different next steps, and `AccountsCount` already knows which applies:

| | | |
|-|-|-|
| **No accounts** | Libation is empty. | `[Add Account]` `[Take a Guided Tour]` |
| **Accounts, no books** | No books in your library yet. | `[Scan Library]` `[Take a Guided Tour]` |

[Empty state with no account configured](https://cursor.com/agents/bc-6ff1bfc7-305d-4d52-ab87-f69c83e07ce7/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fempty_state_no_account.png)

[Empty state with an account but no books](https://cursor.com/agents/bc-6ff1bfc7-305d-4d52-ab87-f69c83e07ce7/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fempty_state_account_but_no_books.png)

The buttons run the same commands as the menu items, so the two cannot drift. The tour is there because it is offered once on first launch and never again once declined, and `Settings > Take a Guided Tour` is not somewhere a new user looks. The panel waits for `LibraryStats` to be counted at least once, so a full library never flashes "Add your Audible account" while loading, and it stands down mid-scan.

**Both at once.** `GetLibrary()` filters `IsDeleted`, so a library whose books are all in the trash reads as empty. Two states were wrong there. Without a filter it claimed "Libation is empty" while books sat in the trash; the panel now carries a trash line. With a filter it was worse - searching for a book that *is* in the trash showed "Libation is empty. Add your Audible account" and suppressed the trash hint, reintroducing the original bug in the one case where the library is empty.

The rule is now that someone searching is not someone getting started, so a filter always answers for itself:

[empty_library_still_points_at_the_trash.mp4](https://cursor.com/agents/bc-6ff1bfc7-305d-4d52-ab87-f69c83e07ce7/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fempty_library_still_points_at_the_trash.mp4)

That leaves one merely-suboptimal case - an empty library filtered to something in neither place says "no books match", which is true and better than claiming the library is empty while it is being filtered.

Both empty states share one set of strings in `GridEmptyStateUi`, rather than the no-matches pair living in `TrashBinUi` where they never belonged.

## 5. Two seeding scripts for manual testing

`Scripts/seed-demo-library.cs` now also seeds three books in the trash: a purchased title, a Plus title, and an episode whose series is still in the library, which exercises the trash bin's nesting.

`Scripts/seed-demo-accounts.cs` is new. Quite a lot of Libation is gated on the account count, and it is not one switch but two - nothing, one, or several - which changes the Import and Remove menus and which action the empty-library panel offers. None of it was reachable without signing in to Audible.

It appends rather than overwrites and `--clean` removes only the accounts it added, because this is the file holding real Audible tokens. Demo accounts are identified by id rather than a marker property: `Account` has no `[JsonExtensionData]`, so I confirmed a marker is silently dropped the first time the app saves, which would strand them. An id is immutable and always persisted, and `example.com` is reserved by RFC 2606 so no real login can collide.

Both are documented in `docs/development/testing.md`.

## 6. Document the trash bin

New `docs/features/trash-bin.md`, leading with the two things people get wrong: removing never touches your audio files, and **Permanently Delete from Libation** keeps a book away *less* effectively than the trash does. Libation recognizes a removed book on the next scan and leaves it in the trash; a permanently deleted book is one it has never seen before, so it is imported again like any other new title.

Also a troubleshooting entry, "A book in my Audible library is missing from Libation", starting with the trash bin and an active default Quick Filter since those account for most reports and neither leaves anything in the log.

## 7. Keep MaskedLogEntry out of AccountsSettings.json

Noticed while proving the point in section 5. `Account.MaskedLogEntry` is derived from `AccountId`, `AccountName` and `Locale` but had no `[JsonIgnore]`, so every save wrote a stale copy of three fields already in the file. `Locale` beside it was already ignored for the same reason.

Four tests pin the serialized shape: both computed properties stay out, the set of persisted members is asserted whole so a new property has to be a decision rather than an accident, and a file already carrying the stray key still loads and is rewritten without it.

---

## Verification

Built off `master` (af163df6). Avalonia and CLI build with 0 errors.

```
ApplicationServices    total: 104 failed: 0  succeeded: 104
AudibleUtilities       total: 97  failed: 0  succeeded: 95  skipped: 2
LibationUiBase         total: 165 failed: 0  succeeded: 165
FileLiberator          total: 68  failed: 0  succeeded: 68
FileManager            total: 214 failed: 0  succeeded: 214
LibationFileManager    total: 673 failed: 0  succeeded: 652 skipped: 21
LibationSearchEngine   total: 69  failed: 0  succeeded: 69
```

Every video and screenshot was captured from a real build, with books seeded straight into SQLite to reach each state and removed afterwards. `npx vitepress build` passes, which also confirms the new doc cross-links resolve since dead-link checking is on. Both seeding scripts were exercised end to end including `--clean`, and `seed-demo-accounts.cs --clean` was verified to leave an unrelated account in the same file untouched.

**The WinForms half is unverified.** It cannot be built on Linux, so `trashBinLbl`, `noMatchesPanel`, `emptyLibraryLbl`, `emptyLibraryActionLink`, `emptyLibraryTourLink`, `emptyLibraryTrashLink`, their designer registrations and the menu text update are code-reviewed only and need your check.

## Not included

Corroborating removals against `AbsentFromLastScan` over several scans. Sound idea, no reported instances, much more invasive.

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6ff1bfc7-305d-4d52-ab87-f69c83e07ce7?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6ff1bfc7-305d-4d52-ab87-f69c83e07ce7&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

