### PR TITLE
Adopt Dinah.Core 10.2.5.1 and AudibleApi 11.0.4.1

### DIFF
--- a/Source/AudibleUtilities/AudibleUtilities.csproj
+++ b/Source/AudibleUtilities/AudibleUtilities.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AudibleApi" Version="11.0.3.1" />
+    <PackageReference Include="AudibleApi" Version="11.0.4.1" />
     <PackageReference Include="Google.Protobuf" Version="3.34.1" />
   </ItemGroup>
 

--- a/Source/DataLayer/DataLayer.csproj
+++ b/Source/DataLayer/DataLayer.csproj
@@ -11,8 +11,8 @@
   </PropertyGroup>
   
   <ItemGroup>
-    <PackageReference Include="Dinah.Core" Version="10.2.4.1" />
-    <PackageReference Include="Dinah.EntityFrameworkCore" Version="10.2.4.1" />
+    <PackageReference Include="Dinah.Core" Version="10.2.5.1" />
+    <PackageReference Include="Dinah.EntityFrameworkCore" Version="10.2.5.1" />
 	<PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.0.1" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.0.7" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.7">

--- a/Source/FileManager/FileManager.csproj
+++ b/Source/FileManager/FileManager.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Dinah.Core" Version="10.2.4.1" />
+    <PackageReference Include="Dinah.Core" Version="10.2.5.1" />
     <PackageReference Include="Polly" Version="8.6.6" />
   </ItemGroup>
 

--- a/Source/LibationFileManager/LibationFileManager.csproj
+++ b/Source/LibationFileManager/LibationFileManager.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AudibleApi" Version="11.0.3.1" />
+    <PackageReference Include="AudibleApi" Version="11.0.4.1" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="10.0.7" />
     <PackageReference Include="NameParserSharp" Version="1.5.0" />
     <PackageReference Include="Serilog.Exceptions" Version="8.4.0" />

--- a/Source/LibationWinForms/LibationWinForms.csproj
+++ b/Source/LibationWinForms/LibationWinForms.csproj
@@ -41,7 +41,7 @@
 
 
 	<ItemGroup>
-		<PackageReference Include="Dinah.Core.WindowsDesktop" Version="10.2.4.1" />
+		<PackageReference Include="Dinah.Core.WindowsDesktop" Version="10.2.5.1" />
 		<PackageReference Include="Microsoft.Web.WebView2" Version="1.0.3912.50" />
 	</ItemGroup>
 

--- a/Source/_Demos/LoadByOS/CrossPlatformClientExe/CrossPlatformClientExe.csproj
+++ b/Source/_Demos/LoadByOS/CrossPlatformClientExe/CrossPlatformClientExe.csproj
@@ -19,7 +19,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Dinah.Core" Version="10.2.4.1" />
+    <PackageReference Include="Dinah.Core" Version="10.2.5.1" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

Moves all six sibling package references onto the newly published versions:

| Project | Package | From | To |
| --- | --- | --- | --- |
| `FileManager` | `Dinah.Core` | 10.2.4.1 | 10.2.5.1 |
| `DataLayer` | `Dinah.Core` | 10.2.4.1 | 10.2.5.1 |
| `DataLayer` | `Dinah.EntityFrameworkCore` | 10.2.4.1 | 10.2.5.1 |
| `_Demos/LoadByOS/CrossPlatformClientExe` | `Dinah.Core` | 10.2.4.1 | 10.2.5.1 |
| `LibationWinForms` | `Dinah.Core.WindowsDesktop` | 10.2.4.1 | 10.2.5.1 |
| `AudibleUtilities` | `AudibleApi` | 11.0.3.1 | 11.0.4.1 |
| `LibationFileManager` | `AudibleApi` | 11.0.3.1 | 11.0.4.1 |

## Why

Both upstreams moved their .NET 10 dependency floors to 10.0.11 and published under new versions:
`Dinah.Core` / `Dinah.EntityFrameworkCore` / `Dinah.Core.WindowsDesktop` 10.2.5.1 from
[rmcrackan/Dinah.Core#28](https://github.com/rmcrackan/dinah.core/pull/28) and
[#30](https://github.com/rmcrackan/dinah.core/pull/30), and `AudibleApi` 11.0.4.1 from
[rmcrackan/AudibleApi#80](https://github.com/rmcrackan/AudibleApi/pull/80). This is the last repo in
that chain.

## Verification

- `dotnet restore Source/Libation.slnx` resolves `Dinah.Core` 10.2.5.1, `Dinah.EntityFrameworkCore` 10.2.5.1, `Dinah.Core.WindowsDesktop` 10.2.5.1 and `AudibleApi` 11.0.4.1, with no new warnings.
- `LibationAvalonia`, `LibationCli` and `LibationWinForms` all build with 0 errors.
- `dotnet test` from `Source/`: **1479 total, 0 failed, 23 skipped** - unchanged.

## Note on NU1903

Restore still reports the `SQLitePCLRaw.lib.e_sqlite3` 2.1.11 advisory on this branch, and that is
expected. `DataLayer` references `Microsoft.EntityFrameworkCore.Sqlite` 10.0.7 directly, and that
reference is what pulls the vulnerable native bundle; picking up `Dinah.EntityFrameworkCore`'s new
`EntityFrameworkCore.Relational` 10.0.11 floor does not change it. The Sqlite bump that clears the
warning is [#1974](https://github.com/rmcrackan/libation/pull/1974).

## Related

Independent of the two other open PRs, [#1974](https://github.com/rmcrackan/libation/pull/1974) and
[#1975](https://github.com/rmcrackan/libation/pull/1975). #1974 also touches
`DataLayer/DataLayer.csproj` and `LibationFileManager/LibationFileManager.csproj`, but on different
lines (`Microsoft.*` versions rather than the `Dinah.*` / `AudibleApi` ones), so they merge in either
order.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-69bbbcc0-545a-428a-9274-ac1d6549accb?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-69bbbcc0-545a-428a-9274-ac1d6549accb&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

