### PR TITLE
Move the .NET 10 package references to 10.0.11

### DIFF
--- a/Source/DataLayer.Postgres/DataLayer.Postgres.csproj
+++ b/Source/DataLayer.Postgres/DataLayer.Postgres.csproj
@@ -9,11 +9,11 @@
     <OutputType>Library</OutputType>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.7">
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.11">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="10.0.7">
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="10.0.11">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/Source/DataLayer.Sqlite/DataLayer.Sqlite.csproj
+++ b/Source/DataLayer.Sqlite/DataLayer.Sqlite.csproj
@@ -9,11 +9,11 @@
     <OutputType>Library</OutputType>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.7">
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.11">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="10.0.7">
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="10.0.11">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/Source/DataLayer/DataLayer.csproj
+++ b/Source/DataLayer/DataLayer.csproj
@@ -14,12 +14,12 @@
     <PackageReference Include="Dinah.Core" Version="10.2.4.1" />
     <PackageReference Include="Dinah.EntityFrameworkCore" Version="10.2.4.1" />
 	<PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.0.1" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.0.7" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.7">
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.0.11" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.11">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="10.0.7">
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="10.0.11">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/Source/LibationFileManager/LibationFileManager.csproj
+++ b/Source/LibationFileManager/LibationFileManager.csproj
@@ -7,7 +7,7 @@
 
   <ItemGroup>
     <PackageReference Include="AudibleApi" Version="11.0.3.1" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="10.0.7" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="10.0.11" />
     <PackageReference Include="NameParserSharp" Version="1.5.0" />
     <PackageReference Include="Serilog.Exceptions" Version="8.4.0" />
   </ItemGroup>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

Bumps every `Microsoft.*` .NET 10 package reference from `10.0.7` to `10.0.11`:

| Project | Package |
| --- | --- |
| `DataLayer` | `Microsoft.EntityFrameworkCore.Sqlite`, `.Design`, `.Tools` |
| `DataLayer.Sqlite` | `Microsoft.EntityFrameworkCore.Design`, `.Tools` |
| `DataLayer.Postgres` | `Microsoft.EntityFrameworkCore.Design`, `.Tools` |
| `LibationFileManager` | `Microsoft.Extensions.Configuration.Json` |

## Why

`dotnet restore Source/Libation.slnx` was emitting, once per project, across 23 projects:

```
warning NU1903: Package 'SQLitePCLRaw.lib.e_sqlite3' 2.1.11 has a known high
severity vulnerability, https://github.com/advisories/GHSA-2m69-gcr7-jv3q
```

`SQLitePCLRaw.lib.e_sqlite3` 2.1.11 bundles a SQLite older than 3.50.2, which is affected by
CVE-2025-6965 (aggregate terms can exceed the available columns, causing memory corruption).
Nothing in the repo asks for it directly - it arrives transitively from `DataLayer`'s one Sqlite
reference and then propagates to every project that reaches `DataLayer`:

`Microsoft.EntityFrameworkCore.Sqlite` -> `Microsoft.Data.Sqlite` -> `SQLitePCLRaw.bundle_e_sqlite3` -> `SQLitePCLRaw.lib.e_sqlite3`

EF Core 10.0.10 and earlier pinned `SQLitePCLRaw` 2.1.11. **10.0.11 is the first 10.0.x servicing
release to move to 2.1.12**, which is outside the advisory's affected range. So the fix is an
ordinary servicing bump - no `SQLitePCLRaw` version pin, no
`CentralPackageTransitivePinningEnabled`, and no jump to the SQLitePCLRaw 3.x core (which does not
land in EF Core proper until the 11.0 previews). Because one reference feeds all 23 projects,
bumping `DataLayer` alone clears every instance of the warning.

The `.Design`/`.Tools`/`Configuration.Json` references move alongside it so the repo stays on one
servicing band rather than drifting back into a resolution that reintroduces the old bundle.

`Npgsql.EntityFrameworkCore.PostgreSQL` 10.0.1 stays put; it accepts EF Core `[10.0.4, 11.0.0)`, so
10.0.11 is inside its supported range.

## Verification

- `dotnet restore Source/Libation.slnx`: clean, zero `NU1903` (was 23).
- `DataLayer/obj/project.assets.json` now resolves the whole `SQLitePCLRaw` graph at `2.1.12`.
- `dotnet build Source/LibationAvalonia/LibationAvalonia.csproj` and `Source/LibationCli/LibationCli.csproj` succeed; only the pre-existing SourceLink "source control information is not available" warnings remain.
- Test suites pass.
- No migrations or schema touched - this is a native-binary version change behind the same `Microsoft.Data.Sqlite` managed API.

## Companion change

`Dinah.Core` carries the same warning in `Dinah.EntityFrameworkCore.Tests` and gets the same
10.0.11 bump in [rmcrackan/Dinah.Core#28](https://github.com/rmcrackan/Dinah.Core/pull/28), keeping
the two repos on matching versions. `AudibleApi` references no `10.0.x` runtime packages, so it
never saw the warning and needs no change.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-69bbbcc0-545a-428a-9274-ac1d6549accb?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-69bbbcc0-545a-428a-9274-ac1d6549accb&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

