### PR TITLE
Fix flaky CatastrophicBacktracking_AnchoredRepeated (#1982)

### DIFF
--- a/Source/_Tests/FileManager.Tests/ConditionalTagCollectionTests.cs
+++ b/Source/_Tests/FileManager.Tests/ConditionalTagCollectionTests.cs
@@ -65,7 +65,9 @@ public class ConditionalTagCollectionTests
 	[DataRow("(a|aa|aaa|aaaa)*?b", "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", DisplayName = "CatastrophicBacktracking_AlternationOverlap")]
 	// (a+a+)+b needs a longer input than other evil-regex cases to exceed the 100ms match timeout on .NET
 	[DataRow("(a+a+)+b", "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", DisplayName = "CatastrophicBacktracking_RepeatedConcatenation")]
-	[DataRow("^(a+)+$", "aaaaaaaaaaaaaaaaaaaaaab", DisplayName = "CatastrophicBacktracking_AnchoredRepeated")]
+	// ^(a+)+$ needs the longer input too: with 22 a's a fast machine finishes the match inside the
+	// 100ms timeout, so nothing throws and the row fails
+	[DataRow("^(a+)+$", "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaab", DisplayName = "CatastrophicBacktracking_AnchoredRepeated")]
 	[DataRow("(a*)*b", "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", DisplayName = "CatastrophicBacktracking_StarStar")]
 	public void ConditionalTag_InvalidRegexPattern_ThrowsInvalidOperationException(string pattern, string testValue)
 	{


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Addresses [#1982](https://github.com/rmcrackan/Libation/issues/1982). Keeps the row, removes the machine-speed dependence.

Worth noting that #1982 was closed by the reporter rather than resolved: no fix landed, so the flaky row is still on `master` exactly as described.

## The problem

`ConditionalTag_InvalidRegexPattern_ThrowsInvalidOperationException` asserts that an evil regex trips `CompareCondition`'s 100 ms match timeout and gets translated into an `InvalidOperationException`. That only holds while the match genuinely takes longer than 100 ms. If it completes, nothing throws and the row falls through to its own `Assert.Fail`.

`^(a+)+$` against 22 a's is right on that line. Measured on the CI-class 4-core Xeon this ran on, the match completes in ~350 ms, i.e. only 3.5x the deadline. Anything more than ~3.5x faster than that box completes it inside the budget and the row fails. The reporter measured ~50 ms, consistent with a machine roughly 7x faster.

The other four catastrophic rows are nowhere near the line: none of them completes in 20 s, so their margin is over 200x and in reality astronomically larger. The anchored row was the only marginal one, and it is the leftover of 9ed98cbf, which gave `(a+a+)+b` exactly this treatment and left `^(a+)+$` at its shorter input.

## The fix

Lengthen the input from 22 a's to 50, matching the sibling row. The work doubles per added character (verified: every measured step from 20 to 28 a's was 1.9-2.0x), so 50 a's is about 2^28 times the old workload - roughly 3 years of backtracking, versus a 100 ms deadline. That puts the row in the same never-completes class as its four siblings.

[Match time vs input length for ^(a+)+$, showing 22 a](https://cursor.com/agents/bc-354c312a-d45b-4619-9545-6f14d2c7362f/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fanchored_row_timeout_margin_v2.png)

Alternatives considered: dropping the row loses coverage the issue thread wanted to keep, and making `RegexpCheckTimeout` injectable would change production code for a test's benefit without removing the race - a smaller timeout still races the same way. Input length is the only lever that scales exponentially.

## Verification

- Production code path, `NamingTemplate.Evaluate` -> `CompareCondition`, real 100 ms timeout: the new input still produces `RegexMatchTimeoutException` -> `InvalidOperationException`, so the row proves exactly what it did before.
- Margin, by scaling the timeout to simulate faster hardware (work scales with CPU speed, the timeout does not, so timeout x K is equivalent to a machine K times faster): the shipped 22-a input already fails at a 10x speedup; 50 a's still times out at 600x.
- `dotnet test` from `Source/`: 1520 tests, 0 failed (23 skipped are the opt-in OS-secret-store tests).
- `dotnet build Source/Libation.slnx`: 0 errors, only pre-existing warnings.
- Five consecutive runs of `FileManager.Tests`: the row is stable at 107 ms, identical to its four siblings. Runtime on this hardware is unchanged from master, which also clocks 107 ms - the longer input costs nothing because the match is aborted by the timeout either way.
- CI: 12/12 green, with 1520 tests passing on all nine platforms in the matrix, macOS arm64 included.

Note that CI going green does not by itself demonstrate the fix was needed - the old input passed CI too, which is why this was never caught there and only showed up on the reporter's desktop. The value of the change is the margin, which the timeout-scaling measurement above is what actually establishes.


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-354c312a-d45b-4619-9545-6f14d2c7362f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-354c312a-d45b-4619-9545-6f14d2c7362f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

