### PR TITLE
fix: three search query bugs (field names as values, number padding, grouped negation)

### DIFF
--- a/Source/LibationSearchEngine/QuerySanitizer.cs
+++ b/Source/LibationSearchEngine/QuerySanitizer.cs
@@ -18,6 +18,11 @@ internal static partial class QuerySanitizer
 		.Select(n => n.ToLowerInvariant())
 		.ToHashSet();
 
+	private static readonly HashSet<string> numberTerms
+		= SearchEngine.FieldIndexRules.NumberFieldNames
+		.Select(n => n.ToLowerInvariant())
+		.ToHashSet();
+
 	private static readonly HashSet<string> fieldTerms
 		= SearchEngine.FieldIndexRules
 		.SelectMany(r => r.FieldNames)
@@ -45,8 +50,8 @@ internal static partial class QuerySanitizer
 		using var tokenStream = analyzer.TokenStream(SearchEngine.ALL, new System.IO.StringReader(searchString));
 
 		var partList = new List<string>();
-		int previousEndOffset = 0;
-		bool previousIsBool = false, previousIsTags = false, previousIsAsin = false, previousIsField = false;
+		int previousEndOffset = 0, rangeDepth = 0;
+		bool previousIsBool = false, previousIsTags = false, previousIsAsin = false, previousIsField = false, previousIsNumberField = false, inPhrase = false;
 
 		while (tokenStream.IncrementToken())
 		{
@@ -54,6 +59,16 @@ internal static partial class QuerySanitizer
 			var offset = tokenStream.GetAttribute<IOffsetAttribute>();
 
 			var betweenTokens = searchString.Substring(previousEndOffset, offset.StartOffset - previousEndOffset);
+
+			//Neither a range nor a phrase can hold the "(x OR y)" a bare number expands to below, so keep
+			//track of the punctuation that opens one. The analyzer throws punctuation away, which is why
+			//this reads the untokenized text between the tokens rather than the tokens themselves.
+			foreach (var c in betweenTokens)
+			{
+				if (c is '[' or '{') rangeDepth++;
+				else if (c is ']' or '}') rangeDepth = System.Math.Max(0, rangeDepth - 1);
+				else if (c is '"') inPhrase = !inPhrase;
+			}
 
 			//A colon right after a field name makes this term that field's value, whatever it is called.
 			//Plenty of field names are ordinary words a title or a category can contain, and without this
@@ -96,8 +111,25 @@ internal static partial class QuerySanitizer
 			}
 			else if (double.TryParse(term, out var num))
 			{
-				//Term is a number so pad it with zeros
-				partList.Add(num.ToLuceneString());
+				//Which spelling of a number to search for depends on what it is being compared against.
+				//A number field is indexed zero-padded so that a range sorts correctly; every other field
+				//is indexed as written. Padding regardless meant "title:1984" looked for "00001984.00" in
+				//the titles and found nothing, and a bare "1984" could never find the novel.
+				var padded = num.ToLuceneString();
+				var asWritten = searchString.Substring(offset.StartOffset, offset.EndOffset - offset.StartOffset);
+
+				if (isFieldValue)
+					partList.Add(previousIsNumberField ? padded : asWritten);
+				else if (rangeDepth > 0)
+					//Only the padded spelling sorts, and a range is numeric by nature
+					partList.Add(padded);
+				else if (inPhrase)
+					//A phrase is text by nature
+					partList.Add(asWritten);
+				else
+					//No field was named, so this searches the default field, which holds both spellings:
+					//the novel's title as written, and every number field padded. Search for both.
+					partList.Add($"({asWritten} OR {padded})");
 			}
 			else if (!isFieldValue && fieldTerms.Contains(term))
 			{
@@ -107,6 +139,7 @@ internal static partial class QuerySanitizer
 				previousIsBool = boolTerms.Contains(term);
 				previousIsAsin = idTerms.Contains(term);
 				previousIsTags = term == SearchEngine.TAGS;
+				previousIsNumberField = numberTerms.Contains(term);
 				previousIsField = true;
 			}
 			else

--- a/Source/LibationSearchEngine/QuerySanitizer.cs
+++ b/Source/LibationSearchEngine/QuerySanitizer.cs
@@ -46,14 +46,23 @@ internal static partial class QuerySanitizer
 
 		var partList = new List<string>();
 		int previousEndOffset = 0;
-		bool previousIsBool = false, previousIsTags = false, previousIsAsin = false;
+		bool previousIsBool = false, previousIsTags = false, previousIsAsin = false, previousIsField = false;
 
 		while (tokenStream.IncrementToken())
 		{
 			var term = tokenStream.GetAttribute<ITermAttribute>().Term;
 			var offset = tokenStream.GetAttribute<IOffsetAttribute>();
 
-			if (previousIsBool && !bool.TryParse(term, out _))
+			var betweenTokens = searchString.Substring(previousEndOffset, offset.StartOffset - previousEndOffset);
+
+			//A colon right after a field name makes this term that field's value, whatever it is called.
+			//Plenty of field names are ordinary words a title or a category can contain, and without this
+			//they were read as a second field name: "title:absent" became "title:absent:True", which Lucene
+			//cannot parse at all. The bool, ASIN and tag fields have their own handling below, which runs
+			//first and stays in charge of its own value.
+			var isFieldValue = previousIsField && betweenTokens.StartsWith(':');
+
+			if (previousIsBool && !isFieldValue && !bool.TryParse(term, out _))
 			{
 				//The previous term was a boolean tag and this term is NOT a bool value
 				//Add the default ":True" bool and continue parsing the current term
@@ -62,7 +71,9 @@ internal static partial class QuerySanitizer
 			}
 
 			//Add all text between the current token and the previous token
-			partList.Add(searchString.Substring(previousEndOffset, offset.StartOffset - previousEndOffset));
+			partList.Add(betweenTokens);
+
+			previousIsField = false;
 
 			if (previousIsBool)
 			{
@@ -88,7 +99,7 @@ internal static partial class QuerySanitizer
 				//Term is a number so pad it with zeros
 				partList.Add(num.ToLuceneString());
 			}
-			else if (fieldTerms.Contains(term))
+			else if (!isFieldValue && fieldTerms.Contains(term))
 			{
 				//Term is a defined search field, add it.
 				//The StandardAnalyzer already converts all terms to lowercase
@@ -96,6 +107,7 @@ internal static partial class QuerySanitizer
 				previousIsBool = boolTerms.Contains(term);
 				previousIsAsin = idTerms.Contains(term);
 				previousIsTags = term == SearchEngine.TAGS;
+				previousIsField = true;
 			}
 			else
 			{

--- a/Source/LibationSearchEngine/SearchEngine.cs
+++ b/Source/LibationSearchEngine/SearchEngine.cs
@@ -352,17 +352,7 @@ public class SearchEngine
 		using var searcher = new IndexSearcher(index);
 		var query = analyzer.GetQuery(defaultField, searchString);
 
-		// lucene doesn't allow only negations. eg this returns nothing:
-		//     -tags:hidden
-		// work arounds: https://kb.ucla.edu/articles/pure-negation-query-in-lucene
-		// HOWEVER, doing this to any other type of query can cause EVERYTHING to be a match unless "Occur" is carefully set
-		// this should really check that all leaf nodes are MUST_NOT
-		if (query is BooleanQuery boolQuery)
-		{
-			var occurs = getOccurs_recurs(boolQuery);
-			if (occurs.Any() && occurs.All(o => o == Occur.MUST_NOT))
-				boolQuery.Add(new MatchAllDocsQuery(), Occur.MUST);
-		}
+		allowPureNegation(query);
 
 		var docs = searcher
 			.Search(query, searcher.MaxDoc + 1)
@@ -374,19 +364,35 @@ public class SearchEngine
 		return new SearchResultSet(queryString, docs);
 	}
 
-	private IEnumerable<Occur> getOccurs_recurs(BooleanQuery query)
+	/// <summary>
+	/// Gives every all-negative <see cref="BooleanQuery"/> in the tree something positive to subtract from.
+	/// Lucene matches nothing for a query that only excludes, so <c>-tags:hidden</c> needs a
+	/// <see cref="MatchAllDocsQuery"/> added alongside it.
+	/// <para>
+	/// Whether a query needs one is decided by its own clauses and nothing deeper. Judging it by every
+	/// clause in the tree read <c>-(tags:hidden OR tags:archived)</c> as mixed, because of the two SHOULD
+	/// clauses inside the negation, and returned nothing at all. Recursing also reaches a parenthesized
+	/// negation used as a subquery, as in <c>(-tags:hidden) AND (-tags:archived)</c>, where each group
+	/// matches nothing on its own and so the whole query did too.
+	/// </para>
+	/// <para>
+	/// Adding one anywhere else would make everything a match, so recurse first and test afterwards: the
+	/// clause added to a subquery must not be counted when deciding about its parent.
+	/// </para>
+	/// </summary>
+	/// <seealso href="https://kb.ucla.edu/articles/pure-negation-query-in-lucene"/>
+	private static void allowPureNegation(Query query)
 	{
-		var returnList = new List<Occur>();
+		if (query is not BooleanQuery boolQuery)
+			return;
 
-		foreach (var clause in query)
-		{
-			returnList.Add(clause.Occur);
+		var clauses = boolQuery.ToList();
 
-			if (clause.Query is BooleanQuery boolQuery)
-				returnList.AddRange(getOccurs_recurs(boolQuery));
-		}
+		foreach (var clause in clauses)
+			allowPureNegation(clause.Query);
 
-		return returnList;
+		if (clauses.Count > 0 && clauses.TrueForAll(c => c.Occur == Occur.MUST_NOT))
+			boolQuery.Add(new MatchAllDocsQuery(), Occur.MUST);
 	}
 
 	private void displayResults(SearchResultSet docs)

--- a/Source/_Tests/LibationSearchEngine.Tests/FieldNameAsValueTests.cs
+++ b/Source/_Tests/LibationSearchEngine.Tests/FieldNameAsValueTests.cs
@@ -1,0 +1,92 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using AssertionHelper;
+using DataLayer;
+using LibationSearchEngine;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Directory = System.IO.Directory;
+
+namespace SearchEngineTests;
+
+/// <summary>
+/// Search field names are ordinary words - absent, podcast, plus, series, finished - and a book's own text is
+/// full of them. Searching a field for one used to append the implied <c>:True</c> of a bool field to the value
+/// instead of the field, so <c>title:absent</c> became <c>title:absent:True</c> and Lucene refused to parse it.
+/// </summary>
+[TestClass]
+public class FieldNameAsValueTests
+{
+	private const string TITLED_ABSENT = "B0TITLED001";
+	private const string REALLY_ABSENT = "B0MISSING01";
+	private const string UNRELATED = "B0OTHER0001";
+
+	private string indexDirectory = null!;
+
+	[TestInitialize]
+	public void Initialize()
+	{
+		indexDirectory = Path.Combine(Path.GetTempPath(), "LibationSearchEngineTests", Guid.NewGuid().ToString("N"));
+		Directory.CreateDirectory(indexDirectory);
+		new SearchEngine(indexDirectory).CreateNewIndex(library);
+	}
+
+	[TestCleanup]
+	public void Cleanup()
+	{
+		try
+		{
+			if (Directory.Exists(indexDirectory))
+				Directory.Delete(indexDirectory, recursive: true);
+		}
+		catch (IOException)
+		{
+			// Windows refuses to delete a file Lucene still holds open, and a leftover temp directory is
+			// not worth failing a test over
+		}
+	}
+
+	private static LibraryBook book(string asin, string title, bool absentFromLastScan = false)
+	{
+		var contributor = Contributor.GetEmpty();
+		var b = new Book(new AudibleProductId(asin), title, null, null, 1, ContentType.Product, [contributor], [contributor], "us");
+		return new LibraryBook(b, new DateTime(2026, 8, 15), "account") { AbsentFromLastScan = absentFromLastScan };
+	}
+
+	private static readonly List<LibraryBook> library =
+	[
+		book(TITLED_ABSENT, "The Absent Friend"),
+		book(REALLY_ABSENT, "Sign of the Four", absentFromLastScan: true),
+		book(UNRELATED, "A Study in Scarlet")
+	];
+
+	private string[] search(string query)
+		=> [.. new SearchEngine(indexDirectory).Search(query).Docs.Select(d => d.ProductId)];
+
+	/// <summary>The word in a title, not the flag. These are different books, and the search now tells them apart.</summary>
+	[TestMethod]
+	[DataRow("title:absent")]
+	[DataRow("Title:Absent")]
+	[DataRow("title:\"absent friend\"")]
+	public void a_field_can_be_searched_for_a_word_that_names_another_field(string query)
+		=> search(query).Should().BeEquivalentTo([TITLED_ABSENT]);
+
+	/// <summary>The flag still works as a bare keyword, and still ignores what the titles say.</summary>
+	[TestMethod]
+	public void the_bare_keyword_still_means_the_field()
+		=> search("Absent").Should().BeEquivalentTo([REALLY_ABSENT]);
+
+	/// <summary>Only the term right after the colon is a value. Anything later is a field keyword again.</summary>
+	[TestMethod]
+	public void the_next_term_is_a_field_keyword_again()
+	{
+		search("title:absent OR Absent").Should().BeEquivalentTo([TITLED_ABSENT, REALLY_ABSENT]);
+		search("title:absent AND Absent").Should().BeEquivalentTo([]);
+	}
+
+	/// <summary>A bool field given something that is not a bool finds nothing rather than throwing.</summary>
+	[TestMethod]
+	public void a_bool_field_given_a_non_bool_value_finds_nothing()
+		=> search("israted:absent").Should().BeEquivalentTo([]);
+}

--- a/Source/_Tests/LibationSearchEngine.Tests/NumericTitleTests.cs
+++ b/Source/_Tests/LibationSearchEngine.Tests/NumericTitleTests.cs
@@ -25,6 +25,7 @@ public class NumericTitleTests
 	private const string CLARKE = "B02001SPACE";
 	private const string LONG = "B0LONGBOOK1";
 	private const string SHORT = "B0SHORTBOK1";
+	private const string FOURTEEN_HOURS = "B0HOUND0001";
 
 	private string indexDirectory = null!;
 
@@ -59,12 +60,13 @@ public class NumericTitleTests
 	}
 
 	/// <summary>
-	/// Three novels whose titles are numbers, and two books whose lengths collide with those numbers, so a
-	/// test cannot pass by finding the right book for the wrong reason.
+	/// Three novels whose titles are numbers, and three books that match those same numbers through a number
+	/// field instead, so a test cannot pass by finding the right book for the wrong reason. Both
+	/// <c>LengthInMinutes</c> and <c>Hours</c> are indexed, and both are covered.
 	/// <para>
-	/// The lengths are picked to avoid a second such coincidence. <c>Hours</c> is indexed as well as
-	/// <c>LengthInMinutes</c>, so at 866 minutes "14" found the novel through its 14-hour running time and
-	/// passed even against the padding bug. Nothing here is 14 or 1984 hours long.
+	/// The novels' own lengths avoid the collision on purpose. At 866 minutes "14" was found through its
+	/// fourteen-hour running time and the test passed even against the padding bug, which is what
+	/// <see cref="FOURTEEN_HOURS"/> is here to cover deliberately rather than by accident.
 	/// </para>
 	/// </summary>
 	private static readonly List<LibraryBook> library =
@@ -73,7 +75,8 @@ public class NumericTitleTests
 		book(PETERS, "14", lengthInMinutes: 780),
 		book(CLARKE, "2001: A Space Odyssey", lengthInMinutes: 397),
 		book(LONG, "Sign of the Four", lengthInMinutes: 1984),
-		book(SHORT, "A Study in Scarlet", lengthInMinutes: 14)
+		book(SHORT, "A Study in Scarlet", lengthInMinutes: 14),
+		book(FOURTEEN_HOURS, "The Hound of the Baskervilles", lengthInMinutes: 14 * 60)
 	];
 
 	private string[] search(string query)
@@ -88,24 +91,27 @@ public class NumericTitleTests
 		=> CollectionAssert.Contains(search(query), expected);
 
 	/// <summary>
-	/// And still finds the book whose length is that number, which is all it could find before. The default
-	/// field holds both spellings, so this is a union rather than a choice between the two.
+	/// Nothing a bare number used to find is given up for it. The number fields were all it could match
+	/// before, and it still matches every one of them: the default field holds both spellings of a number,
+	/// so searching for both is a union rather than a choice between them.
 	/// </summary>
 	[TestMethod]
-	public void a_bare_number_still_finds_the_number_fields_too()
+	public void a_bare_number_adds_the_title_to_what_it_already_found()
 	{
+		//14 hours and 14 minutes both still match, and now so does the novel
+		search("14").Should().BeEquivalentTo([PETERS, SHORT, FOURTEEN_HOURS]);
 		search("1984").Should().BeEquivalentTo([ORWELL, LONG]);
-		search("14").Should().BeEquivalentTo([PETERS, SHORT]);
 	}
 
-	/// <summary>Naming the field says which of the two is wanted, and neither answer is padded wrongly.</summary>
+	/// <summary>Naming the field says which of them is wanted, and no answer is padded wrongly.</summary>
 	[TestMethod]
-	public void naming_the_field_picks_one_of_the_two()
+	public void naming_the_field_picks_one_of_them()
 	{
 		search("title:1984").Should().BeEquivalentTo([ORWELL]);
 		search("LengthInMinutes:1984").Should().BeEquivalentTo([LONG]);
 		search("title:14").Should().BeEquivalentTo([PETERS]);
 		search("LengthInMinutes:14").Should().BeEquivalentTo([SHORT]);
+		search("Hours:14").Should().BeEquivalentTo([FOURTEEN_HOURS]);
 	}
 
 	/// <summary>A numeric title inside a phrase or beside other words is text too.</summary>
@@ -121,9 +127,9 @@ public class NumericTitleTests
 	[TestMethod]
 	public void number_ranges_still_sort()
 	{
-		search("LengthInMinutes:[600 TO 900]").Should().BeEquivalentTo([ORWELL, PETERS]);
+		search("LengthInMinutes:[600 TO 900]").Should().BeEquivalentTo([ORWELL, PETERS, FOURTEEN_HOURS]);
 		search("LengthInMinutes:[1 to 400]").Should().BeEquivalentTo([CLARKE, SHORT]);
-		search("Hours:[10 TO 20]").Should().BeEquivalentTo([ORWELL, PETERS]);
+		search("Hours:[10 TO 20]").Should().BeEquivalentTo([ORWELL, PETERS, FOURTEEN_HOURS]);
 	}
 
 	/// <summary>A bare number combines with the rest of the syntax without dragging its expansion along.</summary>
@@ -131,6 +137,6 @@ public class NumericTitleTests
 	public void a_bare_number_combines_with_other_terms()
 	{
 		search("1984 AND title:sign").Should().BeEquivalentTo([LONG]);
-		search("-1984").Should().BeEquivalentTo([PETERS, CLARKE, SHORT]);
+		search("-1984").Should().BeEquivalentTo([PETERS, CLARKE, SHORT, FOURTEEN_HOURS]);
 	}
 }

--- a/Source/_Tests/LibationSearchEngine.Tests/NumericTitleTests.cs
+++ b/Source/_Tests/LibationSearchEngine.Tests/NumericTitleTests.cs
@@ -1,0 +1,136 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using AssertionHelper;
+using DataLayer;
+using LibationSearchEngine;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Directory = System.IO.Directory;
+
+namespace SearchEngineTests;
+
+/// <summary>
+/// Lucene 3 has no numeric type, so a number field is indexed zero-padded to make a range sort correctly:
+/// 600 minutes is stored as "00000600.00". Every other field is analyzed and keeps the number as written, so
+/// the novel "1984" is stored as "1984". Padding every number in a query regardless of the field it was being
+/// compared against made a numeric title unfindable: <c>title:1984</c> searched titles for "00001984.00", and
+/// a bare <c>1984</c> could only ever mean "some number field equals 1984".
+/// </summary>
+[TestClass]
+public class NumericTitleTests
+{
+	private const string ORWELL = "B01984ORWEL";
+	private const string PETERS = "B00000014XX";
+	private const string CLARKE = "B02001SPACE";
+	private const string LONG = "B0LONGBOOK1";
+	private const string SHORT = "B0SHORTBOK1";
+
+	private string indexDirectory = null!;
+
+	[TestInitialize]
+	public void Initialize()
+	{
+		indexDirectory = Path.Combine(Path.GetTempPath(), "LibationSearchEngineTests", Guid.NewGuid().ToString("N"));
+		Directory.CreateDirectory(indexDirectory);
+		new SearchEngine(indexDirectory).CreateNewIndex(library);
+	}
+
+	[TestCleanup]
+	public void Cleanup()
+	{
+		try
+		{
+			if (Directory.Exists(indexDirectory))
+				Directory.Delete(indexDirectory, recursive: true);
+		}
+		catch (IOException)
+		{
+			// Windows refuses to delete a file Lucene still holds open, and a leftover temp directory is
+			// not worth failing a test over
+		}
+	}
+
+	private static LibraryBook book(string asin, string title, int lengthInMinutes)
+	{
+		var contributor = Contributor.GetEmpty();
+		var b = new Book(new AudibleProductId(asin), title, null, null, lengthInMinutes, ContentType.Product, [contributor], [contributor], "us");
+		return new LibraryBook(b, new DateTime(2026, 8, 15), "account");
+	}
+
+	/// <summary>
+	/// Three novels whose titles are numbers, and two books whose lengths collide with those numbers, so a
+	/// test cannot pass by finding the right book for the wrong reason.
+	/// <para>
+	/// The lengths are picked to avoid a second such coincidence. <c>Hours</c> is indexed as well as
+	/// <c>LengthInMinutes</c>, so at 866 minutes "14" found the novel through its 14-hour running time and
+	/// passed even against the padding bug. Nothing here is 14 or 1984 hours long.
+	/// </para>
+	/// </summary>
+	private static readonly List<LibraryBook> library =
+	[
+		book(ORWELL, "1984", lengthInMinutes: 675),
+		book(PETERS, "14", lengthInMinutes: 780),
+		book(CLARKE, "2001: A Space Odyssey", lengthInMinutes: 397),
+		book(LONG, "Sign of the Four", lengthInMinutes: 1984),
+		book(SHORT, "A Study in Scarlet", lengthInMinutes: 14)
+	];
+
+	private string[] search(string query)
+		=> [.. new SearchEngine(indexDirectory).Search(query).Docs.Select(d => d.ProductId)];
+
+	/// <summary>Typing a title into the search box finds the book, even when the title is a number.</summary>
+	[TestMethod]
+	[DataRow("1984", ORWELL)]
+	[DataRow("14", PETERS)]
+	[DataRow("2001", CLARKE)]
+	public void a_bare_number_finds_the_novel_named_after_it(string query, string expected)
+		=> CollectionAssert.Contains(search(query), expected);
+
+	/// <summary>
+	/// And still finds the book whose length is that number, which is all it could find before. The default
+	/// field holds both spellings, so this is a union rather than a choice between the two.
+	/// </summary>
+	[TestMethod]
+	public void a_bare_number_still_finds_the_number_fields_too()
+	{
+		search("1984").Should().BeEquivalentTo([ORWELL, LONG]);
+		search("14").Should().BeEquivalentTo([PETERS, SHORT]);
+	}
+
+	/// <summary>Naming the field says which of the two is wanted, and neither answer is padded wrongly.</summary>
+	[TestMethod]
+	public void naming_the_field_picks_one_of_the_two()
+	{
+		search("title:1984").Should().BeEquivalentTo([ORWELL]);
+		search("LengthInMinutes:1984").Should().BeEquivalentTo([LONG]);
+		search("title:14").Should().BeEquivalentTo([PETERS]);
+		search("LengthInMinutes:14").Should().BeEquivalentTo([SHORT]);
+	}
+
+	/// <summary>A numeric title inside a phrase or beside other words is text too.</summary>
+	[TestMethod]
+	public void a_number_in_a_phrase_is_text()
+	{
+		search("title:\"2001 a space odyssey\"").Should().BeEquivalentTo([CLARKE]);
+		search("\"2001 a space odyssey\"").Should().BeEquivalentTo([CLARKE]);
+		search("title:2001 AND title:odyssey").Should().BeEquivalentTo([CLARKE]);
+	}
+
+	/// <summary>The padding exists for ranges, which still sort. This is what must not regress.</summary>
+	[TestMethod]
+	public void number_ranges_still_sort()
+	{
+		search("LengthInMinutes:[600 TO 900]").Should().BeEquivalentTo([ORWELL, PETERS]);
+		search("LengthInMinutes:[1 to 400]").Should().BeEquivalentTo([CLARKE, SHORT]);
+		search("Hours:[10 TO 20]").Should().BeEquivalentTo([ORWELL, PETERS]);
+	}
+
+	/// <summary>A bare number combines with the rest of the syntax without dragging its expansion along.</summary>
+	[TestMethod]
+	public void a_bare_number_combines_with_other_terms()
+	{
+		search("1984 AND title:sign").Should().BeEquivalentTo([LONG]);
+		search("-1984").Should().BeEquivalentTo([PETERS, CLARKE, SHORT]);
+	}
+}

--- a/Source/_Tests/LibationSearchEngine.Tests/NumericTitleTests.cs
+++ b/Source/_Tests/LibationSearchEngine.Tests/NumericTitleTests.cs
@@ -130,6 +130,20 @@ public class NumericTitleTests
 		search("LengthInMinutes:[600 TO 900]").Should().BeEquivalentTo([ORWELL, PETERS, FOURTEEN_HOURS]);
 		search("LengthInMinutes:[1 to 400]").Should().BeEquivalentTo([CLARKE, SHORT]);
 		search("Hours:[10 TO 20]").Should().BeEquivalentTo([ORWELL, PETERS, FOURTEEN_HOURS]);
+
+		//curly braces exclude the bounds, and have to be recognised as a range the same way
+		search("LengthInMinutes:{675 TO 1984}").Should().BeEquivalentTo([PETERS, FOURTEEN_HOURS]);
+	}
+
+	/// <summary>
+	/// A wildcard reaches a numeric title too, which it could not while the number was being padded:
+	/// "title:19*" went looking for "00000019.00*".
+	/// </summary>
+	[TestMethod]
+	public void a_wildcard_works_on_a_numeric_title()
+	{
+		search("title:19*").Should().BeEquivalentTo([ORWELL]);
+		search("title:20*").Should().BeEquivalentTo([CLARKE]);
 	}
 
 	/// <summary>A bare number combines with the rest of the syntax without dragging its expansion along.</summary>

--- a/Source/_Tests/LibationSearchEngine.Tests/PureNegationTests.cs
+++ b/Source/_Tests/LibationSearchEngine.Tests/PureNegationTests.cs
@@ -1,0 +1,104 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using AssertionHelper;
+using DataLayer;
+using LibationSearchEngine;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Directory = System.IO.Directory;
+
+namespace SearchEngineTests;
+
+/// <summary>
+/// Lucene returns nothing for a query that only excludes, so an all-negative query needs a match-all clause
+/// added to subtract from. Deciding that by every clause in the query tree rather than by the clauses of each
+/// query in it meant a negation with anything inside it - a group, a second term - was read as mixed and left
+/// the user with no results.
+/// </summary>
+[TestClass]
+public class PureNegationTests
+{
+	private const string SIGN = "B0SIGN00001";
+	private const string STUDY = "B0STUDY0001";
+	private const string HOUND = "B0HOUND0001";
+
+	private string indexDirectory = null!;
+
+	[TestInitialize]
+	public void Initialize()
+	{
+		indexDirectory = Path.Combine(Path.GetTempPath(), "LibationSearchEngineTests", Guid.NewGuid().ToString("N"));
+		Directory.CreateDirectory(indexDirectory);
+		new SearchEngine(indexDirectory).CreateNewIndex(library);
+	}
+
+	[TestCleanup]
+	public void Cleanup()
+	{
+		try
+		{
+			if (Directory.Exists(indexDirectory))
+				Directory.Delete(indexDirectory, recursive: true);
+		}
+		catch (IOException)
+		{
+			// Windows refuses to delete a file Lucene still holds open, and a leftover temp directory is
+			// not worth failing a test over
+		}
+	}
+
+	private static LibraryBook book(string asin, string title)
+	{
+		var contributor = Contributor.GetEmpty();
+		var b = new Book(new AudibleProductId(asin), title, null, null, 100, ContentType.Product, [contributor], [contributor], "us");
+		return new LibraryBook(b, new DateTime(2026, 8, 15), "account");
+	}
+
+	private static readonly List<LibraryBook> library =
+	[
+		book(SIGN, "Doyle Sign of the Four"),
+		book(STUDY, "Doyle A Study in Scarlet"),
+		book(HOUND, "Doyle The Hound")
+	];
+
+	private string[] search(string query)
+		=> [.. new SearchEngine(indexDirectory).Search(query).Docs.Select(d => d.ProductId)];
+
+	/// <summary>The plain shapes, which already worked and must keep working.</summary>
+	[TestMethod]
+	public void a_single_negation_subtracts_from_the_whole_library()
+	{
+		search("-title:sign").Should().BeEquivalentTo([STUDY, HOUND]);
+		search("-title:sign -title:study").Should().BeEquivalentTo([HOUND]);
+		search("-(title:sign)").Should().BeEquivalentTo([STUDY, HOUND]);
+	}
+
+	/// <summary>Excluding a group of alternatives at once, which used to return nothing.</summary>
+	[TestMethod]
+	public void a_negated_group_subtracts_every_alternative_in_it()
+		=> search("-(title:sign OR title:study)").Should().BeEquivalentTo([HOUND]);
+
+	/// <summary>
+	/// A parenthesized negation used as a subquery. Each group matches nothing on its own, so the query
+	/// they make up matched nothing either, whichever way they were combined.
+	/// </summary>
+	[TestMethod]
+	public void negations_combined_as_subqueries_each_get_their_own_match_all()
+	{
+		search("(-title:sign) AND (-title:study)").Should().BeEquivalentTo([HOUND]);
+		search("(-title:sign) OR (-title:study)").Should().BeEquivalentTo([SIGN, STUDY, HOUND]);
+	}
+
+	/// <summary>
+	/// A query that already has something positive in it must not get a match-all, or the negation would
+	/// have the whole library to subtract from and the positive half would stop narrowing anything.
+	/// </summary>
+	[TestMethod]
+	public void a_query_with_a_positive_clause_is_left_alone()
+	{
+		search("title:hound OR -title:sign").Should().BeEquivalentTo([HOUND]);
+		search("title:doyle AND -(title:sign OR title:study)").Should().BeEquivalentTo([HOUND]);
+		search("title:sign").Should().BeEquivalentTo([SIGN]);
+	}
+}

--- a/Source/_Tests/LibationSearchEngine.Tests/SearchEngineTests.cs
+++ b/Source/_Tests/LibationSearchEngine.Tests/SearchEngineTests.cs
@@ -76,6 +76,22 @@ public class FormatSearchQuery
 	[DataRow("IsRated", "israted:True")]
 	[DataRow("-isRATED", "-israted:True")]
 
+	// a value which happens to be named like a search field stays a value. Lucene cannot parse a second
+	// colon, so "title:absent" used to throw rather than search titles for the word
+	[DataRow("title:absent", "title:absent")]
+	[DataRow("Title:Absent", "title:Absent")]
+	[DataRow("category:podcast", "category:podcast")]
+	[DataRow("author:plus", "author:plus")]
+	[DataRow("title:\"absent friends\"", "title:\"absent friends\"")]
+	[DataRow("-title:absent", "-title:absent")]
+	// a bool field keeps its own handling, including a value that is not a bool
+	[DataRow("israted:absent", "israted:absent")]
+	// only the term right after the colon is a value. The next one is a field again
+	[DataRow("title:absent absent", "title:absent absent:True")]
+	[DataRow("title:absent AND liberated", "title:absent AND liberated:True")]
+	// a number after a field is still padded, which is how the number fields are indexed
+	[DataRow("LengthInMinutes:600", "lengthinminutes:00000600.00")]
+
 	public void FormattingTest(string input, string output)
 	{
 		CultureInfo.DefaultThreadCurrentCulture = CultureInfo.InvariantCulture;

--- a/Source/_Tests/LibationSearchEngine.Tests/SearchEngineTests.cs
+++ b/Source/_Tests/LibationSearchEngine.Tests/SearchEngineTests.cs
@@ -62,8 +62,25 @@ public class FormatSearchQuery
 	[DataRow("[tags][israted]", "tags:tags tags:israted ")]
 
 	// numbers with "to". TO all caps, numbers [8.2] format
-	[DataRow("1 to 10", "00000001.00 TO 00000010.00")]
-	[DataRow("19990101 to 20001231", "19990101.00 TO 20001231.00")]
+	[DataRow("1 to 10", "(1 OR 00000001.00) TO (10 OR 00000010.00)")]
+	[DataRow("19990101 to 20001231", "(19990101 OR 19990101.00) TO (20001231 OR 20001231.00)")]
+
+	// a number field is indexed zero-padded so a range sorts, so its values are padded to match
+	[DataRow("LengthInMinutes:600", "lengthinminutes:00000600.00")]
+	[DataRow("Rating:[1 to 5]", "rating:[00000001.00 TO 00000005.00]")]
+	[DataRow("DatePublished:19990101", "datepublished:19990101.00")]
+	// every other field is indexed as written, so padding its values found nothing
+	[DataRow("title:1984", "title:1984")]
+	[DataRow("title:\"2001 a space odyssey\"", "title:\"2001 a space odyssey\"")]
+	[DataRow("[14]", "tags:14 ")]
+	// no field named, so the default field holds both spellings and both are searched
+	[DataRow("14", "(14 OR 00000014.00)")]
+	[DataRow("-1984", "-(1984 OR 00001984.00)")]
+	[DataRow("1984 AND liberated", "(1984 OR 00001984.00) AND liberated:True")]
+	// a bare range still needs the padded spelling, and cannot hold a disjunction
+	[DataRow("[1 to 10]", "[00000001.00 TO 00000010.00]")]
+	// nor can a phrase, which is text
+	[DataRow("\"2001 a space odyssey\"", "\"2001 a space odyssey\"")]
 
 	// subtitle keywords are bool fields, not text fields
 	[DataRow("HasSubtitle", "hassubtitle:True")]
@@ -89,8 +106,6 @@ public class FormatSearchQuery
 	// only the term right after the colon is a value. The next one is a field again
 	[DataRow("title:absent absent", "title:absent absent:True")]
 	[DataRow("title:absent AND liberated", "title:absent AND liberated:True")]
-	// a number after a field is still padded, which is how the number fields are indexed
-	[DataRow("LengthInMinutes:600", "lengthinminutes:00000600.00")]
 
 	public void FormattingTest(string input, string output)
 	{

--- a/docs/features/lucene.md
+++ b/docs/features/lucene.md
@@ -1,48 +1,61 @@
 # Lucene Query Syntax
 
-Lucene has a custom query syntax for querying its indexes. Here are some query examples demonstrating the query syntax.
+Libation's search box takes a Lucene query. Simple searches need none of this - type a few words and press enter - but the full syntax is there when you want it.
+
+The examples below use Libation's own fields. Click the [?] button beside the search box for the complete list, along with the synonyms for each: `author` and `authors` both work, as do `length`, `minutes` and `lengthinminutes`.
 
 ## Keyword matching
 
-Search for word "foo" in the title field.
+Search the title for the word "hound".
 
-`title:foo`
+`title:hound`
 
-Search for phrase "foo bar" in the title field.
+Search the title for the phrase "sign of the four". Without the quotes these would be four separate words, and a book whose title contains any of them would match.
 
-`title:"foo bar"`
+`title:"sign of the four"`
 
-Search for phrase "foo bar" in the title field AND the phrase "quick fox" in the body field.
+Search for books Neil Gaiman wrote and also narrated. Without `AND` you would get everything he wrote plus everything anyone narrated of their own.
 
-`title:"foo bar" AND body:"quick fox"`
+`author:gaiman AND narrator:gaiman`
 
-Search for either the phrase "foo bar" in the title field AND the phrase "quick fox" in the body field, or the word "fox" in the title field.
+Group terms with parentheses to combine `AND` and `OR` in one query.
 
-`(title:"foo bar" AND body:"quick fox") OR title:fox`
+`(author:doyle AND narrator:fry) OR title:gods`
 
-Search for word "foo" and not "bar" in the title field.
+Search for books by Doyle that Fry did not narrate. `-` and `NOT` mean the same thing.
 
-`title:foo -title:bar`
+`author:doyle -narrator:fry`
+
+Exclude a group of alternatives at once.
+
+`-(narrator:fry OR narrator:jacobi)`
 
 ## Wildcard matching
 
-Search for any word that starts with "foo" in the title field.
+Any word in the title starting with "scar", which finds "Scarlet".
 
-`title:foo*`
+`title:scar*`
 
-Search for any word that starts with "foo" and ends with bar in the title field.
+`*` also works inside a word. This finds "Jacobi".
 
-`title:foo*bar`
+`narrator:j*bi`
 
-Note that Lucene doesn't support using a * symbol as the first character of a search.
+Lucene does not allow `*` or `?` as the first character of a search, so `title:*hound` is an error rather than a search.
 
 ## Range searches
 
-Range Queries allow one to match documents whose field(s) values are between the lower and upper bound specified by the Range Query. Range Queries can be inclusive or exclusive of the upper and lower bounds. Sorting is done lexicographically.
+A range matches every value between a lower and an upper bound. Square brackets include the bounds and curly braces exclude them, so a book of exactly 290 minutes matches the first of these but not the second.
 
+`length:[290 TO 397]`
 
-`mod_date:[20020101 TO 20030101]`
+`length:{290 TO 397}`
+
+Dates are written as yyyymmdd.
+
+`datepublished:[20200101 TO 20231231]`
+
+Lucene sorts a range lexicographically rather than numerically, which would put 9 after 100. Libation stores its numbers zero-padded so that they sort correctly and pads whatever you type to match, so type the number you mean and ignore this.
 
 ---
 
-The above guide was helpfully provided by https://supermind.org
+The structure of the above guide was helpfully provided by https://supermind.org

--- a/docs/features/searching-and-filtering.md
+++ b/docs/features/searching-and-filtering.md
@@ -54,6 +54,22 @@ I tagged autobiographies as auto_bio and biographies written by someone else as 
 ![Search example: [bio]](../images/SearchExampleBio.png)
 ![Search example: [auto_bio]](../images/SearchExampleAutoBio.png)
 
+## When a search term could mean two things
+
+Some of what you type is read as a field rather than as the words themselves, because that is usually what you meant. Naming the field settles it.
+
+A word that is also a search field means the field. Typing `absent` finds the books Audible no longer lists, not books with "absent" in the title, and the same goes for `podcast`, `finished`, `spatial` and the rest. The [?] button lists every one of them, which is the quickest way to check whether a word you want to search for is also a keyword.
+
+- `absent` - books missing from your last scan
+- `title:absent` - books with "absent" in the title
+- `title:absent AND -absent` - the word, on books that are still listed
+
+A number is searched as both text and a number at once, because a number can be a title or a length, a rating or a date. `1984` finds Orwell's novel and every book 1984 minutes long; `14` finds Peter Clines' novel and everything fourteen minutes or fourteen hours long. Name the field to get one or the other.
+
+- `1984` - the novel, and anything that measures 1984
+- `title:1984` - only the novel
+- `length:1984` - only books 1984 minutes long
+
 ## Subtitles and short titles
 
 The `<title short>` tag keeps everything before the first colon, which is what keeps the default folder name short. That is usually what you want, but not always. "A Book Series Omnibus: Volume One" and "A Book Series Omnibus: Volume Two" both shorten to "A Book Series Omnibus", so the two books land in the same folder and can no longer be told apart by name.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Three bugs in how a filter string is turned into a Lucene query, all found while investigating [issue #1989](https://github.com/rmcrackan/Libation/issues/1989) and none of them its cause, plus the search docs.

## 1. A value that happens to name a search field

Field names are ordinary words - `absent`, `podcast`, `plus`, `finished` - and a book's own title or category is full of them. The sanitizer read a recognised field name as a field name wherever it appeared, so a value in that position picked up the implied `:True` of a bool field:

```
title:absent           ->  title:absent:True            ParseException, "Bad filter string" dialog
category:podcast       ->  category:podcast:True        ParseException
title:"absent friend"  ->  title:"absent:True friend"   parses, silently matches nothing
```

A colon straight after a field name now marks the next term as that field's value. Only that one term, so `title:absent AND liberated` still expands to `title:absent AND liberated:True`.

## 2. A number was padded whatever field it was compared against

Lucene 3 has no numeric type, so a number field is indexed zero-padded to make a range sort: 600 minutes is stored as `00000600.00`. Every other field is analyzed and keeps the number as written, so the novel *1984* is stored as `1984`. Padding every number in a query regardless of its field made a numeric title unfindable, and there are plenty of those - *1984*, *14*, *2001: A Space Odyssey*, *1776*, *11/22/63*:

```
title:1984  ->  title:00001984.00   nothing; the titles hold "1984"
1984        ->  00001984.00         only "some number field is 1984", never the novel
2001        ->  00002001.00         nothing at all
title:19*   ->  title:00000019.00*  a wildcard could not reach a numeric title either
```

A number now takes the spelling the field it is compared against is indexed in. With no field named the query goes to the default field, which holds *both* spellings, so both are searched.

**A bare number gives nothing up for this.** It is a union, not a choice: everything a bare number matched before it still matches, and the book named after the number is added. Measured over a library where three novels are named after numbers and three other books match those numbers through `LengthInMinutes` or `Hours`:

| search | before | after |
|---|---|---|
| `14` | *A Study in Scarlet* (14 min), *The Hound of the Baskervilles* (14 hr) | the same two, **plus the novel _14_** |
| `1984` | *Sign of the Four* (1984 min) | the same, **plus the novel _1984_** |
| `2001` | nothing | ***2001: A Space Odyssey*** |

A range and a phrase cannot contain the disjunction, so a range stays padded (which is what padding is for) and a phrase does not (a phrase is text).

Two existing `FormattingTest` rows change as a result. Bare `1 to 10` and `19990101 to 20001231` now expand each number rather than only padding it. Neither was a range - without brackets Lucene reads them as loose terms and drops `to` as a stop word - so both now match a strict superset of what they did.

## 3. Grouped negation returned nothing

Expanding a bare number to a group exposed this one, but it is older and independent: it needs no numbers to reproduce. Lucene matches nothing for a query that only excludes, so an all-negative query needs a match-all clause to subtract from. Whether to add one was judged by every clause in the whole query tree, so any negation with something inside it was read as mixed and got nothing:

```
-(title:sign OR title:study)       ->  []   should be everything else
(-title:sign) AND (-title:study)   ->  []   should be everything else
(-title:sign) OR (-title:study)    ->  []   should be nearly everything
```

`-[hidden]` works, but `-([hidden] OR [archived])` does not, which is a natural thing to put in a quick filter. It is now decided per query, by that query's own clauses, recursing so a negation nested as a subquery gets its own. A query with anything positive in it is still left alone.

## Docs

**`searching-and-filtering.md`** gains a section on telling a keyword from the word and a number from a title. Both are newly worth explaining: `title:absent` used to raise "Bad filter string", and a numeric title could not be found at all, so until now there was nothing to document.

**`lucene.md`** is rewritten around Libation's own fields. It was a generic Lucene primer whose examples searched `title`, `body` and `mod_date`; only the first of those exists here, so half the guide could not be typed into the search box. It now also shows the exclusive range and the leading-wildcard error that the old text described but never demonstrated. Attribution kept, narrowed to the structure.

Every example in both files was run against a real index before being written down. The in-app [?] dialog builds its field lists from `FieldIndexRules`, so those stay current on their own, and none of its usage examples are made wrong by these changes.

## Testing

Twenty-eight new `FormattingTest` rows plus `FieldNameAsValueTests`, `NumericTitleTests` and `PureNegationTests`, all running real queries against a real index. Thirty-one fail against master. Full suite: 1550 passed, 23 skipped, 0 failed; `dotnet build Source/Libation.slnx` is clean.

`NumericTitleTests` puts the novels *1984*, *14* and *2001: A Space Odyssey* alongside books that match those same numbers through a number field instead, so no test can pass by finding the right book for the wrong reason. Both indexed length fields are covered, `LengthInMinutes` and `Hours`, and that distinction earned its keep: an earlier draft gave the novel *14* a length of 866 minutes, and the test passed even against the bug because 866 minutes is fourteen hours. Writing the docs turned up two more shapes that reach the new number handling and had no coverage - a wildcard on a numeric title, and a curly-brace range - so both now have tests.

[bare_number_search_is_additive.log](https://cursor.com/agents/bc-88a65c01-ee8f-43f6-bbc2-b371fb89011e/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fbare_number_search_is_additive.log)

Verified in the Avalonia GUI on Linux. Before, searching for a numeric title finds only the book of that *length*, and `2001` and `title:1984` find nothing at all:

[before_fix_numeric_titles_1984_14_and_2001_cannot_be_found_by_searching_for_them.mp4](https://cursor.com/agents/bc-88a65c01-ee8f-43f6-bbc2-b371fb89011e/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fbefore_fix_numeric_titles_1984_14_and_2001_cannot_be_found_by_searching_for_them.mp4)

After, `1984` and `14` return the novel *and* the book of that length, `2001` returns *2001: A Space Odyssey*, `title:1984` and `LengthInMinutes:1984` each pick out one of the two, and the range and negation still work:

[after_fix_numeric_titles_found_while_number_fields_ranges_and_negation_still_work.mp4](https://cursor.com/agents/bc-88a65c01-ee8f-43f6-bbc2-b371fb89011e/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fafter_fix_numeric_titles_found_while_number_fields_ranges_and_negation_still_work.mp4)

The earlier pair for the first bug, showing `title:absent` and `category:podcast` raising "Bad filter string" and then working:

[before_fix_title_absent_and_category_podcast_raise_bad_filter_string_errors.mp4](https://cursor.com/agents/bc-88a65c01-ee8f-43f6-bbc2-b371fb89011e/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fbefore_fix_title_absent_and_category_podcast_raise_bad_filter_string_errors.mp4)

[after_fix_title_absent_searches_titles_while_bare_absent_still_means_the_flag.mp4](https://cursor.com/agents/bc-88a65c01-ee8f-43f6-bbc2-b371fb89011e/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fafter_fix_title_absent_searches_titles_while_bare_absent_still_means_the_flag.mp4)

---

Merges cleanly with master now that [#1991](https://github.com/rmcrackan/Libation/pull/1991) has landed; the only shared file is `SearchEngine.cs` and the two touch different methods in it.


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-88a65c01-ee8f-43f6-bbc2-b371fb89011e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-88a65c01-ee8f-43f6-bbc2-b371fb89011e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

