### PR TITLE
Keep a failing Books volume from closing Libation

### DIFF
--- a/Source/AppScaffolding/LibationScaffolding.cs
+++ b/Source/AppScaffolding/LibationScaffolding.cs
@@ -289,11 +289,20 @@ public static class LibationScaffolding
 		// begin logging session with a form feed
 		Log.Logger.Information("\r\n\f");
 
+		// -1 means the count could not be taken. Listing a directory no longer throws when it stops being
+		// readable partway through, so an incomplete walk has to be asked about rather than caught: a count
+		// that silently means "as many as I managed to read" is worse than no count in a bug report.
 		static int fileCount(FileManager.LongPath? longPath)
 		{
 			if (longPath is null)
 				return -1;
-			try { return FileManager.FileUtility.SaferEnumerateFiles(longPath).Count(); }
+
+			var complete = true;
+			try
+			{
+				var count = FileManager.FileUtility.SaferEnumerateFiles(longPath, onIncomplete: _ => complete = false).Count();
+				return complete ? count : -1;
+			}
 			catch { return -1; }
 		}
 

--- a/Source/FileManager/BackgroundFileSystem.cs
+++ b/Source/FileManager/BackgroundFileSystem.cs
@@ -69,19 +69,33 @@ public class BackgroundFileSystem : IDisposable
 			fsCache.AddRange(SafestEnumerateFiles(RootDirectory));
 		}
 
-		directoryChangesEvents = new BlockingCollection<FileSystemEventArgs>();
-		fileSystemWatcher = new FileSystemWatcher(RootDirectory)
+		try
 		{
-			IncludeSubdirectories = true,
-			EnableRaisingEvents = true
-		};
-		fileSystemWatcher.Created += FileSystemWatcher_Changed;
-		fileSystemWatcher.Deleted += FileSystemWatcher_Changed;
-		fileSystemWatcher.Renamed += FileSystemWatcher_Changed;
-		fileSystemWatcher.Error += FileSystemWatcher_Error;
+			directoryChangesEvents = new BlockingCollection<FileSystemEventArgs>();
+			fileSystemWatcher = new FileSystemWatcher(RootDirectory)
+			{
+				IncludeSubdirectories = true,
+				EnableRaisingEvents = true
+			};
+			fileSystemWatcher.Created += FileSystemWatcher_Changed;
+			fileSystemWatcher.Deleted += FileSystemWatcher_Changed;
+			fileSystemWatcher.Renamed += FileSystemWatcher_Changed;
+			fileSystemWatcher.Error += FileSystemWatcher_Error;
 
-		backgroundScanner = new Task(BackgroundScanner);
-		backgroundScanner.Start();
+			backgroundScanner = new Task(BackgroundScanner);
+			backgroundScanner.Start();
+		}
+		// Watching a directory fails for the same reasons reading one does, and a removable drive can be pulled
+		// between the listing above and this. Constructing this type happens inside the static initializer that
+		// builds the Books file cache, and the runtime caches a failed initializer for the life of the process:
+		// one throw here would be rethrown at every later reader of the Books directory. Give up the live
+		// updates instead. Dropping RootDirectory has the owner rebuild this once the directory works again.
+		catch (Exception ex)
+		{
+			Serilog.Log.Logger.Error(ex, "Could not watch a directory for changes, so its file cache was abandoned: {@DebugText}", new { path = (string?)RootDirectory });
+			Stop();
+			RootDirectory = null;
+		}
 	}
 	private void Stop()
 	{

--- a/Source/FileManager/FileUtility.cs
+++ b/Source/FileManager/FileUtility.cs
@@ -263,8 +263,10 @@ public static class FileUtility
 	/// <param name="rootPath">Starting directory</param>
 	/// <param name="patternMatch">Filename pattern match</param>
 	/// <param name="searchOption">Search subdirectories or only top level directory for files</param>
+	/// <param name="onIncomplete">Called with the reason when the walk ends early, so a caller that must not
+	/// mistake a truncated list for an empty directory can tell the difference.</param>
 	/// <returns>List of files</returns>
-	public static IEnumerable<LongPath> SaferEnumerateFiles(LongPath path, string searchPattern = "*", SearchOption searchOption = SearchOption.TopDirectoryOnly)
+	public static IEnumerable<LongPath> SaferEnumerateFiles(LongPath path, string searchPattern = "*", SearchOption searchOption = SearchOption.TopDirectoryOnly, Action<Exception>? onIncomplete = null)
 	{
 		var enumOptions = new EnumerationOptions
 		{
@@ -273,7 +275,101 @@ public static class FileUtility
 			ReturnSpecialDirectories = false,
 			MatchType = MatchType.Simple
 		};
-		return Directory.EnumerateFiles(path.Path, searchPattern, enumOptions).Select(p => (LongPath)p);
+		return IterateSafely(
+			() => Directory.EnumerateFiles(path.Path, searchPattern, enumOptions).Select(p => (LongPath)p),
+			path,
+			onIncomplete);
+	}
+
+	/// <summary>
+	/// Walks a file system sequence so that a directory which stops being readable partway through ends the walk
+	/// instead of throwing at whoever is consuming it.
+	/// <para>
+	/// <see cref="EnumerationOptions.IgnoreInaccessible"/> only forgives permissions. A disconnected or failing
+	/// volume raises an I/O error from the enumerator itself, and because enumeration is lazy that error is
+	/// raised wherever the sequence is finally walked - which is past any try/catch the caller wrapped around
+	/// the call that produced it. Libation lost a whole session that way: a Books folder on a USB drive that
+	/// started returning I/O errors took down the file cache, the type initializer that builds it, and with it
+	/// every subsequent launch. See issue #1984.
+	/// </para>
+	/// </summary>
+	internal static IEnumerable<LongPath> IterateSafely(Func<IEnumerable<LongPath>> getSequence, LongPath path, Action<Exception>? onIncomplete = null)
+	{
+		IEnumerator<LongPath> enumerator;
+		try
+		{
+			//Opening the directory is itself a read, and fails the same way.
+			enumerator = getSequence().GetEnumerator();
+		}
+		catch (Exception ex) when (IsUnreadable(ex))
+		{
+			ReportIncomplete(ex, path, onIncomplete);
+			yield break;
+		}
+
+		try
+		{
+			while (true)
+			{
+				LongPath current;
+				try
+				{
+					if (!enumerator.MoveNext())
+						break;
+					current = enumerator.Current;
+				}
+				catch (Exception ex) when (IsUnreadable(ex))
+				{
+					//Whatever has already been read is still good and still worth returning.
+					ReportIncomplete(ex, path, onIncomplete);
+					break;
+				}
+
+				yield return current;
+			}
+		}
+		finally
+		{
+			enumerator.Dispose();
+		}
+	}
+
+	private static bool IsUnreadable(Exception ex)
+		=> ex is IOException or UnauthorizedAccessException or System.Security.SecurityException;
+
+	private static void ReportIncomplete(Exception ex, LongPath path, Action<Exception>? onIncomplete)
+	{
+		try
+		{
+			//A directory that has simply gone is routine: temp folders are created and cleaned up under a scan
+			//all the time. A directory that is there and cannot be read is worth seeing in a bug report.
+			if (ex is DirectoryNotFoundException)
+				Serilog.Log.Logger.Debug(ex, "Stopped listing files in a directory that is no longer there: {@DebugText}", new { path = (string)path });
+			else
+				Serilog.Log.Logger.Warning(ex, "Could not finish listing files. The results are incomplete: {@DebugText}", new { path = (string)path });
+		}
+		catch { /* logging must not be the thing that breaks a file listing */ }
+
+		onIncomplete?.Invoke(ex);
+	}
+
+	/// <summary>
+	/// Whether a directory can actually be read, as opposed to merely existing. A removable drive that has been
+	/// pulled, and a failing one, can both still answer that they are a directory while every read of them fails.
+	/// </summary>
+	public static bool CanEnumerate(LongPath path)
+	{
+		var readable = true;
+
+		//The first entry is enough. A volume that cannot be read fails on the first attempt, and this must not
+		//pay for walking a whole library to answer the question.
+		foreach (var _ in IterateSafely(
+			() => Directory.EnumerateFileSystemEntries(path.Path).Select(p => (LongPath)p),
+			path,
+			_ => readable = false))
+			break;
+
+		return readable;
 	}
 
 	/// <summary>

--- a/Source/LibationAvalonia/ViewModels/MainVM.VisibleBooks.cs
+++ b/Source/LibationAvalonia/ViewModels/MainVM.VisibleBooks.cs
@@ -199,8 +199,19 @@ partial class MainVM
 
 	private async Task setLiberatedVisibleMenuItemAsync()
 	{
-		var visible = ProductsDisplay.GetVisibleBookEntries();
-		var libraryStats = await Task.Run(() => LibraryCommands.GetCounts(visible));
-		await Dispatcher.UIThread.InvokeAsync(() => setVisibleNotLiberatedCount(libraryStats.PendingBooks));
+		try
+		{
+			var visible = ProductsDisplay.GetVisibleBookEntries();
+			var libraryStats = await Task.Run(() => LibraryCommands.GetCounts(visible));
+			await Dispatcher.UIThread.InvokeAsync(() => setVisibleNotLiberatedCount(libraryStats.PendingBooks));
+		}
+		// Every caller is an async void event handler, where a failure is not a faulted task anyone awaits but
+		// an unhandled exception that closes Libation. Counting these books reads the file system, which can
+		// fail at any moment for reasons that have nothing to do with the app - a Books folder on a drive that
+		// was just unplugged is enough. A stale number above a menu item is not worth the session.
+		catch (Exception ex)
+		{
+			Serilog.Log.Logger.Error(ex, "Error counting the visible books which are not yet liberated");
+		}
 	}
 }

--- a/Source/LibationFileManager/AudibleFileStorage.cs
+++ b/Source/LibationFileManager/AudibleFileStorage.cs
@@ -219,8 +219,26 @@ public class AudioFileStorage : AudibleFileStorage
 		=> GetFilePathsCustom(productId).FirstOrDefault();
 
 	private static BackgroundFileSystem? newBookDirectoryFiles()
-		=> BooksDirectory is LongPath books ? new BackgroundFileSystem(books, "*.*", SearchOption.AllDirectories)
-		: null;
+	{
+		try
+		{
+			return BooksDirectory is LongPath books
+				? new BackgroundFileSystem(books, "*.*", SearchOption.AllDirectories)
+				: null;
+		}
+		// The first call here comes from the static initializer of AudibleFileStorage, by way of the Audio
+		// field. The runtime caches a failed initializer and rethrows it at every later reader of the type, so
+		// one unreadable Books directory would cost the process every path that touches BooksDirectory - down
+		// to the startup logging, which is where a failing USB drive turned into a crash on launch that
+		// outlasted the drive itself. See issue #1984. Files are still found without this cache, through
+		// FilePathCache and direct existence checks.
+		catch (Exception ex)
+		{
+			try { Serilog.Log.Error(ex, "Could not build the Books directory file cache. Book files will be located without it."); }
+			catch { }
+			return null;
+		}
+	}
 
 	protected override List<LongPath> GetFilePathsCustom(string productId)
 	{

--- a/Source/LibationUiBase/ProcessQueue/ProcessQueueViewModel.cs
+++ b/Source/LibationUiBase/ProcessQueue/ProcessQueueViewModel.cs
@@ -296,12 +296,25 @@ public class ProcessQueueViewModel : ReactiveObject
 				MessageBoxIcon.Error);
 			return false;
 		}
-		else if (AudibleFileStorage.BooksDirectory is null)
+		else if (AudibleFileStorage.BooksDirectory is not FileManager.LongPath booksDirectory)
 		{
 			Serilog.Log.Logger.Error("Failed to create books directory: {booksDir}", config.Books?.Path);
 			await MessageBoxBase.Show(
 				$"Libation was unable to create the \"Books location\" folder at:\n{config.Books}\n\nPlease change the Books location in the settings menu.",
 				"Failed to Create Books Directory",
+				MessageBoxButtons.OK,
+				MessageBoxIcon.Error);
+			return false;
+		}
+		// A removable or failing drive can still answer that it is a directory while every read of it fails, so
+		// existing is not the same as usable. Without this the download would begin against an unreadable folder
+		// and fail book by book, and Libation would report the library as having nothing downloaded.
+		else if (!FileManager.FileUtility.CanEnumerate(booksDirectory))
+		{
+			Serilog.Log.Logger.Error("Books directory exists but cannot be read: {booksDir}", (string)booksDirectory);
+			await MessageBoxBase.Show(
+				$"Libation was unable to read the \"Books location\" folder at:\n{booksDirectory}\n\nIf it is on a removable or network drive, check that the drive is connected and working. Otherwise, change the Books location in the settings menu.",
+				"Unable to Read Books Directory",
 				MessageBoxButtons.OK,
 				MessageBoxIcon.Error);
 			return false;

--- a/Source/LibationWinForms/Form1.VisibleBooks.cs
+++ b/Source/LibationWinForms/Form1.VisibleBooks.cs
@@ -29,6 +29,22 @@ public partial class Form1
 	private static DateTime lastVisibleCountUpdated;
 	void setLiberatedVisibleMenuItem()
 	{
+		try
+		{
+			setLiberatedVisibleMenuItemCore();
+		}
+		// Both callers are async void event handlers, where a failure is not a faulted task anyone awaits but
+		// an unhandled exception that closes Libation. Counting these books reads the file system, which can
+		// fail at any moment for reasons that have nothing to do with the app - a Books folder on a drive that
+		// was just unplugged is enough. A stale number above a menu item is not worth the session.
+		catch (Exception ex)
+		{
+			Serilog.Log.Logger.Error(ex, "Error counting the visible books which are not yet liberated");
+		}
+	}
+
+	private void setLiberatedVisibleMenuItemCore()
+	{
 		//Assume that all calls to update arrive in order,
 		//Only display results of the latest book count.
 		var updaterTime = lastVisibleCountUpdated = DateTime.UtcNow;

--- a/Source/_Tests/FileManager.Tests/BackgroundFileSystemTests.cs
+++ b/Source/_Tests/FileManager.Tests/BackgroundFileSystemTests.cs
@@ -2,6 +2,7 @@ using FileManager;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
 using System.IO;
+using System.Runtime.Versioning;
 using System.Text.RegularExpressions;
 using System.Threading;
 
@@ -101,6 +102,82 @@ public class DisposeWhileEventsAreArriving
 		}
 
 		return false;
+	}
+}
+
+/// <summary>
+/// From issue #1984, where a Books folder on a failing USB drive closed Libation on every launch. This type is
+/// constructed from the static initializer of <c>AudibleFileStorage</c>, and the runtime caches a failed static
+/// initializer for the life of the process: anything that escapes here is rethrown at every later caller that
+/// so much as asks where the Books folder is, including the startup logging that runs before the window opens.
+/// So construction has to survive a root directory it cannot read, however it cannot read it.
+/// </summary>
+[TestClass]
+[DoNotParallelize]
+public class WhenTheRootDirectoryCannotBeRead
+{
+	private string tempDir = string.Empty;
+
+	[TestInitialize]
+	public void Initialize()
+	{
+		tempDir = Path.Combine(Path.GetTempPath(), $"libation-bfs-unreadable-{Guid.NewGuid():N}");
+		Directory.CreateDirectory(tempDir);
+	}
+
+	[TestCleanup]
+	public void Cleanup()
+	{
+		try
+		{
+			if (!OperatingSystem.IsWindows() && Directory.Exists(tempDir))
+				File.SetUnixFileMode(tempDir, UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute);
+			Directory.Delete(tempDir, recursive: true);
+		}
+		catch (IOException)
+		{
+			// A leftover temp directory is not worth failing a test over.
+		}
+	}
+
+	[TestMethod]
+	public void a_root_that_is_not_there_is_reported_rather_than_thrown()
+	{
+		using var sut = new BackgroundFileSystem(Path.Combine(tempDir, "no-such-folder"), "*.*", SearchOption.AllDirectories);
+
+		Assert.IsNull(sut.RootDirectory, "a root that cannot be used is dropped, so the owner rebuilds this when it can");
+		Assert.IsNull(sut.FindFile(new Regex(".*")));
+	}
+
+	[TestMethod]
+	public void a_root_that_refuses_to_be_read_costs_the_cache_and_nothing_else()
+	{
+		// Assert.Inconclusive is not [DoesNotReturn], so return explicitly or the body below still
+		// looks reachable on Windows to the platform compatibility analyzer
+		if (!OperatingSystem.IsLinux() && !OperatingSystem.IsMacOS())
+		{
+			Assert.Inconclusive("Skipped because revoking directory read permission needs unix file modes.");
+			return;
+		}
+		if (Environment.IsPrivilegedProcess)
+		{
+			Assert.Inconclusive("Skipped because root may read a directory with no permissions, so there is nothing to refuse.");
+			return;
+		}
+
+		aRootThatRefusesToBeRead(tempDir);
+	}
+
+	[SupportedOSPlatform("linux")]
+	[SupportedOSPlatform("macos")]
+	private static void aRootThatRefusesToBeRead(string directory)
+	{
+		File.WriteAllText(Path.Combine(directory, "book.m4b"), "audio");
+		File.SetUnixFileMode(directory, UnixFileMode.None);
+
+		using var sut = new BackgroundFileSystem(directory, "*.*", SearchOption.AllDirectories);
+
+		Assert.IsNull(sut.FindFile(new Regex(@"book\.m4b$")), "nothing can be read, so nothing is found");
 	}
 }
 

--- a/Source/_Tests/FileManager.Tests/SaferEnumerateFilesTests.cs
+++ b/Source/_Tests/FileManager.Tests/SaferEnumerateFilesTests.cs
@@ -1,0 +1,254 @@
+using FileManager;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.Versioning;
+
+namespace SaferEnumerateFilesTests;
+
+/// <summary>
+/// From issue #1984: a Books folder on a USB drive started returning I/O errors partway through a library scan,
+/// and Libation closed with "Libation encountered a fatal error". It then closed the same way on every launch
+/// afterwards, before the window appeared.
+/// <para>
+/// Two guards were supposed to prevent that and neither did. <see cref="EnumerationOptions.IgnoreInaccessible"/>
+/// only forgives permissions, so an I/O error still came out of the enumerator. And the try/catch the caller had
+/// wrapped around the call never saw it: listing files is lazy, so the error was raised where the sequence was
+/// walked - inside the caller's AddRange, long after the try/catch had exited.
+/// </para>
+/// </summary>
+[TestClass]
+public class WhenADirectoryStopsBeingReadablePartwayThrough
+{
+	private static IEnumerable<LongPath> TwoFilesThenFails(Exception failure)
+	{
+		yield return (LongPath)"/books/first.m4b";
+		yield return (LongPath)"/books/second.m4b";
+		throw failure;
+	}
+
+	/// <summary>The shape of the crash: the walk is consumed by an AddRange, exactly as the file cache does.</summary>
+	[TestMethod]
+	public void the_walk_ends_early_instead_of_throwing_at_whoever_is_consuming_it()
+	{
+		var found = new List<LongPath>();
+
+		found.AddRange(FileUtility.IterateSafely(
+			() => TwoFilesThenFails(new IOException("Input/output error : '/Volumes/NO NAME/Audible audiobooks'")),
+			(LongPath)"/Volumes/NO NAME/Audible audiobooks"));
+
+		CollectionAssert.AreEqual(
+			new[] { "/books/first.m4b", "/books/second.m4b" },
+			found.Select(f => (string)f).ToArray(),
+			"everything read before the failure is still good, and still worth returning");
+	}
+
+	[TestMethod]
+	public void the_caller_can_tell_a_truncated_walk_from_an_empty_directory()
+	{
+		Exception? reported = null;
+		var failure = new IOException("Input/output error");
+
+		FileUtility.IterateSafely(() => TwoFilesThenFails(failure), (LongPath)"/books", ex => reported = ex).ToList();
+
+		Assert.AreSame(failure, reported);
+	}
+
+	[TestMethod]
+	public void nothing_is_reported_when_the_whole_directory_was_read()
+	{
+		var reported = false;
+
+		FileUtility.IterateSafely(() => new[] { (LongPath)"/books/only.m4b" }, (LongPath)"/books", _ => reported = true).ToList();
+
+		Assert.IsFalse(reported);
+	}
+
+	/// <summary>Opening the directory is itself a read, and fails the same way.</summary>
+	[TestMethod]
+	public void a_failure_before_the_first_entry_lists_nothing_rather_than_throwing()
+	{
+		Exception? reported = null;
+
+		var found = FileUtility.IterateSafely(
+			() => throw new IOException("Input/output error"),
+			(LongPath)"/books",
+			ex => reported = ex).ToList();
+
+		Assert.AreEqual(0, found.Count);
+		Assert.IsInstanceOfType<IOException>(reported);
+	}
+
+	[TestMethod]
+	public void a_directory_that_has_gone_is_forgiven_too()
+	{
+		var found = FileUtility.IterateSafely(
+			() => TwoFilesThenFails(new DirectoryNotFoundException()),
+			(LongPath)"/books").ToList();
+
+		Assert.AreEqual(2, found.Count);
+	}
+
+	[TestMethod]
+	public void so_is_a_directory_the_user_is_not_allowed_to_read()
+	{
+		var found = FileUtility.IterateSafely(
+			() => TwoFilesThenFails(new UnauthorizedAccessException()),
+			(LongPath)"/books").ToList();
+
+		Assert.AreEqual(2, found.Count);
+	}
+
+	/// <summary>
+	/// The guard is for a file system that will not answer, not for bugs. Widening it to everything would hide
+	/// the next defect in here behind a short list of files.
+	/// </summary>
+	[TestMethod]
+	public void a_failure_that_is_not_the_file_system_is_still_raised()
+	{
+		var found = FileUtility.IterateSafely(
+			() => TwoFilesThenFails(new InvalidOperationException("a real bug")),
+			(LongPath)"/books");
+
+		Assert.ThrowsExactly<InvalidOperationException>(() => found.ToList());
+	}
+}
+
+[TestClass]
+public class SaferEnumerateFilesAgainstARealDirectory
+{
+	private string tempDir = string.Empty;
+
+	[TestInitialize]
+	public void Initialize()
+	{
+		tempDir = Path.Combine(Path.GetTempPath(), $"libation-enumerate-tests-{Guid.NewGuid():N}");
+		Directory.CreateDirectory(tempDir);
+	}
+
+	[TestCleanup]
+	public void Cleanup()
+	{
+		try
+		{
+			if (!OperatingSystem.IsWindows() && Directory.Exists(tempDir))
+				File.SetUnixFileMode(tempDir, UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute);
+			Directory.Delete(tempDir, recursive: true);
+		}
+		catch (IOException)
+		{
+			// A leftover temp directory is not worth failing a test over.
+		}
+	}
+
+	[TestMethod]
+	public void the_files_that_are_there_are_listed()
+	{
+		File.WriteAllText(Path.Combine(tempDir, "book.m4b"), "audio");
+		Directory.CreateDirectory(Path.Combine(tempDir, "nested"));
+		File.WriteAllText(Path.Combine(tempDir, "nested", "another.m4b"), "audio");
+
+		var topOnly = FileUtility.SaferEnumerateFiles(tempDir).Select(f => Path.GetFileName((string)f)).ToArray();
+		var everything = FileUtility.SaferEnumerateFiles(tempDir, "*", SearchOption.AllDirectories).Select(f => Path.GetFileName((string)f)).Order().ToArray();
+
+		CollectionAssert.AreEqual(new[] { "book.m4b" }, topOnly);
+		CollectionAssert.AreEqual(new[] { "another.m4b", "book.m4b" }, everything);
+	}
+
+	/// <summary>
+	/// This used to throw, and lazily, so it landed on whoever walked the sequence rather than whoever asked for
+	/// it. A Books folder that is not there is a settings problem to report, never a crash.
+	/// </summary>
+	[TestMethod]
+	public void a_directory_that_is_not_there_lists_nothing_and_says_why()
+	{
+		Exception? reported = null;
+		var missing = Path.Combine(tempDir, "no-such-folder");
+
+		var found = FileUtility.SaferEnumerateFiles(missing, onIncomplete: ex => reported = ex).ToList();
+
+		Assert.AreEqual(0, found.Count);
+		Assert.IsInstanceOfType<DirectoryNotFoundException>(reported);
+	}
+}
+
+[TestClass]
+public class CanEnumerate
+{
+	private string tempDir = string.Empty;
+
+	[TestInitialize]
+	public void Initialize()
+	{
+		tempDir = Path.Combine(Path.GetTempPath(), $"libation-can-enumerate-tests-{Guid.NewGuid():N}");
+		Directory.CreateDirectory(tempDir);
+	}
+
+	[TestCleanup]
+	public void Cleanup()
+	{
+		try
+		{
+			if (!OperatingSystem.IsWindows() && Directory.Exists(tempDir))
+				File.SetUnixFileMode(tempDir, UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute);
+			Directory.Delete(tempDir, recursive: true);
+		}
+		catch (IOException)
+		{
+			// A leftover temp directory is not worth failing a test over.
+		}
+	}
+
+	[TestMethod]
+	public void a_readable_directory_can_be_read()
+	{
+		Assert.IsTrue(FileUtility.CanEnumerate(tempDir), "an empty directory is readable, it is just empty");
+
+		File.WriteAllText(Path.Combine(tempDir, "book.m4b"), "audio");
+
+		Assert.IsTrue(FileUtility.CanEnumerate(tempDir));
+	}
+
+	[TestMethod]
+	public void a_directory_that_is_not_there_cannot_be_read()
+		=> Assert.IsFalse(FileUtility.CanEnumerate(Path.Combine(tempDir, "no-such-folder")));
+
+	/// <summary>
+	/// Existing is not the same as usable, which is the whole point of asking. A pulled or failing drive still
+	/// answers that it is a directory, and a recursive listing of it comes back empty rather than refusing -
+	/// IgnoreInaccessible sees to that - so without this check Libation reports a full library as downloading
+	/// nothing instead of saying the drive is unreadable.
+	/// </summary>
+	[TestMethod]
+	public void a_directory_that_exists_but_refuses_to_be_read_cannot_be_read()
+	{
+		// Assert.Inconclusive is not [DoesNotReturn], so return explicitly or the body below still
+		// looks reachable on Windows to the platform compatibility analyzer
+		if (!OperatingSystem.IsLinux() && !OperatingSystem.IsMacOS())
+		{
+			Assert.Inconclusive("Skipped because revoking directory read permission needs unix file modes.");
+			return;
+		}
+		if (Environment.IsPrivilegedProcess)
+		{
+			Assert.Inconclusive("Skipped because root may read a directory with no permissions, so there is nothing to refuse.");
+			return;
+		}
+
+		aDirectoryThatExistsButRefusesToBeRead(tempDir);
+	}
+
+	[SupportedOSPlatform("linux")]
+	[SupportedOSPlatform("macos")]
+	private static void aDirectoryThatExistsButRefusesToBeRead(string directory)
+	{
+		File.WriteAllText(Path.Combine(directory, "book.m4b"), "audio");
+		File.SetUnixFileMode(directory, UnixFileMode.None);
+
+		Assert.IsTrue(Directory.Exists(directory), "the directory is still there; it just cannot be read");
+		Assert.AreEqual(0, FileUtility.SaferEnumerateFiles(directory, "*", SearchOption.AllDirectories).Count(), "a listing comes back empty rather than refusing");
+		Assert.IsFalse(FileUtility.CanEnumerate(directory));
+	}
+}

--- a/Source/_Tests/FileManager.Tests/SaferEnumerateFilesTests.cs
+++ b/Source/_Tests/FileManager.Tests/SaferEnumerateFilesTests.cs
@@ -22,10 +22,16 @@ namespace SaferEnumerateFilesTests;
 [TestClass]
 public class WhenADirectoryStopsBeingReadablePartwayThrough
 {
+	// Relative, and built with Path.Combine, so the separators are whatever this platform uses. LongPath
+	// rewrites '/' to '\' on Windows, which is not what any of these tests are about.
+	private static readonly LongPath BooksDirectory = "books";
+	private static readonly LongPath FirstFile = Path.Combine("books", "first.m4b");
+	private static readonly LongPath SecondFile = Path.Combine("books", "second.m4b");
+
 	private static IEnumerable<LongPath> TwoFilesThenFails(Exception failure)
 	{
-		yield return (LongPath)"/books/first.m4b";
-		yield return (LongPath)"/books/second.m4b";
+		yield return FirstFile;
+		yield return SecondFile;
 		throw failure;
 	}
 
@@ -36,12 +42,12 @@ public class WhenADirectoryStopsBeingReadablePartwayThrough
 		var found = new List<LongPath>();
 
 		found.AddRange(FileUtility.IterateSafely(
-			() => TwoFilesThenFails(new IOException("Input/output error : '/Volumes/NO NAME/Audible audiobooks'")),
-			(LongPath)"/Volumes/NO NAME/Audible audiobooks"));
+			() => TwoFilesThenFails(new IOException("Input/output error")),
+			BooksDirectory));
 
 		CollectionAssert.AreEqual(
-			new[] { "/books/first.m4b", "/books/second.m4b" },
-			found.Select(f => (string)f).ToArray(),
+			new[] { FirstFile, SecondFile },
+			found,
 			"everything read before the failure is still good, and still worth returning");
 	}
 
@@ -51,7 +57,7 @@ public class WhenADirectoryStopsBeingReadablePartwayThrough
 		Exception? reported = null;
 		var failure = new IOException("Input/output error");
 
-		FileUtility.IterateSafely(() => TwoFilesThenFails(failure), (LongPath)"/books", ex => reported = ex).ToList();
+		FileUtility.IterateSafely(() => TwoFilesThenFails(failure), BooksDirectory, ex => reported = ex).ToList();
 
 		Assert.AreSame(failure, reported);
 	}
@@ -61,7 +67,7 @@ public class WhenADirectoryStopsBeingReadablePartwayThrough
 	{
 		var reported = false;
 
-		FileUtility.IterateSafely(() => new[] { (LongPath)"/books/only.m4b" }, (LongPath)"/books", _ => reported = true).ToList();
+		FileUtility.IterateSafely(() => new[] { FirstFile }, BooksDirectory, _ => reported = true).ToList();
 
 		Assert.IsFalse(reported);
 	}
@@ -74,7 +80,7 @@ public class WhenADirectoryStopsBeingReadablePartwayThrough
 
 		var found = FileUtility.IterateSafely(
 			() => throw new IOException("Input/output error"),
-			(LongPath)"/books",
+			BooksDirectory,
 			ex => reported = ex).ToList();
 
 		Assert.AreEqual(0, found.Count);
@@ -86,7 +92,7 @@ public class WhenADirectoryStopsBeingReadablePartwayThrough
 	{
 		var found = FileUtility.IterateSafely(
 			() => TwoFilesThenFails(new DirectoryNotFoundException()),
-			(LongPath)"/books").ToList();
+			BooksDirectory).ToList();
 
 		Assert.AreEqual(2, found.Count);
 	}
@@ -96,7 +102,7 @@ public class WhenADirectoryStopsBeingReadablePartwayThrough
 	{
 		var found = FileUtility.IterateSafely(
 			() => TwoFilesThenFails(new UnauthorizedAccessException()),
-			(LongPath)"/books").ToList();
+			BooksDirectory).ToList();
 
 		Assert.AreEqual(2, found.Count);
 	}
@@ -110,7 +116,7 @@ public class WhenADirectoryStopsBeingReadablePartwayThrough
 	{
 		var found = FileUtility.IterateSafely(
 			() => TwoFilesThenFails(new InvalidOperationException("a real bug")),
-			(LongPath)"/books");
+			BooksDirectory);
 
 		Assert.ThrowsExactly<InvalidOperationException>(() => found.ToList());
 	}

--- a/docs/advanced/troubleshoot.md
+++ b/docs/advanced/troubleshoot.md
@@ -17,6 +17,20 @@ NTFS filesystems (Windows, and NTFS-formatted external drives on Linux or Mac) d
 
 **Fix:** Add or edit `ReplacementCharacters` in `Settings.json` on your config volume (or Libation files directory) so colons are replaced before download. The `HiFi_NTFS` example includes a colon replacement. See [Command Line Interface - Set custom replacement characters](/docs/advanced/command-line-interface#set-custom-replacement-characters).
 
+## 'Input/output error' on the Books folder (removable or failing drive)
+
+**Symptoms:** Downloads that were working start failing one after another, and the log fills with `System.IO.IOException: Input/output error` naming paths under your Books location. On a removable drive the folder often still appears to be there, because the mount point answers even though nothing on it can be read.
+
+**Cause:** The drive itself, not Libation. A USB drive that has been pulled, is failing, or has gone to sleep reports an I/O error for every read. Libation now reports the folder as unreadable and carries on. Older versions closed with a fatal error instead, and kept closing on launch until the Books location was changed ([#1984](https://github.com/rmcrackan/Libation/issues/1984)).
+
+**What to try:**
+
+1. Eject and reconnect the drive, then check it with your OS disk tool (**Disk Utility** on macOS, `chkdsk` on Windows, `fsck` on Linux).
+2. Keep the **in-progress / temporary** location in **Settings > Download/Decrypt** on your internal disk even when Books lives on an external drive. It is written to constantly during a download, so it is the first thing to fail.
+3. If Libation cannot start while the drive is disconnected, set `Books` in `Settings.json` back to a folder on your internal disk.
+
+Books already downloaded to the drive are unaffected; Libation finds them again once the drive is readable.
+
 ## SQLite Error 10: 'disk I/O error'.
 
 There are two possible causes of this error.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes the crash in #1984, where a Books folder on a USB drive that started returning I/O errors closed Libation with "Libation encountered a fatal error", and then closed it the same way on every launch afterwards, before the window appeared.

## What went wrong

Libation already treats a Books folder it cannot use as a settings problem rather than a fatal one. Two guards were supposed to make that true here, and neither did.

`FileUtility.SaferEnumerateFiles` returned a lazy sequence, so an I/O error was raised where the sequence was finally walked - inside the caller's `AddRange` - rather than where it was created, which is past the try/catch the caller had wrapped around it. `EnumerationOptions.IgnoreInaccessible` did not cover it either: that forgives permissions, not a volume that has stopped answering.

That left two crash sites. `AaxcFileStorage.GetFilePathsCustom` threw during a routine recount of the visible books, and reached the fatal dialog through an `async void` event handler, where an exception is unhandled rather than a faulted task. And `BackgroundFileSystem.Init` threw while the Books file cache was being built from a static field initializer, which the runtime caches as a `TypeInitializationException` and rethrows at every later reader of the type - which is why later launches died in the startup logging, and why the crash outlived the drive.

## What changed

- **Listing a directory fails safe.** `SaferEnumerateFiles` walks the enumerator defensively, keeps what it read, and reports the reason through an optional `onIncomplete` callback so a caller can tell a truncated walk from an empty folder. A new `FileUtility.CanEnumerate` answers whether a directory can actually be read, as opposed to merely existing.
- **`BackgroundFileSystem` degrades instead of throwing.** If it cannot watch a directory it gives up the live updates and drops `RootDirectory`, which is the same signal its owner already uses to decide the cache needs rebuilding.
- **`AudibleFileStorage` cannot poison itself.** Building the cache no longer lets anything escape the static initializer. Files are still located without it, through `FilePathCache` and direct existence checks.
- **A book count cannot end the session.** Both UIs log and carry on rather than taking an unhandled exception out of an `async void` handler.
- **The user is told.** Queueing a download against a Books folder that exists but cannot be read now says so and names a disconnected drive as the likely cause, instead of starting a download that fails book by book and reporting a full library as having nothing downloaded.
- A troubleshooting entry for the same symptom.

## Verification

A FUSE mount stands in for the dying drive: it answers `stat` while every read fails with `EIO`, which is what the reporter's log shows. `Books` and the in-progress folder both point at it, as they did in the report.

On `master`, filtering the grid after the drive fails reproduces the reporter's crash exactly, down to `AudibleFileStorage.cs:line 187`:

[master: Libation Crash dialog showing Input/output error from AaxcFileStorage.GetFilePathsCustom](https://cursor.com/agents/bc-13b32507-6f65-4869-8afe-efe301e474f7/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fcrash_before_fix.webp)

On this branch the same actions leave the app running, and asking it to liberate names the drive:

[this branch: the same filter applied after the drive fails, app still running, with a dialog reading Unable to Read Books Directory](https://cursor.com/agents/bc-13b32507-6f65-4869-8afe-efe301e474f7/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fno_crash_after_fix.webp)

[libation_survives_failing_books_drive.mp4](https://cursor.com/agents/bc-13b32507-6f65-4869-8afe-efe301e474f7/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Flibation_survives_failing_books_drive.mp4)

The startup crash is reproducible without the GUI at all - `master` cannot even print its version number with `Books` on that volume, while this branch starts normally:

```
BEFORE - master
  Unhandled exception. System.TypeInitializationException: The type initializer for
  'LibationFileManager.AudibleFileStorage' threw an exception.
   ---> System.IO.IOException: Input/output error : '/tmp/flaky/mount'
     at FileManager.BackgroundFileSystem.Init()
     at LibationFileManager.AudioFileStorage.newBookDirectoryFiles()
     at LibationFileManager.AudibleFileStorage..cctor()
     at AppScaffolding.LibationScaffolding.logStartupState(Configuration config)
  exit code: 134

AFTER - this branch
  Libation Chardonnay v13.7.10
  exit code: 0
```

The failure is now a log line rather than a dialog:

```
[WRN] Could not finish listing files. The results are incomplete: {"path":"/tmp/flaky/mount/DownloadsInProgress"}
[ERR] Books directory exists but cannot be read: /tmp/flaky/mount
```

Full suite passes (1534 tests, 23 skipped), with 14 new tests covering the truncated walk, the readability check, and construction over a root that cannot be read. `LibationWinForms` compile-checks with no warnings; that change has no Linux runtime, so its behaviour still wants a look on Windows.

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-13b32507-6f65-4869-8afe-efe301e474f7?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-13b32507-6f65-4869-8afe-efe301e474f7&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

