### PR TITLE
Generate real source links for the built assemblies

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -2,4 +2,12 @@
   <PropertyGroup>
     <EnableMSTestRunner>true</EnableMSTestRunner>
   </PropertyGroup>
+
+  <ItemGroup>
+    <!-- The SDK supplies Microsoft.SourceLink.Common and the git tasks, which is enough to find the
+         repository but not to turn its URL into fetchable source URLs. Without a host provider every
+         project warns that the generated source link is empty and ships PDBs that cannot locate their
+         sources. -->
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="10.0.301" PrivateAssets="All" />
+  </ItemGroup>
 </Project>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

Adds `Microsoft.SourceLink.GitHub` 10.0.301 to `Directory.Build.props`, so it applies to every
project. One file, eight lines.

## Why

Every build emitted, once per project:

```
warning : Source control information is not available - the generated source link is empty.
```

477 times in the last `validate` run.

SourceLink's job is to embed a map in the PDB from each compiled source path to a URL where that
exact revision can be fetched, which is what lets a debugger pull matching sources for a built
binary. The warning means that map came out empty, so the PDBs shipped without it.

The repository was never the problem. The build resolves the URL and commit fine:

```
SourceRoot: /.../libation/  RepoUrl=https://github.com/rmcrackan/libation  SourceLinkUrl=
```

`SourceLinkUrl` was blank because no SourceLink **host provider** was referenced anywhere in the
repo. The SDK supplies `Microsoft.SourceLink.Common` - which is what emits the warning - along with
the git tasks that find the repository, but nothing translated a `github.com` remote into
`raw.githubusercontent.com` URLs. `AudibleApi` builds warning-free precisely because it references
this provider explicitly, so this brings Libation in line.

## Verification

The generated map is now populated:

```json
{"documents":{"/agent/repos/libation/*":"https://raw.githubusercontent.com/rmcrackan/libation/63dc8fc.../*"}}
```

- Clean rebuilds of `LibationAvalonia`, `LibationCli` and `LibationWinForms`: 0 errors, and zero occurrences of the warning.
- `dotnet test` from `Source/`: 1479 total, 0 failed, 23 skipped - unchanged.

`PrivateAssets="All"` keeps it out of anything downstream; it only affects the build.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-69bbbcc0-545a-428a-9274-ac1d6549accb?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-69bbbcc0-545a-428a-9274-ac1d6549accb&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

