### PR TITLE
Name the caller in the book and PDF count logs

### DIFF
--- a/Source/ApplicationServices/LibraryCommands.cs
+++ b/Source/ApplicationServices/LibraryCommands.cs
@@ -11,6 +11,7 @@ using Serilog;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Runtime.CompilerServices;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
@@ -673,7 +674,12 @@ public static class LibraryCommands
 		}
 	}
 
-	public static LibraryStats GetCounts(IEnumerable<LibraryBook>? libraryBooks = null)
+	/// <param name="requestedBy">
+	/// Names the caller in the log. Both UIs count the whole library and the visible subset as the
+	/// library loads, and the two produce identical lines whenever no filter is applied, so without
+	/// this there is no way to tell which set a given count describes.
+	/// </param>
+	public static LibraryStats GetCounts(IEnumerable<LibraryBook>? libraryBooks = null, [CallerMemberName] string requestedBy = "")
 	{
 		libraryBooks ??= DbContexts.GetLibrary_Flat_NoTracking();
 
@@ -689,7 +695,7 @@ public static class LibraryCommands
 		var booksError = results.Count(r => r.status == LiberatedStatus.Error);
 		var booksUnavailable = results.Count(r => r.absent && r.status is LiberatedStatus.NotLiberated or LiberatedStatus.PartialDownload);
 
-		Log.Logger.Information("Book counts. {@DebugInfo}", new { total = results.Count, booksFullyBackedUp, booksDownloadedOnly, booksNoProgress, booksError, booksUnavailable });
+		Log.Logger.Information("Book counts for {RequestedBy}. {@DebugInfo}", requestedBy, new { total = results.Count, booksFullyBackedUp, booksDownloadedOnly, booksNoProgress, booksError, booksUnavailable });
 
 		var pdfResults = libraryBooks
 			.AsParallel()
@@ -701,7 +707,7 @@ public static class LibraryCommands
 		var pdfsNotDownloaded = pdfResults.Count(r => !r.absent && r.status == LiberatedStatus.NotLiberated);
 		var pdfsUnavailable = pdfResults.Count(r => r.absent && r.status == LiberatedStatus.NotLiberated);
 
-		Log.Logger.Information("PDF counts. {@DebugInfo}", new { total = pdfResults.Count, pdfsDownloaded, pdfsNotDownloaded, pdfsUnavailable });
+		Log.Logger.Information("PDF counts for {RequestedBy}. {@DebugInfo}", requestedBy, new { total = pdfResults.Count, pdfsDownloaded, pdfsNotDownloaded, pdfsUnavailable });
 
 		return new(booksFullyBackedUp, booksDownloadedOnly, booksNoProgress, booksError, booksUnavailable, pdfsDownloaded, pdfsNotDownloaded, pdfsUnavailable, libraryBooks);
 	}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
A startup log looks like it contains duplicated output:

```
[INF] ... Book counts. {"total":0,"booksFullyBackedUp":0, ...}
[INF] ... Book counts. {"total":0,"booksFullyBackedUp":0, ...}
[INF] ... PDF counts. {"total":0,"pdfsDownloaded":0, ...}
[INF] ... PDF counts. {"total":0,"pdfsDownloaded":0, ...}
```

It is not one call logged twice. Two callers count as the library loads, and `GetCounts` logs the same two lines for each of them. In Classic that is `setBackupCounts` (via `LibrarySizeChanged`) counting the whole library for the status bar and the "N remaining" menu items, and `setLiberatedVisibleMenuItem` (via `productsDisplay_VisibleCountChanged`) counting only the visible books for the "liberate visible" items. Chardonnay does the same through `MainVM.BackupCounts` and `MainVM.VisibleBooks`.

Whenever no filter is applied the two sets contain the same books, so the output really is identical, and there is no way to tell which set a given count describes or whether a difference between the pairs is a filter doing its job or a bug.

`[CallerMemberName]` distinguishes them without touching any call site, and without a label that the next caller can forget to pass.

## Verification

All 1467 tests pass and both UIs build. Running Chardonnay produces the two pairs, now attributable:

[book_count_log_tagged_by_caller.txt](https://cursor.com/agents/bc-99309e43-551e-4d2b-bb0f-622a596f3e8d/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fbook_count_log_tagged_by_caller.txt)

## Not addressed

The duplicated *work*. `GetCounts` hits the file system for every book, and on an unfiltered startup both callers do that pass over the same set. Deduplicating it is a larger question, since the two callers legitimately want different sets and only coincide when no filter is active, so this change just makes the log honest about what is happening.


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-99309e43-551e-4d2b-bb0f-622a596f3e8d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-99309e43-551e-4d2b-bb0f-622a596f3e8d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

