### PR TITLE
bugfix: WinForms defects found while testing #1970

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,10 +15,16 @@ plus a headless CLI (`LibationCli`) that shares the same config and SQLite libra
   `dotnet restore Source/Libation.slnx`. No other setup is needed.
 - The solution file is the new XML format: `Source/Libation.slnx` (there is no classic `.sln`).
 
-### Building — Linux only builds the cross-platform projects
-- Do **not** build the whole solution on Linux. Several projects are Windows/OS-specific and will
-  not build here: `LibationWinForms`, `HangoverWinForms` (target `net10.0-windows7.0`) and the
-  `LoadByOS/{Windows,MacOS}ConfigApp` helpers.
+### Building — everything compiles on Linux, only some of it runs
+- `dotnet build Source/Libation.slnx` succeeds on Linux with 0 errors. So do
+  `LibationWinForms`, `HangoverWinForms` and the `LoadByOS/{Windows,MacOS}ConfigApp` helpers,
+  individually: they target `net10.0-windows7.0` but set `EnableWindowsTargeting`, which is what makes
+  a non-Windows SDK build them. **Always compile-check a change to the WinForms projects** — an earlier
+  version of this file said they could not be built here, and a whole PR's worth of WinForms edits went
+  out unverified on the strength of that.
+- Compiling is not running. WinForms has no Linux runtime, so behaviour and layout in
+  `LibationWinForms` / `HangoverWinForms` still need a human on Windows. Say so explicitly rather than
+  implying a WinForms change was tested.
 - Build the runnable cross-platform apps directly:
   - `dotnet build Source/LibationAvalonia/LibationAvalonia.csproj`
   - `dotnet build Source/LibationCli/LibationCli.csproj`

--- a/Scripts/seed-demo-library.cs
+++ b/Scripts/seed-demo-library.cs
@@ -14,6 +14,9 @@ using System.Text.Json;
 // Reproducing every icon by hand is tedious, and two of them are not database state at all:
 // the yellow lamp means "a partial download is sitting on disk", so this writes placeholder
 // .aaxc files as well.
+//
+// Writing rows directly also leaves Libation's search index stale, which makes every filter on the
+// seeded books come back empty, so this deletes the index and lets Libation rebuild it.
 
 const int NotLiberated = 0, Liberated = 1, Error = 2;
 const int Product = 1, Episode = 2, Parent = 4;
@@ -52,6 +55,7 @@ if (clean)
 		File.Delete(partial);
 
 	Console.WriteLine($"Removed {removed} demo book(s) and their placeholder downloads.");
+	InvalidateSearchIndex();
 	return 0;
 }
 
@@ -136,6 +140,7 @@ foreach (var book in books)
 
 transaction.Commit();
 Console.WriteLine($"Added {added} book(s).");
+InvalidateSearchIndex();
 
 if (partials.Count > 0)
 {
@@ -147,6 +152,8 @@ if (partials.Count > 0)
 	Console.WriteLine($"Wrote {partials.Count} placeholder download(s) to {inProgress}");
 }
 
+Console.WriteLine();
+Console.WriteLine("Filtering covers these books. Try  HasSubtitle ,  TitleHasColon , or  Trashed  for no matches.");
 Console.WriteLine();
 Console.WriteLine("Start Libation and sort by Title. Expected Liberate column, top to bottom:");
 foreach (var book in books.Where(b => !b.IsDeleted))
@@ -396,6 +403,31 @@ string DownloadsInProgress()
 	}
 
 	return Path.Combine(inProgress, "DownloadsInProgress");
+}
+
+/// <summary>Delete the Lucene index so Libation rebuilds it from the database.</summary>
+/// <remarks>
+/// This script writes rows straight to SQLite, which leaves the index untouched, so every filter on the
+/// main grid came back empty no matter what had been seeded. Libation treats a missing index as a full
+/// re-index rather than an error, so deleting the folder is enough: the first search rebuilds it from the
+/// library, and the rebuild excludes trashed books the same way the grid does.
+/// </remarks>
+void InvalidateSearchIndex()
+{
+	var searchEngine = Path.Combine(libationFiles, "SearchEngine");
+	if (!Directory.Exists(searchEngine))
+		return;
+
+	try
+	{
+		Directory.Delete(searchEngine, recursive: true);
+		Console.WriteLine("Deleted the search index. Libation rebuilds it on the first search or filter.");
+	}
+	catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+	{
+		Console.Error.WriteLine($"Could not delete the search index at {searchEngine}: {ex.Message}");
+		Console.Error.WriteLine("Close Libation and delete that folder by hand, or filtering will not find the seeded books.");
+	}
 }
 
 /// <summary>Look up a row's id by its Audible id, inserting it first if it isn't there yet.</summary>

--- a/Source/LibationWinForms/Form1.BackupCounts.cs
+++ b/Source/LibationWinForms/Form1.BackupCounts.cs
@@ -24,6 +24,7 @@ public partial class Form1
 		trashBinLbl.Text = "";
 		trashBinLbl.Visible = false;
 		trashBinLbl.ToolTipText = LibationUiBase.TrashBinUi.StatusToolTip;
+		trashBinLbl.SetLinkLabelColors();
 		refreshBooksInTrash();
 
 		updateCountsBw.DoWork += UpdateCountsBw_DoWork;

--- a/Source/LibationWinForms/Form1.Filter.cs
+++ b/Source/LibationWinForms/Form1.Filter.cs
@@ -98,16 +98,23 @@ public partial class Form1
 
 			// The books are not gone, they are in the trash. Saying so keeps the headline above from
 			// reading as though they were never there.
-			emptyLibraryTrashLink.Visible = gettingStarted && booksInTrash > 0;
-			if (emptyLibraryTrashLink.Visible)
+			//
+			// Set the text from the count rather than from reading Visible back. Control.Visible returns
+			// effective visibility, walking up the parent chain, and noMatchesPanel is still hidden until
+			// further down - so on the first transition into an empty library the read-back was false and
+			// the link kept the empty Text it has from the designer. That is why the line only appeared
+			// once something else refreshed the panel while it was already on screen.
+			if (booksInTrash > 0)
 				SetTrashLink(emptyLibraryTrashLink, GridEmptyStateUi.EmptyLibraryTrashHintText(booksInTrash));
+			emptyLibraryTrashLink.Visible = gettingStarted && booksInTrash > 0;
 
 			noMatchesLbl.Text = GridEmptyStateUi.NoMatchesText(filterString);
 			noMatchesLbl.Visible = noMatches;
 			noMatchesTrashLink.Visible = false;
 
-			noMatchesPanel.Visible = gettingStarted || noMatches;
-			if (noMatchesPanel.Visible)
+			var showPanel = gettingStarted || noMatches;
+			noMatchesPanel.Visible = showPanel;
+			if (showPanel)
 				noMatchesPanel.BringToFront();
 		});
 

--- a/Source/LibationWinForms/Form1.Filter.cs
+++ b/Source/LibationWinForms/Form1.Filter.cs
@@ -10,7 +10,14 @@ namespace LibationWinForms;
 
 public partial class Form1
 {
-	protected void Configure_Filter() { }
+	protected void Configure_Filter()
+	{
+		//Changing the theme requires a restart, so link colors are set once here rather than on every refresh.
+		noMatchesTrashLink.SetLinkLabelColors();
+		emptyLibraryActionLink.SetLinkLabelColors();
+		emptyLibraryTourLink.SetLinkLabelColors();
+		emptyLibraryTrashLink.SetLinkLabelColors();
+	}
 
 	private void filterHelpBtn_Click(object sender, EventArgs e) => ShowSearchSyntaxDialog();
 

--- a/Source/LibationWinForms/ThemeExtensions.cs
+++ b/Source/LibationWinForms/ThemeExtensions.cs
@@ -28,6 +28,15 @@ internal static class ThemeExtensions
 		}
 	}
 
+	extension(ToolStripLabel tsl)
+	{
+		public void SetLinkLabelColors()
+		{
+			tsl.VisitedLinkColor = VisitedLinkColor;
+			tsl.LinkColor = LinkColor;
+		}
+	}
+
 	public static Rectangle GetPrimaryScreenWorkingArea()
 		=> Screen.PrimaryScreen is not null ? Screen.PrimaryScreen.WorkingArea
 		: Screen.AllScreens.Length > 0 ? Screen.AllScreens[0].WorkingArea

--- a/docs/development/testing.md
+++ b/docs/development/testing.md
@@ -85,6 +85,16 @@ Both commands are safe to re-run. Seeding skips books that are already present, 
 The seeded books are not real, so do not click their stoplights - that queues a download which cannot succeed. Expanding a seeded series row is fine.
 :::
 
+#### The search index
+
+The script writes rows straight to SQLite, which leaves Libation's Lucene index untouched, so seeded books were invisible to every search and filter until the index caught up. That made the empty-grid states impossible to test properly: with nothing findable, every filter produced **No books match**, whether or not that was the right answer.
+
+So the script deletes the `SearchEngine` folder in your Libation files directory and lets Libation rebuild it. That is not a workaround for a bug - a missing index is a state Libation already handles. `SearchEngineCommands.performSafeQuery` catches the `FileNotFoundException`, runs a full re-index from the database, and retries the query, so the first search after seeding rebuilds and returns the seeded books.
+
+The rebuild reads `GetLibrary_Flat_NoTracking`, which filters on `IsDeleted`, so trashed books stay out of the index exactly as they do in a normal Libation session. Filtering for `Trashed` therefore finds nothing in the grid while the trash bin still holds three matches - which is the state the empty-search trash hint needs.
+
+If the folder cannot be deleted, the script says so and carries on rather than failing. That normally means Libation is still open; close it and delete the folder by hand.
+
 #### Books in the trash
 
 Three of the seeded books are in the trash, and they are the only ones that will not be in the grid. Removal is a soft delete: `GetLibrary()` filters `IsDeleted` out, which takes a trashed book out of the grid, out of the search index and out of every status count at once. Nothing then distinguishes it from a book that was never imported, which is what made [#1925](https://github.com/rmcrackan/Libation/issues/1925) take a week to answer. These rows are how the affordances that fixed that are checked.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Collects the fixes found while working through the post-merge test plan for #1970.

# Fix 1: the trash line never appeared the first time the library went empty

## Repro

1. `dotnet run Scripts/seed-demo-library.cs`, start Libation - status bar correctly reads visible 30, "3 books in trash"
2. **Visible Books > Remove from library...**, confirm - status bar correctly updates to visible 0, "33 books in trash"
3. Centre panel shows "No books in your library yet." but the "33 books are in the trash." line and its Open Trash Bin link are **missing**
4. Open `Settings > Trash Bin`, close it - the trash line now appears
5. Restart: the bug is back, and opening the trash bin fixes it again

## Cause

`Control.Visible` returns *effective* visibility - the getter walks up the parent chain. The text was set behind a guard reading the property that had just been assigned:

```csharp
emptyLibraryTrashLink.Visible = gettingStarted && booksInTrash > 0;
if (emptyLibraryTrashLink.Visible)
    SetTrashLink(emptyLibraryTrashLink, ...);
...
noMatchesPanel.Visible = gettingStarted || noMatches;   // parent shown only here
```

On the first transition into an empty library, `noMatchesPanel` is still hidden, so the read-back is `false` even though `true` was just assigned. `SetTrashLink` is skipped and the `LinkLabel` renders the empty `Text` it carries from the designer, which never assigns one.

That accounts for every part of the report. The headline and both action links assign their `Text` unconditionally, so they showed and only the trash line was blank. Opening and closing the trash bin fixed it because by then the panel was already on screen and the read-back was true. A restart put it back because the panel starts hidden again.

Avalonia's XAML binds `Text` and `IsVisible` independently, so it never had this.

## Fix

Drive the text off the count rather than off a read-back, and use a local for the panel's own `BringToFront` guard so the same idiom isn't left in place next to it.

The `noMatchesTrashLink` path was already correct - it assigns `Text` before setting `Visible = true` - which is why the filter-plus-trash-hint case passed testing.

**Confirmed fixed on Windows.** The trash line now appears on the first transition.

# Fix 2: the new links were never themed

`ThemeExtensions.SetLinkLabelColors()` exists because the default WinForms link blue does not follow dark mode, and every other `LinkLabel` in the app calls it - seven call sites across `BookDetailsDialog` and `AboutDialog`. The five clickable pieces of text added by #1970 did not:

- `noMatchesTrashLink`, `emptyLibraryActionLink`, `emptyLibraryTourLink` and `emptyLibraryTrashLink` in the empty-grid block
- `trashBinLbl`, the clickable trash count in the status bar

So in dark mode all five kept the bright blue that the rest of the app deliberately overrides.

The four `LinkLabel`s are now themed once in `Configure_Filter()`. Doing it at setup rather than on every refresh is enough because changing the theme requires a restart, which the settings dialog already says.

`trashBinLbl` needed a little more: it is a `ToolStripStatusLabel` with `IsLink = true`, and the existing extension only had a `LinkLabel` receiver. `SetLinkLabelColors` now has a second receiver for `ToolStripLabel`, which covers both it and `ToolStripStatusLabel`.

Both receivers set only `LinkColor` and `VisitedLinkColor`, matching what the existing call sites do - `ActiveLinkColor` is left at its default everywhere in the app.

Avalonia has no equivalent gap: its empty-state actions and trash count are real `Button`s, themed by the framework.

**Confirmed on Windows** in both dark and light themes.

# Fix 3: seeded books were invisible to search

Not a product bug, but it blocked testing the feature this PR is about. `Scripts/seed-demo-library.cs` writes rows straight to SQLite, which leaves Libation's Lucene index untouched, so no filter ever matched a seeded book. That makes the empty-grid states untestable: with nothing findable, every filter produces **No books match** whether or not that is the right answer - including the trash hint, which only appears when a filter legitimately matches nothing in the grid.

The script now deletes the `SearchEngine` folder after seeding and after `--clean`. A missing index is a state Libation already handles rather than something to work around: `SearchEngineCommands.performSafeQuery` catches the `FileNotFoundException`, runs a full re-index from the database, and retries the query, so the first search rebuilds and returns the seeded books.

The rebuild reads `GetLibrary_Flat_NoTracking`, which filters `IsDeleted`, so trashed books stay out of the index exactly as in a normal session. That is what makes the hint testable: `Trashed` matches nothing in the grid while the trash still holds three books.

Verified end to end against a seeded library:

```
=== index files before seeding ===
_0.cfs
segments_2
segments.gen

=== seed-demo-library.cs ===
Deleted the search index. Libation rebuilds it on the first search or filter.

=== searching from a rebuilt index ===
index files present before any search: 0
  library search  HasSubtitle    -> 3 hit(s)
  library search  TitleHasColon  -> 2 hit(s)
  library search  Demo Series    -> 30 hit(s)
  library search  Trashed        -> 0 hit(s)
index files present after: 3
  trash search    Trashed        -> 3 hit(s)
      28 Trashed | purchased
      29 Trashed | PLUS
      30 Demo Series - episode 3 (trashed)
```

`docs/development/testing.md` documents the behaviour, including that the script reports and carries on rather than failing when the folder is locked, which normally means Libation is still open.

# A correction to AGENTS.md

While confirming the first diagnosis I found that AGENTS.md is wrong: it says `LibationWinForms`, `HangoverWinForms` and the `LoadByOS` ConfigApp helpers "will not build" on Linux. All of them do, and so does `dotnet build Source/Libation.slnx`, with 0 errors. They target `net10.0-windows7.0` but set `EnableWindowsTargeting`, which is what lets a non-Windows SDK build them.

I took that claim at face value and shipped #1970's WinForms half without ever compiling it. That bug would have survived a compile anyway, but several of the hand-edited designer changes could just as easily have failed outright.

The AGENTS.md commit rewrites that section and records the distinction the old text blurred: everything compiles on Linux, WinForms still cannot *run* on Linux, and those are different claims.

# Verification

`LibationWinForms` compiles with 0 errors - which I can now actually check. Avalonia and the full solution also build clean, and the docs site builds. Full test suite:

```
ApplicationServices    total: 104 failed: 0  succeeded: 104
AudibleUtilities       total: 97  failed: 0  succeeded: 95  skipped: 2
LibationUiBase         total: 169 failed: 0  succeeded: 169
FileLiberator          total: 68  failed: 0  succeeded: 68
FileManager            total: 214 failed: 0  succeeded: 214
LibationFileManager    total: 691 failed: 0  succeeded: 670 skipped: 21
LibationSearchEngine   total: 69  failed: 0  succeeded: 69
```

Fixes 1 and 2 are confirmed on Windows. Fix 3 is confirmed on Linux by the run above.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6ff1bfc7-305d-4d52-ab87-f69c83e07ce7?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6ff1bfc7-305d-4d52-ab87-f69c83e07ce7&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

