### PR TITLE
Add parallel recursive directory scan for performance improvement

### DIFF
--- a/Source/FileManager/BackgroundFileSystem.cs
+++ b/Source/FileManager/BackgroundFileSystem.cs
@@ -191,14 +191,32 @@ public class BackgroundFileSystem : IDisposable
 
 	private IEnumerable<LongPath> SafestEnumerateFiles(string path)
 	{
-		try
+		var shouldRecurse = SearchOption == SearchOption.AllDirectories;
+		var results = new ConcurrentBag<LongPath>();
+
+		// Internal function to (optionally) recursively scan each subdirectory.
+		// Parallel.ForEach speeds results by an order of magnitude for large
+		// libraries, especially over high-latency connections.
+
+		void walk(string dir)
 		{
-			return FileUtility.SaferEnumerateFiles(path, SearchPattern, SearchOption);
+			try
+			{
+				var files = FileUtility.SaferEnumerateFiles(dir,
+															SearchPattern,
+															SearchOption.TopDirectoryOnly);
+				foreach (var file in files)
+					results.Add(file);
+				if (shouldRecurse)
+					Parallel.ForEach(Directory.EnumerateDirectories(dir), walk);
+			}
+			catch { }
 		}
-		catch
-		{
-			return [];
-		}
+
+		// Actually execute the directory walk and return the results
+
+		walk(path);
+		return results;
 	}
 
 	private void AddUniqueFiles(IEnumerable<LongPath> newFiles)


### PR DESCRIPTION
Introducing myself with this tiny (but impactful) change before hitting you with a massive PR for a LocalLibraryManager subproject that I accidentally got myself tangled up in. While working on that, I discovered that parallelizing the process of walking directory trees resulted in a massive (10x or more) performance bump.

Although unrelated to my other effort, I encountered the issue here, as well, because I was diagnosing the cause of slow startup on CLI commands. I have my library (> 700 books/1100 files) stored on an SMB share, and it was taking 3 to 4 seconds just to get to the point that you called ProcessAsync on a CLI Option. This PR reduces that to around 1 second.

I'm sure the change is imperceptible for small libraries stored on local SSD's. But I'm confident that it shouldn't hurt anything either. Builds and tests pass (except for one pre-existing fail) on both Windows and Linux (WSL).

Separately, have you considered temporarily bumping the SQLitePCLRaw version to get rid of those scary warnings:

```
warning NU1903: Package 'SQLitePCLRaw.lib.e_sqlite3' 2.1.11 has a known 
high severity vulnerability, https://github.com/advisories/GHSA-2m69-gcr7-jv3q
```

Just need to add something like this to DataLayer.csproj.

```
  <ItemGroup>
    <!--
      Explicitly overrides the EF Core transitive dependency to drop the
      vulnerable 2.x package. Remove when Microsoft.EntityFrameworkCore.Sqlite
      ships with the updated binary, supposedly with v11.
    -->
    <PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" Version="3.0.5" />
  </ItemGroup>
```
