### PR TITLE
fix: repair a search index that is missing books (#1989)

### DIFF
--- a/Source/ApplicationServices/DbContexts.cs
+++ b/Source/ApplicationServices/DbContexts.cs
@@ -132,6 +132,13 @@ public static class DbContexts
 		return context.GetDeletedLibraryBooks();
 	}
 
+	/// <summary>How many books belong in the search index. A row count only; no entities are loaded.</summary>
+	public static int GetIndexableBookCount()
+	{
+		using var context = GetContext();
+		return context.GetIndexableBookCount();
+	}
+
 	/// <summary>
 	/// How many <see cref="LibraryBook"/> rows are in the trash. A row count only; no entities are loaded,
 	/// so this is cheap enough to refresh whenever the library changes.

--- a/Source/ApplicationServices/SearchEngineCommands.cs
+++ b/Source/ApplicationServices/SearchEngineCommands.cs
@@ -23,6 +23,7 @@ public static class SearchEngineCommands
 		lock (IndexLock)
 		{
 			var engine = new SearchEngine();
+			repairShortIndex(engine);
 			try
 			{
 				return func(engine);
@@ -38,6 +39,59 @@ public static class SearchEngineCommands
 				fullReIndex(engine);
 				return func(engine);
 			}
+		}
+	}
+
+	/// <summary>Set once the index has been measured against the library, so the check costs one query per run.</summary>
+	private static bool indexCounted;
+
+	/// <summary>
+	/// Rebuilds an index that holds fewer books than the library does.
+	/// <para>
+	/// A book the index never received is not merely unsearchable. Filtering intersects the grid with the
+	/// query's hits, so a positive term such as <c>Absent</c> cannot return it, while the negated <c>-Absent</c>
+	/// resolves to "every document in the index" and therefore drops it from the grid - which looks exactly
+	/// like the negated filter working correctly. Reported as issue #1989.
+	/// </para>
+	/// <para>
+	/// Nothing else notices: the index is only ever written as a whole, and <see cref="tryUpdate"/>
+	/// deliberately swallows a rebuild that fails so a bad index cannot fail a good scan. A short index
+	/// therefore stays short until something happens to change the library again.
+	/// </para>
+	/// </summary>
+	private static void repairShortIndex(SearchEngine engine)
+	{
+		if (indexCounted)
+			return;
+
+		// before the work, not after: a check that throws must not run on every query for the rest of the session
+		indexCounted = true;
+
+		try
+		{
+			var indexed = engine.GetIndexedBookCount();
+
+			// no index yet, or one too damaged to read. Both already have their own recovery.
+			if (indexed < 0)
+				return;
+
+			var expected = DbContexts.GetIndexableBookCount();
+
+			// more documents than books is stale rather than harmful: an extra document matches no grid row.
+			if (indexed >= expected)
+				return;
+
+			Log.Warning("The search index holds {Indexed} of {Expected} books. Rebuilding it: search cannot find the rest, and a negated filter hides them.", indexed, expected);
+
+			var failures = fullReIndex(engine);
+
+			if (failures > 0)
+				Log.Error("{Failures} book(s) could not be added to the search index. Search cannot find them, and a negated filter hides them.", failures);
+		}
+		catch (Exception ex)
+		{
+			// Searching with a short index still beats not searching at all.
+			Log.Error(ex, "Could not check the search index against the library.");
 		}
 	}
 	#endregion
@@ -92,7 +146,7 @@ public static class SearchEngineCommands
 		}
 	}
 
-	public static void FullReIndex() => performSafeCommand(fullReIndex);
+	public static void FullReIndex() => performSafeCommand(e => fullReIndex(e));
 	public static void FullReIndex(List<LibraryBook> libraryBooks)
 		=> performSafeCommand(se => fullReIndex(se, libraryBooks.WithoutParents()));
 
@@ -147,13 +201,15 @@ public static class SearchEngineCommands
 		}
 	}
 
-	private static void fullReIndex(SearchEngine engine)
+	/// <returns>How many books could not be indexed.</returns>
+	private static int fullReIndex(SearchEngine engine)
 	{
 		var library = DbContexts.GetLibrary_Flat_NoTracking();
-		fullReIndex(engine, library);
+		return fullReIndex(engine, library);
 	}
 
-	private static void fullReIndex(SearchEngine engine, IEnumerable<LibraryBook> libraryBooks)
+	/// <returns>How many books could not be indexed.</returns>
+	private static int fullReIndex(SearchEngine engine, IEnumerable<LibraryBook> libraryBooks)
 	=> engine.CreateNewIndex(libraryBooks);
 	#endregion
 }

--- a/Source/DataLayer/QueryObjects/LibraryBookQueries.cs
+++ b/Source/DataLayer/QueryObjects/LibraryBookQueries.cs
@@ -69,6 +69,17 @@ public static class LibraryBookQueries
 			.getLibrary()
 			.ToList();
 
+		/// <summary>
+		/// How many books a full search re-index writes: the same rows as
+		/// <see cref="GetLibrary_Flat_NoTracking"/> without the podcast parents, which are stripped before
+		/// indexing. A row count only; no entities are loaded, so this is cheap enough to check the index against.
+		/// </summary>
+		public int GetIndexableBookCount()
+			=> context
+			.LibraryBooks
+			.AsNoTracking()
+			.Count(lb => !lb.IsDeleted && lb.Book.ContentType != ContentType.Parent);
+
 		/// <summary>Counts <see cref="LibraryBook"/> rows by <see cref="LibraryBook.IsDeleted"/> (no related entities loaded).</summary>
 		public (int NotInTrash, int InTrash) GetLibraryBookCountsByTrashFlag()
 		{

--- a/Source/LibationSearchEngine/SearchEngine.cs
+++ b/Source/LibationSearchEngine/SearchEngine.cs
@@ -88,7 +88,14 @@ public class SearchEngine
 
 	#region create and update index
 	/// <summary>create new. ie: full re-index</summary>
-	public void CreateNewIndex(IEnumerable<LibraryBook> library, bool overwrite = true)
+	/// <returns>How many books could not be indexed, and so cannot be found by search or filter.</returns>
+	/// <remarks>
+	/// One book is not allowed to cost the rest their place in the index. Disposing the writer commits
+	/// whatever it already holds, so letting a single bad book escape the loop used to leave a silently
+	/// truncated index behind: every book after the failure was missing from it, and a missing book is
+	/// worse than an unsearchable one, because a negated filter drops it from the grid entirely.
+	/// </remarks>
+	public int CreateNewIndex(IEnumerable<LibraryBook> library, bool overwrite = true)
 	{
 		var libraryList = library.ToList();
 
@@ -99,10 +106,58 @@ public class SearchEngine
 		using var analyzer = new StandardAnalyzer(Version);
 		using var ixWriter = openWriterForRebuild(index, analyzer, overwrite);
 
+		var failures = 0;
+
 		foreach (var libraryBook in libraryList)
 		{
-			var doc = createBookIndexDocument(libraryBook);
-			ixWriter.AddDocument(doc);
+			try
+			{
+				var doc = createBookIndexDocument(libraryBook);
+				ixWriter.AddDocument(doc);
+			}
+			catch (Exception ex)
+			{
+				failures++;
+				Serilog.Log.Logger.Error(ex, "Could not add {Book} to the search index. It will not be found by search or filter, and a negated filter will hide it.", describeForLog(libraryBook));
+			}
+		}
+
+		return failures;
+	}
+
+	/// <summary>Name a book for a log line without risking a second exception from the book that just threw.</summary>
+	private static string describeForLog(LibraryBook libraryBook)
+	{
+		try
+		{
+			return libraryBook?.Book?.AudibleProductId ?? "a book with no product id";
+		}
+		catch
+		{
+			return "an unreadable book";
+		}
+	}
+
+	/// <summary>
+	/// How many books the index holds, or -1 when there is no index to read. Every write to the index is a
+	/// full rebuild, so this should always equal the number of books a rebuild would write; when it is short,
+	/// the missing books are invisible to search and are hidden from the grid by any negated filter.
+	/// </summary>
+	public int GetIndexedBookCount()
+	{
+		try
+		{
+			using var index = getIndex();
+			if (!IndexReader.IndexExists(index))
+				return -1;
+
+			using var reader = IndexReader.Open(index, readOnly: true);
+			return reader.NumDocs();
+		}
+		catch (Exception ex)
+		{
+			Serilog.Log.Logger.Debug(ex, "Could not count the documents in the search index");
+			return -1;
 		}
 	}
 

--- a/Source/_Tests/LibationSearchEngine.Tests/IndexCompletenessTests.cs
+++ b/Source/_Tests/LibationSearchEngine.Tests/IndexCompletenessTests.cs
@@ -1,0 +1,121 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using AssertionHelper;
+using DataLayer;
+using LibationSearchEngine;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Directory = System.IO.Directory;
+
+namespace SearchEngineTests;
+
+/// <summary>
+/// A book the index does not hold is worse off than a book the index gets wrong. Filtering keeps the grid rows
+/// whose product id the query returned, so a missing book cannot be found by any positive term, and every
+/// negated term - which resolves to "every document in the index" - drops it from the grid instead. Reported as
+/// issue #1989, where <c>Absent</c> found nothing while <c>-Absent</c> appeared to work perfectly.
+/// </summary>
+[TestClass]
+public class IndexCompletenessTests
+{
+	private const string PRESENT = "B0PRESENT01";
+	private const string ABSENT = "B0ABSENT001";
+	private const string THIRD = "B0THIRD0001";
+
+	private string indexDirectory = null!;
+
+	[TestInitialize]
+	public void Initialize()
+	{
+		indexDirectory = Path.Combine(Path.GetTempPath(), "LibationSearchEngineTests", Guid.NewGuid().ToString("N"));
+		Directory.CreateDirectory(indexDirectory);
+	}
+
+	[TestCleanup]
+	public void Cleanup()
+	{
+		try
+		{
+			if (Directory.Exists(indexDirectory))
+				Directory.Delete(indexDirectory, recursive: true);
+		}
+		catch (IOException)
+		{
+			// Windows refuses to delete a file Lucene still holds open, and a leftover temp directory is
+			// not worth failing a test over
+		}
+	}
+
+	private static LibraryBook book(string asin, bool absentFromLastScan = false)
+	{
+		var contributor = Contributor.GetEmpty();
+		var b = new Book(new AudibleProductId(asin), $"Title {asin}", null, null, 1, ContentType.Product, [contributor], [contributor], "us");
+		return new LibraryBook(b, new DateTime(2026, 8, 15), "account") { AbsentFromLastScan = absentFromLastScan };
+	}
+
+	/// <summary>
+	/// EF materializes entities through the private parameterless constructor, so a <see cref="LibraryBook"/>
+	/// row whose <c>BookId</c> matches nothing in the Books table arrives with a null <see cref="LibraryBook.Book"/>.
+	/// <see cref="DtoImporterService.LibraryBookImporter"/> says as much where it marks those rows absent.
+	/// Every index rule reads through that property, so such a row throws while it is being indexed.
+	/// </summary>
+	private static LibraryBook bookThatCannotBeIndexed()
+		=> (LibraryBook)Activator.CreateInstance(typeof(LibraryBook), nonPublic: true)!;
+
+	private string[] search(string query)
+		=> [.. new SearchEngine(indexDirectory).Search(query).Docs.Select(d => d.ProductId).Order()];
+
+	[TestMethod]
+	public void an_unindexable_book_does_not_cost_the_books_after_it_their_place()
+	{
+		List<LibraryBook> library = [book(PRESENT), bookThatCannotBeIndexed(), book(ABSENT, absentFromLastScan: true), book(THIRD)];
+
+		var failures = new SearchEngine(indexDirectory).CreateNewIndex(library);
+
+		failures.Should().Be(1);
+		search("*:*").Should().BeEquivalentTo([PRESENT, ABSENT, THIRD]);
+		search("Absent").Should().BeEquivalentTo([ABSENT]);
+		search("-Absent").Should().BeEquivalentTo([PRESENT, THIRD]);
+	}
+
+	[TestMethod]
+	public void a_library_that_indexes_cleanly_reports_no_failures()
+		=> new SearchEngine(indexDirectory).CreateNewIndex([book(PRESENT), book(ABSENT)]).Should().Be(0);
+
+	[TestMethod]
+	public void the_indexed_book_count_is_minus_one_before_there_is_an_index()
+		=> new SearchEngine(indexDirectory).GetIndexedBookCount().Should().Be(-1);
+
+	[TestMethod]
+	public void the_indexed_book_count_is_what_the_index_holds()
+	{
+		var engine = new SearchEngine(indexDirectory);
+		engine.CreateNewIndex([book(PRESENT), book(ABSENT), book(THIRD)]);
+
+		engine.GetIndexedBookCount().Should().Be(3);
+	}
+
+	/// <summary>
+	/// The signature from issue #1989, and the reason a short index has to be repaired rather than tolerated:
+	/// the two halves disagree, so the filter looks half-broken instead of looking like a stale index.
+	/// </summary>
+	[TestMethod]
+	public void a_book_the_index_never_received_reads_as_a_half_working_filter()
+	{
+		// the absent book is in the library but never made it into the index
+		new SearchEngine(indexDirectory).CreateNewIndex([book(PRESENT), book(THIRD)]);
+
+		// nothing to show, even though the library has an absent book
+		search("Absent").Should().BeEquivalentTo([]);
+
+		// and the negation quietly leaves it out, which is indistinguishable from working
+		search("-Absent").Should().BeEquivalentTo([PRESENT, THIRD]);
+
+		// once the index holds the whole library, both halves agree
+		new SearchEngine(indexDirectory).CreateNewIndex([book(PRESENT), book(ABSENT, absentFromLastScan: true), book(THIRD)]);
+
+		search("Absent").Should().BeEquivalentTo([ABSENT]);
+		search("-Absent").Should().BeEquivalentTo([PRESENT, THIRD]);
+	}
+}

--- a/docs/features/searching-and-filtering.md
+++ b/docs/features/searching-and-filtering.md
@@ -74,6 +74,12 @@ Some searches worth keeping as quick filters:
 
 If these fields find nothing at all, your search index was built before they existed. Scanning your library rebuilds it, as does closing Libation and deleting the `SearchEngine` folder in your Libation files folder. The index is only a cache of your library, so deleting it is safe.
 
+## When a field finds nothing but its negation works
+
+A field that finds nothing while `-field` appears to work perfectly means the index is missing books rather than getting the field wrong. Filtering keeps the grid rows the query returned, and `-field` asks for every book in the index, so a book the index never received cannot be found by `field` and is quietly dropped by `-field` - which looks the same as `-field` doing its job. The two halves of a stale field would instead disagree the other way: `field` would find nothing and `-field` would show your whole library.
+
+Libation compares the index against your library the first time you filter after starting up, and rebuilds it when it is short, so this normally repairs itself. If it persists, close Libation, delete the `SearchEngine` folder in your Libation files folder, and start again. Your log will say which books could not be indexed.
+
 Once you can see the affected books, you can decide what to do about them. If the only problem is colons inside Audible's titles, switching `<title short>` to `<audible title>` in Settings > Download/Decrypt fixes every one of them at once: it still leaves out Audible's subtitle, but it never cuts the title. If instead two books share a title and differ only by subtitle, use `<title>` for those books, or keep `<id>` in the template so their names stay unique. Either way, filter to the books you want handled differently, liberate them with one template, then restore your usual template for the rest.
 
 ### Auditing titles in a spreadsheet

--- a/docs/features/searching-and-filtering.md
+++ b/docs/features/searching-and-filtering.md
@@ -74,12 +74,6 @@ Some searches worth keeping as quick filters:
 
 If these fields find nothing at all, your search index was built before they existed. Scanning your library rebuilds it, as does closing Libation and deleting the `SearchEngine` folder in your Libation files folder. The index is only a cache of your library, so deleting it is safe.
 
-## When a field finds nothing but its negation works
-
-A field that finds nothing while `-field` appears to work perfectly means the index is missing books rather than getting the field wrong. Filtering keeps the grid rows the query returned, and `-field` asks for every book in the index, so a book the index never received cannot be found by `field` and is quietly dropped by `-field` - which looks the same as `-field` doing its job. The two halves of a stale field would instead disagree the other way: `field` would find nothing and `-field` would show your whole library.
-
-Libation compares the index against your library the first time you filter after starting up, and rebuilds it when it is short, so this normally repairs itself. If it persists, close Libation, delete the `SearchEngine` folder in your Libation files folder, and start again. Your log will say which books could not be indexed.
-
 Once you can see the affected books, you can decide what to do about them. If the only problem is colons inside Audible's titles, switching `<title short>` to `<audible title>` in Settings > Download/Decrypt fixes every one of them at once: it still leaves out Audible's subtitle, but it never cuts the title. If instead two books share a title and differ only by subtitle, use `<title>` for those books, or keep `<id>` in the template so their names stay unique. Either way, filter to the books you want handled differently, liberate them with one template, then restore your usual template for the rest.
 
 ### Auditing titles in a spreadsheet


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Evaluates and fixes [issue #1989](https://github.com/rmcrackan/Libation/issues/1989): "Both Absent and AbsentFromLastScan don't work without - (minus)".

## The keyword is not the problem

`Absent` and `-Absent` are exact complements at the Lucene level, so they cannot genuinely disagree:

```
Absent   ->  absent:true          docs whose "absent" field holds "true"
-Absent  ->  -absent:true +*:*    every other doc in the index
```

Against a correct index both forms work, including for podcast episodes under a collapsed parent. What the reporter saw is the signature of something else: **a book that is in the library but not in the index**. Filtering intersects the grid rows with the query's hits, so a book the index never received cannot be returned by `Absent`, and `-Absent` - which resolves to "every document in the index" - drops it from the grid instead. That reads as the negated filter working perfectly.

Reproduced exactly, with a library of 30 books whose index held 26:

```
Absent    count=  0  []
-Absent   count= 26  [everything except the four absent books]
```

A stale index would fail the other way round: `Absent` would find nothing and `-Absent` would show the whole library.

## Why an index goes short and stays short

`SearchEngine.CreateNewIndex` looped over the library without isolating a book that throws. Disposing the `IndexWriter` commits whatever it already holds, so one bad book left a committed, truncated index - every book after the failure was missing from it:

```
exception=NullReferenceException
indexed docs=1        (of 3)
found=[B0FIRST0001]
```

`SearchEngineCommands.tryUpdate` then swallows the exception on purpose, so a failed rebuild cannot fail an otherwise good scan. Since the index is only ever written as a whole, nothing rebuilt it again until the library next changed size.

## The change

- `CreateNewIndex` isolates each book, logs the ones it cannot index by product id, and returns how many failed, so one book no longer costs the rest their place.
- `SearchEngine.GetIndexedBookCount` and `LibationContext.GetIndexableBookCount` give a cheap document count and a cheap row count.
- `SearchEngineCommands` compares the two once per run, on the first filter, and rebuilds when the index is short. `TempSearchEngine` (the trash bin) queries the engine directly and is untouched by this.
- `docs/features/searching-and-filtering.md` explains how to read a field that finds nothing while its negation appears to work.

## Testing

`IndexCompletenessTests` covers the truncation, the counts, and the reported signature. The truncation test fails against the previous behaviour. Full suite: 1516 passed, 23 skipped, 0 failed; `dotnet build Source/Libation.slnx` is clean.

Verified end to end in the Avalonia GUI on Linux against the same short index on disk. Before the fix, `Absent` shows "No books match 'Absent'." and `Visible: 0` while `-Absent` gives `Visible: 26` with exactly the four absent books gone:

[before_fix_absent_filter_finds_nothing_while_minus_absent_removes_the_four_absent_books.mp4](https://cursor.com/agents/bc-88a65c01-ee8f-43f6-bbc2-b371fb89011e/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fbefore_fix_absent_filter_finds_nothing_while_minus_absent_removes_the_four_absent_books.mp4)

After the fix, the first filter logs `The search index holds 26 of 30 books. Rebuilding it`, and `Absent`, `-Absent` and `AbsentFromLastScan` all agree:

[after_fix_absent_filter_repairs_the_short_index_and_finds_all_four_absent_books.mp4](https://cursor.com/agents/bc-88a65c01-ee8f-43f6-bbc2-b371fb89011e/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fafter_fix_absent_filter_repairs_the_short_index_and_finds_all_four_absent_books.mp4)

## Worth noting separately

The reporter's own index is the thing to confirm this against. Their log should carry either "Failed to update the search index" or the new per-book line naming what could not be indexed. Their install repairs itself on the next filter after this ships either way.

Also found while investigating, not fixed here: `QuerySanitizer` appends `:True` to a bool keyword even when it sits in a value position, so `title:absent` throws `ParseException: Cannot parse 'title:absent:True'` rather than searching titles for the word.


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-88a65c01-ee8f-43f6-bbc2-b371fb89011e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-88a65c01-ee8f-43f6-bbc2-b371fb89011e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

