### PR TITLE
Fix QuickFilters not loading from disk after restart (#1979)

### DIFF
--- a/Source/LibationFileManager/Configuration.PersistentSettings.cs
+++ b/Source/LibationFileManager/Configuration.PersistentSettings.cs
@@ -203,8 +203,18 @@ public partial class Configuration
 	[Description("Lame encoder target. true = Bitrate, false = Quality")]
 	public bool LameTargetBitrate { get => GetNonString(defaultValue: false); set => SetNonString(value); }
 
+	/// <summary>
+	/// Clamped to LAME's supported range: a pre-v11.6.5 or hand-edited Settings.json may hold a defined
+	/// but unsupported rate such as Hz_7350 or Hz_96000, which fails the encoder (#1116). Enum validation
+	/// alone cannot catch these because they are valid <see cref="AAXClean.SampleRate"/> members.
+	/// </summary>
 	[Description("Maximum audio sample rate")]
-	public AAXClean.SampleRate MaxSampleRate { get => GetNonString(defaultValue: AAXClean.SampleRate.Hz_44100); set => SetNonString(value); }
+	public AAXClean.SampleRate MaxSampleRate { get => clampSampleRate(GetNonString(defaultValue: AAXClean.SampleRate.Hz_44100)); set => SetNonString(clampSampleRate(value)); }
+
+	private static AAXClean.SampleRate clampSampleRate(AAXClean.SampleRate rate)
+		=> rate < AAXClean.SampleRate.Hz_8000 ? AAXClean.SampleRate.Hz_8000
+		: rate > AAXClean.SampleRate.Hz_48000 ? AAXClean.SampleRate.Hz_48000
+		: rate;
 
 	[Description("Lame encoder quality")]
 	public NAudio.Lame.EncoderQuality LameEncoderQuality { get => GetNonString(defaultValue: NAudio.Lame.EncoderQuality.High); set => SetNonString(value); }

--- a/Source/LibationFileManager/LibationFiles.cs
+++ b/Source/LibationFileManager/LibationFiles.cs
@@ -10,6 +10,7 @@ using System.Runtime.CompilerServices;
 
 [assembly: InternalsVisibleTo("AppScaffolding")]
 [assembly: InternalsVisibleTo("LibationUiBase.Tests")]
+[assembly: InternalsVisibleTo("LibationFileManager.Tests")]
 
 namespace LibationFileManager;
 

--- a/Source/LibationFileManager/QuickFilters.cs
+++ b/Source/LibationFileManager/QuickFilters.cs
@@ -4,6 +4,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Threading;
 
 namespace LibationFileManager;
 
@@ -167,7 +168,7 @@ public static class QuickFilters
 		}
 	}
 
-	private static object locker { get; } = new();
+	private static Lock locker { get; } = new();
 
 	// ONLY call this within lock()
 	private static void save(bool invokeUpdatedEvent = true)

--- a/Source/LibationFileManager/QuickFilters.cs
+++ b/Source/LibationFileManager/QuickFilters.cs
@@ -22,15 +22,71 @@ public static class QuickFilters
 	public static string JsonFile => Path.Combine(Configuration.Instance.LibationFiles.Location, "QuickFilters.json");
 
 
-	// load json into memory. if file doesn't exist, nothing to do. save() will create if needed
-	public static FilterState? InMemoryState { get; set; }
+	// Lazily loaded from JsonFile on first access. If the file doesn't exist, starts empty; save() will create it if needed.
+	private static FilterState? inMemoryState;
+	private static FilterState InMemoryState
+	{
+		get
+		{
+			lock (locker)
+				return inMemoryState ??= LoadFromFile(JsonFile);
+		}
+	}
+
+	/// <summary>Discard the in-memory state so the next access reloads from disk. For testing.</summary>
+	internal static void Reset()
+	{
+		lock (locker)
+			inMemoryState = null;
+	}
+
+	internal static FilterState LoadFromFile(string jsonFile)
+	{
+		try
+		{
+			if (!File.Exists(jsonFile))
+				return new();
+
+			var json = File.ReadAllText(jsonFile);
+
+			try
+			{
+				if (JsonConvert.DeserializeObject<FilterState>(json) is FilterState state)
+					return state;
+			}
+			catch
+			{
+				// fall through and try the legacy format
+			}
+
+			if (JsonConvert.DeserializeObject<FilterState_v11_4>(json) is FilterState_v11_4 legacyState)
+			{
+				var state = new FilterState { UseDefault = legacyState.UseDefault };
+				foreach (var filter in legacyState.Filters)
+					state.Filters.Add(new NamedFilter(filter, null));
+				return state;
+			}
+		}
+		catch (Exception ex)
+		{
+			Serilog.Log.Logger.Error(ex, "Error loading QuickFilters.json");
+		}
+		return new();
+	}
+
+	// Format used until v11.5.0: filters were plain strings without names
+	private class FilterState_v11_4
+	{
+		public bool UseDefault { get; set; }
+		public List<string> Filters { get; set; } = new();
+	}
 
 	public static bool UseDefault
 	{
-		get => InMemoryState?.UseDefault ?? false;
+		get => InMemoryState.UseDefault;
 		set
 		{
-			if (InMemoryState is null || UseDefault == value)
+			if (UseDefault == value)
 				return;
 
 			lock (locker)
@@ -52,7 +108,7 @@ public static class QuickFilters
 	}
 
 	public static IEnumerable<NamedFilter> Filters
-		=> InMemoryState?.Filters.AsReadOnly() ?? Enumerable.Empty<NamedFilter>();
+		=> InMemoryState.Filters.AsReadOnly();
 
 	public static void Add(NamedFilter namedFilter)
 	{
@@ -66,7 +122,6 @@ public static class QuickFilters
 
 		lock (locker)
 		{
-			InMemoryState ??= new();
 			// check for duplicates
 			if (InMemoryState.Filters.Select(x => x.Filter).ContainsInsensative(namedFilter.Filter))
 				return;
@@ -80,8 +135,6 @@ public static class QuickFilters
 	{
 		lock (locker)
 		{
-			if (InMemoryState is null)
-				return;
 			InMemoryState.Filters.Remove(filter);
 			save();
 		}
@@ -91,7 +144,7 @@ public static class QuickFilters
 	{
 		lock (locker)
 		{
-			if (InMemoryState is null || InMemoryState.Filters.IndexOf(oldFilter) < 0)
+			if (InMemoryState.Filters.IndexOf(oldFilter) < 0)
 				return;
 
 			InMemoryState.Filters = InMemoryState.Filters.Select(f => f == oldFilter ? newFilter : f).ToList();
@@ -109,7 +162,6 @@ public static class QuickFilters
 			filter.Filter = filter.Filter.Trim();
 		lock (locker)
 		{
-			InMemoryState ??= new();
 			InMemoryState.Filters = new List<NamedFilter>(filters);
 			save();
 		}

--- a/Source/_Tests/LibationFileManager.Tests/MaxSampleRateTests.cs
+++ b/Source/_Tests/LibationFileManager.Tests/MaxSampleRateTests.cs
@@ -1,0 +1,71 @@
+using AAXClean;
+using AssertionHelper;
+using LibationFileManager;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace MaxSampleRateTests;
+
+[TestClass]
+[DoNotParallelize]
+public class MaxSampleRateTests
+{
+	[TestCleanup]
+	public void Cleanup() => Configuration.RestoreSingletonInstance();
+
+	[TestMethod]
+	public void Default_when_missing_is_Hz_44100()
+	{
+		var config = Configuration.CreateMockInstance();
+
+		config.Exists(nameof(Configuration.MaxSampleRate)).Should().BeFalse();
+		Assert.AreEqual(SampleRate.Hz_44100, config.MaxSampleRate);
+	}
+
+	[TestMethod]
+	public void In_range_values_round_trip_unchanged()
+	{
+		var config = Configuration.CreateMockInstance();
+
+		config.MaxSampleRate = SampleRate.Hz_8000;
+		Assert.AreEqual(SampleRate.Hz_8000, config.MaxSampleRate);
+
+		config.MaxSampleRate = SampleRate.Hz_22050;
+		Assert.AreEqual(SampleRate.Hz_22050, config.MaxSampleRate);
+
+		config.MaxSampleRate = SampleRate.Hz_48000;
+		Assert.AreEqual(SampleRate.Hz_48000, config.MaxSampleRate);
+	}
+
+	[TestMethod]
+	public void Setter_clamps_out_of_range_values()
+	{
+		var config = Configuration.CreateMockInstance();
+
+		config.MaxSampleRate = SampleRate.Hz_7350;
+		Assert.AreEqual(SampleRate.Hz_8000, config.MaxSampleRate);
+
+		config.MaxSampleRate = SampleRate.Hz_96000;
+		Assert.AreEqual(SampleRate.Hz_48000, config.MaxSampleRate);
+	}
+
+	[TestMethod]
+	public void Getter_clamps_a_hand_edited_low_rate()
+	{
+		var config = Configuration.CreateMockInstance();
+
+		// Bypass the property setter, as a hand-edited Settings.json or a pre-v11.6.5 install would
+		config.SetNonString(nameof(SampleRate.Hz_7350), nameof(Configuration.MaxSampleRate));
+
+		Assert.AreEqual(SampleRate.Hz_8000, config.MaxSampleRate);
+	}
+
+	[TestMethod]
+	public void Getter_clamps_a_hand_edited_high_rate()
+	{
+		var config = Configuration.CreateMockInstance();
+
+		config.SetNonString(nameof(SampleRate.Hz_96000), nameof(Configuration.MaxSampleRate));
+
+		Assert.AreEqual(SampleRate.Hz_48000, config.MaxSampleRate);
+	}
+}

--- a/Source/_Tests/LibationFileManager.Tests/QuickFiltersTests.cs
+++ b/Source/_Tests/LibationFileManager.Tests/QuickFiltersTests.cs
@@ -1,0 +1,158 @@
+using AssertionHelper;
+using LibationFileManager;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.IO;
+using System.Linq;
+
+namespace QuickFiltersTests;
+
+[TestClass]
+[DoNotParallelize]
+public class QuickFiltersTests
+{
+	private string tempDir = null!;
+
+	[TestInitialize]
+	public void Initialize()
+	{
+		tempDir = Path.Combine(Path.GetTempPath(), "QuickFiltersTests_" + Guid.NewGuid().ToString("N"));
+		Directory.CreateDirectory(tempDir);
+
+		Environment.SetEnvironmentVariable(LibationFiles.LIBATION_FILES_DIR, tempDir);
+		Configuration.CreateMockInstance();
+		QuickFilters.Reset();
+	}
+
+	[TestCleanup]
+	public void Cleanup()
+	{
+		QuickFilters.Reset();
+		Configuration.RestoreSingletonInstance();
+		Environment.SetEnvironmentVariable(LibationFiles.LIBATION_FILES_DIR, null);
+		try { Directory.Delete(tempDir, recursive: true); } catch { }
+	}
+
+	private string JsonFile => Path.Combine(tempDir, "QuickFilters.json");
+
+	#region loading from file
+
+	[TestMethod]
+	public void Loads_current_format_from_file()
+	{
+		// Exact file contents attached to issue #1979
+		File.WriteAllText(JsonFile, """
+			{
+			  "UseDefault": false,
+			  "Filters": [
+			    {
+			      "Filter": "!IsPodcast&!IsLiberated&!Absent",
+			      "Name": "!IsPodcast&!IsLiberated&!Absent"
+			    }
+			  ]
+			}
+			""");
+
+		var state = QuickFilters.LoadFromFile(JsonFile);
+
+		state.UseDefault.Should().BeFalse();
+		state.Filters.Count.Should().Be(1);
+		state.Filters[0].Filter.Should().Be("!IsPodcast&!IsLiberated&!Absent");
+		state.Filters[0].Name.Should().Be("!IsPodcast&!IsLiberated&!Absent");
+	}
+
+	[TestMethod]
+	public void Loads_legacy_pre_11_5_0_format_from_file()
+	{
+		File.WriteAllText(JsonFile, """
+			{
+			  "UseDefault": true,
+			  "Filters": [ "tag1", "author:Sanderson" ]
+			}
+			""");
+
+		var state = QuickFilters.LoadFromFile(JsonFile);
+
+		state.UseDefault.Should().BeTrue();
+		state.Filters.Select(f => f.Filter).Should().BeEquivalentTo(new[] { "tag1", "author:Sanderson" });
+		state.Filters.All(f => f.Name == null).Should().BeTrue();
+	}
+
+	[TestMethod]
+	public void Missing_file_yields_empty_state()
+	{
+		var state = QuickFilters.LoadFromFile(JsonFile);
+
+		state.UseDefault.Should().BeFalse();
+		state.Filters.Should().HaveCount(0);
+	}
+
+	[TestMethod]
+	public void Malformed_file_yields_empty_state_without_throwing()
+	{
+		File.WriteAllText(JsonFile, "this is not json {{{");
+
+		var state = QuickFilters.LoadFromFile(JsonFile);
+
+		state.UseDefault.Should().BeFalse();
+		state.Filters.Should().HaveCount(0);
+	}
+
+	#endregion
+
+	#region persistence across restarts (issue #1979)
+
+	[TestMethod]
+	public void Filters_survive_restart()
+	{
+		QuickFilters.Add(new QuickFilters.NamedFilter("!IsPodcast&!IsLiberated&!Absent", "My filter"));
+		File.Exists(JsonFile).Should().BeTrue();
+
+		// Simulate an app restart: discard all in-memory state
+		QuickFilters.Reset();
+
+		var filters = QuickFilters.Filters.ToList();
+		filters.Count.Should().Be(1);
+		filters[0].Filter.Should().Be("!IsPodcast&!IsLiberated&!Absent");
+		filters[0].Name.Should().Be("My filter");
+	}
+
+	[TestMethod]
+	public void Adding_after_restart_appends_instead_of_overwriting()
+	{
+		QuickFilters.Add(new QuickFilters.NamedFilter("filter one", null));
+		QuickFilters.Reset();
+
+		QuickFilters.Add(new QuickFilters.NamedFilter("filter two", null));
+
+		QuickFilters.Filters.Select(f => f.Filter).Should().BeEquivalentTo(new[] { "filter one", "filter two" });
+
+		// And the file on disk has both, too
+		QuickFilters.Reset();
+		QuickFilters.Filters.Select(f => f.Filter).Should().BeEquivalentTo(new[] { "filter one", "filter two" });
+	}
+
+	[TestMethod]
+	public void UseDefault_survives_restart()
+	{
+		QuickFilters.Add(new QuickFilters.NamedFilter("some filter", null));
+		QuickFilters.UseDefault = true;
+
+		QuickFilters.Reset();
+
+		QuickFilters.UseDefault.Should().BeTrue();
+	}
+
+	[TestMethod]
+	public void UseDefault_can_be_set_before_any_filter_is_added()
+	{
+		QuickFilters.UseDefault = true;
+
+		QuickFilters.Reset();
+
+		QuickFilters.UseDefault.Should().BeTrue();
+		QuickFilters.Filters.Should().HaveCount(0);
+	}
+
+	#endregion
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes [#1979](https://github.com/rmcrackan/Libation/issues/1979): quick filters saved to `QuickFilters.json` were no longer available after restarting the app, and adding a new filter after a restart overwrote the file.

Auditing the commit that caused it turned up a second, latent regression from the same migration cleanup, also fixed here (see below).

## Root cause

Commit 065118cf (first shipped in v13.7.6) deleted `Migrations.migrate_to_v11_5_0` as a dead migration. Despite its name, that method ran on every startup from `RunPostConfigMigrations` and was the only code that read `QuickFilters.json` into `QuickFilters.InMemoryState`. With it gone, `InMemoryState` stayed `null`:

- `QuickFilters.Filters` returned an empty enumerable, so the Quick Filters menu was empty after restart.
- `Add` did `InMemoryState ??= new()` and then saved, overwriting the file with only the new filter.
- Nothing was logged because every code path silently tolerated the null state.

## Fix

- `QuickFilters` now lazily loads its state from `QuickFilters.json` on first access (guarded by the existing lock), so it no longer depends on a startup hook that looks like removable migration code.
- The pre-v11.5.0 format fallback (filters as plain strings without names) that the deleted migration provided is restored, so users upgrading straight from old versions keep their filters.
- A missing or malformed file yields an empty state without throwing (malformed files log an error).
- Side-effect fix: the "first filter is default" toggle can now be persisted even before any filter has been added in the session (the `UseDefault` setter previously no-oped while `InMemoryState` was null).
- The `QuickFilters` locker is now a `System.Threading.Lock`, matching `PersistentDictionary` and `LibationAvalonia.Program`.

## Second regression from the same cleanup: MaxSampleRate clamp

Commit 065118cf also deleted `migrate_to_v11_6_5`, which clamped `MaxSampleRate` into LAME's supported [`Hz_8000`, `Hz_48000`] range on every startup (the fix for [#1116](https://github.com/rmcrackan/Libation/issues/1116)). Its replacement, `ValidateEnumSettings`, only rejects values that fail to parse - but `AAXClean.SampleRate` defines `Hz_7350`, `Hz_64000`, `Hz_88200` and `Hz_96000`, so a hand-edited or pre-v11.6.5 `Settings.json` could carry a valid-but-unsupported rate straight into the encoder via `GetLameOptions`. The clamp is restored in the `MaxSampleRate` property getter and setter (following the `DailyDownloadLimitQuantity` pattern), so it too no longer depends on a startup hook.

(The third deleted migration, `migrate_to_v6_6_9`'s Serilog fixups, was left alone: its removal only softens log quality for configs that predate v6.6.9 and never ran a version in between, and force-rewriting `outputTemplate` clashed with the commit's intent of not clobbering hand-edited configs.)

## Testing

- New regression tests in `Source/_Tests/LibationFileManager.Tests/QuickFiltersTests.cs`: loading the exact JSON attached to the issue, the legacy string format, missing/malformed files, and restart-persistence scenarios (add -> reset -> still present; add after reset appends instead of overwriting; `UseDefault` persistence).
- New tests in `Source/_Tests/LibationFileManager.Tests/MaxSampleRateTests.cs`: default, in-range round-trips, setter clamping, and getter clamping of hand-edited out-of-range values.
- Full suite passes (`dotnet test` from `Source/`, all 8 projects, 1492 tests).
- Manually verified in the Avalonia GUI on Linux with the seeded demo library: added the issue's filter `!IsPodcast&!IsLiberated&!Absent`, closed the app, relaunched, and the filter is present in the Quick Filters menu and applies correctly (Visible Books 30 -> 18).

Filter added in the first session:

[Quick filter added before restart](https://cursor.com/agents/bc-329ca6b3-38c5-45f7-b711-6d80848dc279/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fquick_filter_added_before_restart.webp)

After restarting the app, the menu still has it and clicking it filters the grid:

[quick_filter_persists_after_restart.mp4](https://cursor.com/agents/bc-329ca6b3-38c5-45f7-b711-6d80848dc279/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fquick_filter_persists_after_restart.mp4)

WinForms note: the fixes are entirely in shared `LibationFileManager` code and the solution (including `LibationWinForms`, which consumes `MaxSampleRate` in its settings dialog) compiles with 0 errors, but WinForms behaviour was not run on Windows.

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-329ca6b3-38c5-45f7-b711-6d80848dc279?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-329ca6b3-38c5-45f7-b711-6d80848dc279&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

