### PR TITLE
Update MSTest to 4.3.3

### DIFF
--- a/Source/_Tests/ApplicationServices.Tests/ApplicationServices.Tests.csproj
+++ b/Source/_Tests/ApplicationServices.Tests/ApplicationServices.Tests.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="MSTest" Version="4.2.2" />
+    <PackageReference Include="MSTest" Version="4.3.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Source/_Tests/AssertionHelper/AssertionHelper.csproj
+++ b/Source/_Tests/AssertionHelper/AssertionHelper.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="MSTest.TestFramework" Version="4.2.2" />
+    <PackageReference Include="MSTest.TestFramework" Version="4.3.3" />
   </ItemGroup>
 
 </Project>

--- a/Source/_Tests/AudibleUtilities.Tests/AudibleUtilities.Tests.csproj
+++ b/Source/_Tests/AudibleUtilities.Tests/AudibleUtilities.Tests.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="MSTest" Version="4.2.2" />
+    <PackageReference Include="MSTest" Version="4.3.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Source/_Tests/FileLiberator.Tests/FileLiberator.Tests.csproj
+++ b/Source/_Tests/FileLiberator.Tests/FileLiberator.Tests.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="MSTest" Version="4.2.2" />
+    <PackageReference Include="MSTest" Version="4.3.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Source/_Tests/FileManager.Tests/FileManager.Tests.csproj
+++ b/Source/_Tests/FileManager.Tests/FileManager.Tests.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="MSTest" Version="4.2.2" />
+    <PackageReference Include="MSTest" Version="4.3.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Source/_Tests/LibationCli.Tests/LibationCli.Tests.csproj
+++ b/Source/_Tests/LibationCli.Tests/LibationCli.Tests.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="MSTest" Version="4.2.2" />
+    <PackageReference Include="MSTest" Version="4.3.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Source/_Tests/LibationFileManager.Tests/LibationFileManager.Tests.csproj
+++ b/Source/_Tests/LibationFileManager.Tests/LibationFileManager.Tests.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="MSTest" Version="4.2.2" />
+    <PackageReference Include="MSTest" Version="4.3.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Source/_Tests/LibationSearchEngine.Tests/LibationSearchEngine.Tests.csproj
+++ b/Source/_Tests/LibationSearchEngine.Tests/LibationSearchEngine.Tests.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="MSTest" Version="4.2.2" />
+    <PackageReference Include="MSTest" Version="4.3.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Source/_Tests/LibationUiBase.Tests/LibationUiBase.Tests.csproj
+++ b/Source/_Tests/LibationUiBase.Tests/LibationUiBase.Tests.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="MSTest" Version="4.2.2" />
+    <PackageReference Include="MSTest" Version="4.3.3" />
     <!-- The Liberate icon tests rasterize with SkiaSharp, whose Linux native isn't
          brought in by the SkiaSharp package itself the way Windows' and macOS' are. -->
     <PackageReference Include="SkiaSharp.NativeAssets.Linux" Version="3.119.4" Condition="$([MSBuild]::IsOSPlatform('Linux'))" />


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

Bumps `MSTest` from 4.2.2 to 4.3.3 across the eight test projects, and `MSTest.TestFramework` to
4.3.3 in `AssertionHelper`.

## Why

Libation is already on the recommended MSTest 4.x arrangement - the `MSTest` metapackage,
`EnableMSTestRunner` in `Directory.Build.props`, test projects built as `Exe`, and the
Microsoft.Testing.Platform runner selected in `global.json`. Nothing structural to change here; this
only moves the version so all three repos name the same MSTest release. `AudibleApi` and
`Dinah.Core` were already on 4.3.3 and are being moved onto this same runner in
[rmcrackan/AudibleApi#80](https://github.com/rmcrackan/AudibleApi/pull/80) and
[rmcrackan/Dinah.Core#29](https://github.com/rmcrackan/dinah.core/pull/29).

`AssertionHelper` stays on `MSTest.TestFramework` alone rather than the metapackage, since it is a
shared helper library with no tests of its own and no need for a runner.

## Verification

`dotnet test` from `Source/` reports **1479 total, 0 failed, 23 skipped** - identical to the counts
on 4.2.2.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-69bbbcc0-545a-428a-9274-ac1d6549accb?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-69bbbcc0-545a-428a-9274-ac1d6549accb&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

