### PR TITLE
Queue notification cleanups left over from #1958

### DIFF
--- a/Source/LibationUiBase/TrackedQueue[T].cs
+++ b/Source/LibationUiBase/TrackedQueue[T].cs
@@ -109,10 +109,10 @@ public class TrackedQueue<T> : IReadOnlyCollection<T>, IList, INotifyCollectionC
 	public ISynchronizeInvoke? NotificationInvoker { get; set; }
 
 	/// <summary>Call while holding <see cref="lockObject"/>.</summary>
-	private void Pend(int completedCount) => _pending.Add(new(NotificationKind.CompletedCount, completedCount, null));
+	private void PendCompletedCount(int completedCount) => _pending.Add(new(NotificationKind.CompletedCount, completedCount, null));
 
 	/// <summary>Call while holding <see cref="lockObject"/>.</summary>
-	private void PendQueued(int queuedCount) => _pending.Add(new(NotificationKind.QueuedCount, queuedCount, null));
+	private void PendQueuedCount(int queuedCount) => _pending.Add(new(NotificationKind.QueuedCount, queuedCount, null));
 
 	/// <summary>Call while holding <see cref="lockObject"/>.</summary>
 	private void Pend(NotifyCollectionChangedEventArgs args) => _pending.Add(new(NotificationKind.Collection, 0, args));
@@ -237,7 +237,7 @@ public class TrackedQueue<T> : IReadOnlyCollection<T>, IList, INotifyCollectionC
 			if (removed)
 			{
 				Queued.RemoveAt(queueIndex);
-				PendQueued(Queued.Count);
+				PendQueuedCount(Queued.Count);
 				Pend(new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Remove, item, QueueStartIndex + queueIndex));
 			}
 		}
@@ -257,7 +257,7 @@ public class TrackedQueue<T> : IReadOnlyCollection<T>, IList, INotifyCollectionC
 			if (removed)
 			{
 				_completed.RemoveAt(completedIndex);
-				Pend(_completed.Count);
+				PendCompletedCount(_completed.Count);
 				Pend(new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Remove, item, completedIndex));
 			}
 		}
@@ -282,7 +282,7 @@ public class TrackedQueue<T> : IReadOnlyCollection<T>, IList, INotifyCollectionC
 			item = Queued[0];
 			Queued.RemoveAt(0);
 			_active.Add(item);
-			PendQueued(Queued.Count);
+			PendQueuedCount(Queued.Count);
 		}
 		DispatchPending();
 		return true;
@@ -298,29 +298,35 @@ public class TrackedQueue<T> : IReadOnlyCollection<T>, IList, INotifyCollectionC
 	/// </remarks>
 	public void MarkCompleted(T item)
 	{
+		bool wasActive;
 		lock (lockObject)
 		{
 			var activeIndex = _active.IndexOf(item);
-			if (activeIndex < 0)
+			wasActive = activeIndex >= 0;
+
+			if (wasActive)
 			{
-				Serilog.Log.Logger.Error("MarkCompleted called on an item that is not active: {Item}", item);
-				return;
+				int oldIndex = _completed.Count + activeIndex;
+				_active.RemoveAt(activeIndex);
+				_completed.Add(item);
+				int newIndex = _completed.Count - 1;
+
+				PendCompletedCount(_completed.Count);
+
+				// One book at a time, the finishing book is always the first active one, oldIndex equals
+				// newIndex and nothing has moved. Concurrently it is normal for the second of two active
+				// books to finish first, which puts it ahead of the other in the display order. Without
+				// this a bound list keeps painting the previous order, so rows show the wrong book.
+				if (oldIndex != newIndex)
+					Pend(new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Move, item, newIndex, oldIndex));
 			}
-
-			int oldIndex = _completed.Count + activeIndex;
-			_active.RemoveAt(activeIndex);
-			_completed.Add(item);
-			int newIndex = _completed.Count - 1;
-
-			Pend(_completed.Count);
-
-			// One book at a time, the finishing book is always the first active one, oldIndex equals
-			// newIndex and nothing has moved. Concurrently it is normal for the second of two active
-			// books to finish first, which puts it ahead of the other in the display order. Without
-			// this a bound list keeps painting the previous order, so rows show the wrong book.
-			if (oldIndex != newIndex)
-				Pend(new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Move, item, newIndex, oldIndex));
 		}
+
+		// Outside the lock: a sink can be slow, and the UI thread takes this lock on every read of
+		// Count, IndexOf and the indexer.
+		if (!wasActive)
+			Serilog.Log.Logger.Error("MarkCompleted called on an item that is not active: {Item}", item);
+
 		DispatchPending();
 	}
 
@@ -358,7 +364,7 @@ public class TrackedQueue<T> : IReadOnlyCollection<T>, IList, INotifyCollectionC
 		{
 			var queuedItems = Queued.ToList();
 			Queued.Clear();
-			PendQueued(0);
+			PendQueuedCount(0);
 			Pend(new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Remove, queuedItems, QueueStartIndex));
 		}
 		DispatchPending();
@@ -370,7 +376,7 @@ public class TrackedQueue<T> : IReadOnlyCollection<T>, IList, INotifyCollectionC
 		{
 			var completedItems = _completed.ToList();
 			_completed.Clear();
-			Pend(0);
+			PendCompletedCount(0);
 			Pend(new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Remove, completedItems, 0));
 		}
 		DispatchPending();
@@ -404,7 +410,7 @@ public class TrackedQueue<T> : IReadOnlyCollection<T>, IList, INotifyCollectionC
 		lock (lockObject)
 		{
 			Queued.AddRange(item);
-			PendQueued(Queued.Count);
+			PendQueuedCount(Queued.Count);
 			Pend(new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Add, item, QueueStartIndex + Queued.Count));
 		}
 		DispatchPending();

--- a/Source/LibationUiBase/TrackedQueue[T].cs
+++ b/Source/LibationUiBase/TrackedQueue[T].cs
@@ -409,9 +409,18 @@ public class TrackedQueue<T> : IReadOnlyCollection<T>, IList, INotifyCollectionC
 	{
 		lock (lockObject)
 		{
-			Queued.AddRange(item);
+			// Copied, and held as List<T> rather than IList<T>: only the non-generic IList reaches the
+			// changedItems overload below. Handed an IList<T> the compiler picks changedItem instead,
+			// and the event then describes the list itself as the single item added.
+			var added = item.ToList();
+
+			Queued.AddRange(added);
 			PendQueuedCount(Queued.Count);
-			Pend(new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Add, item, QueueStartIndex + Queued.Count));
+
+			// Where the new items start, which is where the queue ended before they were added. Taken
+			// after the range is added, the index lands past the end by the size of the batch.
+			int addedAt = QueueStartIndex + Queued.Count - added.Count;
+			Pend(new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Add, added, addedAt));
 		}
 		DispatchPending();
 	}

--- a/Source/_Tests/LibationUiBase.Tests/TrackedQueueTests.cs
+++ b/Source/_Tests/LibationUiBase.Tests/TrackedQueueTests.cs
@@ -208,6 +208,33 @@ public class TrackedQueueTests
 	}
 
 	[TestMethod]
+	public void enqueuing_reports_the_books_it_added_and_where_they_start()
+	{
+		// Both halves of the Add event were wrong. The index was taken after the range was added, so
+		// it landed past the end by the size of the batch; and an IList<T> binds the changedItem
+		// overload, so the event named the list itself as the one thing added.
+		Book a = new("A"), b = new("B"), c = new("C"), d = new("D");
+		var queue = QueueOf(a, b);
+		queue.TryDequeueNext(out _);
+		queue.MarkCompleted(a);
+		queue.TryDequeueNext(out _);
+
+		NotifyCollectionChangedEventArgs? add = null;
+		queue.CollectionChanged += (_, e) =>
+		{
+			if (e.Action is NotifyCollectionChangedAction.Add)
+				add = e;
+		};
+
+		queue.Enqueue([c, d]);
+
+		Assert.IsNotNull(add);
+		CollectionAssert.AreEqual(new[] { c, d }, add.NewItems);
+		Assert.AreEqual(2, add.NewStartingIndex);
+		Assert.AreEqual(queue.IndexOf(c), add.NewStartingIndex);
+	}
+
+	[TestMethod]
 	public void completing_a_book_that_is_not_active_changes_nothing()
 	{
 		Book a = new("A"), b = new("B");

--- a/docs/features/parallel-downloads.md
+++ b/docs/features/parallel-downloads.md
@@ -26,7 +26,7 @@ When the two differ, Libation says so next to the setting: Chardonnay shows a no
 
 ## Auto-scroll
 
-The **Auto-scroll** checkbox keeps newly started downloads in view as the queue advances. It only scrolls when you were already looking at the bottom of the queue, so scrolling up to read something further back is not interrupted by the next book starting. Unchecking it stops the queue scrolling on its own entirely.
+The **Auto-scroll** checkbox keeps newly started downloads in view as the queue advances. It only scrolls when the book above the new one is already on screen, so scrolling away to read something elsewhere in the queue is not interrupted by the next book starting. Unchecking it stops the queue scrolling on its own entirely.
 
 ## Stopping a run
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Follow-ups to [#1958](https://github.com/rmcrackan/Libation/pull/1958), which were called out in review as too small to hold the merge for. Three commits, one per item.

## Report the books an enqueue added, and where they start

The only notification in `TrackedQueue<T>` that still described something other than what happened. Both halves were wrong:

- The index was read after `AddRange`, so it pointed past the end by the size of the batch — queueing two books into a list of four announced them at index 6.
- The parameter is `IList<T>`, which does not implement the non-generic `IList`, so the compiler bound the `changedItem` overload and the event named the list object itself as the single item added.

Both UIs survived it — WinForms discards the event args and re-reads, and Avalonia evidently falls back to re-reading as well — but the class exists to give an index-based consumer something it can follow, and this was the one notification it could not. The list is copied now too, so the event doesn't hand out a reference the caller can still mutate.

Covered by `enqueuing_reports_the_books_it_added_and_where_they_start`, which fails on both counts before the change.

## Name the pending helpers, and log a stray completion outside the lock

`Pend(int)` and `PendQueued(int)` differed only in which counter they stood for, which is the kind of pair someone eventually calls the wrong half of; they are now `PendCompletedCount` and `PendQueuedCount`. And `MarkCompleted` logged its "not active" case while holding `lockObject`, which the UI thread takes on every read of `Count`, `IndexOf` and the indexer — the write happens after the lock is released. No behaviour change in either.

## Say what auto-scroll actually waits for

The docs page said auto-scroll only moves "when you were already looking at the bottom of the queue". The condition in both UIs is that the item above the one starting is still on screen, which is not the same claim.

## Testing

`dotnet test --project Source/_Tests/LibationUiBase.Tests` — **194 of 194 pass**.

The Add notification is the only change a bound list can observe, so I also exercised it in Chardonnay: queued five books through the debug bad-book simulator, then filtered the grid and queued five different ones, so the second batch arrived with finished rows already in the list — the case where the corrected index differs (5 rather than 10). All ten rows render, the new batch sits below the finished ones, and each row's title matches its status. Row order also matches the completion order in the log (`02, 03, 01, 04, 05` then `07, 10, 09, 11, 08`), so the `Move` notifications still land correctly alongside the new `Add`.

[Queue panel with five finished Green rows followed by the newly queued Yellow rows](https://cursor.com/agents/bc-ca5cf961-6951-401b-be91-a6485fc98e7b/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fqueue_add_below_finished_rows.png)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ca5cf961-6951-401b-be91-a6485fc98e7b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ca5cf961-6951-401b-be91-a6485fc98e7b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

