### PR TITLE
fix: restore the LibationWinForms build

### DIFF
--- a/Source/LibationWinForms/Form1.VisibleBooks.cs
+++ b/Source/LibationWinForms/Form1.VisibleBooks.cs
@@ -35,7 +35,7 @@ public partial class Form1
 	{
 		try
 		{
-			setLiberatedVisibleMenuItemCore();
+			setLiberatedVisibleMenuItemCore(visible);
 		}
 		// Both callers are async void event handlers, where a failure is not a faulted task anyone awaits but
 		// an unhandled exception that closes Libation. Counting these books reads the file system, which can
@@ -47,7 +47,11 @@ public partial class Form1
 		}
 	}
 
-	private void setLiberatedVisibleMenuItemCore()
+	/// <param name="visible">
+	/// The books to count, which every caller reads off the grid on the UI thread before handing the counting
+	/// to a thread pool thread. This runs on that thread, so reaching for the grid here instead would race.
+	/// </param>
+	private void setLiberatedVisibleMenuItemCore(List<DataLayer.LibraryBook>? visible)
 	{
 		//Assume that all calls to update arrive in order,
 		//Only display results of the latest book count.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
`LibationWinForms` has not compiled on master since [#1958](https://github.com/rmcrackan/Libation/pull/1958) merged:

```
Source/LibationWinForms/Form1.VisibleBooks.cs(55,3):  error CS0103: The name 'visible' does not exist in the current context
Source/LibationWinForms/Form1.VisibleBooks.cs(56,48): error CS0103: The name 'visible' does not exist in the current context
```

`setLiberatedVisibleMenuItem` takes the books to count as a parameter, but the body that reads it was extracted into `setLiberatedVisibleMenuItemCore`, which does not, so the extracted method refers to a name that is not in its scope.

Two changes landed on the same method within hours of each other and git merged them with no textual conflict:

- `75f1d753` (14:22 UTC) pulled the body out into `setLiberatedVisibleMenuItemCore` behind a try/catch.
- `819193fe` (17:41 UTC) merged #1958, bringing in `e90850f1` from June, which had added the `visible ??=` fallback to that body.

Neither is wrong on its own. The merge put the fallback inside the extracted method and left the parameter on the caller.

## The change

Thread the parameter through, which is the whole fix, plus a note on why it is a parameter at all: both callers read the grid on the UI thread before handing the counting to a thread pool thread, so the extracted method must not reach for the grid itself. That constraint is invisible from inside the method, and losing it is how this broke.

## Testing

`dotnet build Source/Libation.slnx` now succeeds with 0 errors, where it failed with 2 before. `HangoverWinForms`, `LoadByOS/WindowsConfigApp` and `LoadByOS/MacOSConfigApp` each build individually as well. `dotnet test` from `Source/`: 1580 passed, 23 skipped, 0 failed.

This is a compile fix, and WinForms has no Linux runtime, so the menu item's behaviour at runtime has not been exercised here and still wants a look on Windows. The code path is unchanged from what #1958 intended: the caller supplies the list, and the `??=` fallback stays for a call that does not.

## Related

CI did not catch this, and its Windows job hit the identical error while still reporting success. That is a separate bug in `build-windows.yml`, fixed in [#1995](https://github.com/rmcrackan/Libation/pull/1995). This PR is worth merging first, since that one will correctly go red until this lands.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-88a65c01-ee8f-43f6-bbc2-b371fb89011e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-88a65c01-ee8f-43f6-bbc2-b371fb89011e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

