### PR TITLE
ci: fail the Windows build when a publish fails

### DIFF
--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -66,10 +66,20 @@ jobs:
             "-p:PublishReadyToRun=${{ inputs.publish-r2r }}",
             "-p:SelfContained=true")            
           
-          dotnet publish "Libation${{ matrix.ui }}/Libation${{ matrix.ui }}.csproj" $PUBLISH_ARGS
-          dotnet publish "LoadByOS/WindowsConfigApp/WindowsConfigApp.csproj" $PUBLISH_ARGS
-          dotnet publish "LibationCli/LibationCli.csproj" $PUBLISH_ARGS
-          dotnet publish "Hangover${{ matrix.ui }}/Hangover${{ matrix.ui }}.csproj" $PUBLISH_ARGS
+          # PowerShell does not stop at a native command that fails, and the step is judged by the exit code
+          # of the last one, so a publish that fails anywhere but the end passes as a green build. That is not
+          # hypothetical: LibationWinForms failed to compile for a while and every run stayed green, uploading
+          # a Libation-Classic zip with no Libation.exe in it. Check each one.
+          $projects = @(
+            "Libation${{ matrix.ui }}/Libation${{ matrix.ui }}.csproj",
+            "LoadByOS/WindowsConfigApp/WindowsConfigApp.csproj",
+            "LibationCli/LibationCli.csproj",
+            "Hangover${{ matrix.ui }}/Hangover${{ matrix.ui }}.csproj")
+          
+          foreach ($project in $projects) {
+            dotnet publish "$project" $PUBLISH_ARGS
+            if ($LASTEXITCODE -ne 0) { throw "dotnet publish failed for $project" }
+          }
 
       - name: Zip artifact
         id: zip
@@ -81,6 +91,11 @@ jobs:
             "WindowsConfigApp.deps.json")
           
           foreach ($file in $delfiles){ if (test-path $file){ Remove-Item $file } }
+          
+          # Both UIs publish as Libation.exe. upload-artifact's if-no-files-found only proves the zip exists,
+          # which it does whether or not the app is inside it, so say outright that it has to be.
+          if (-not (Test-Path "Libation.exe")) { throw "Libation.exe is missing from the publish output" }
+          
           $artifact="${{ matrix.artifact_stem }}.${{ inputs.libation-version }}-windows-${{ matrix.release_name }}-${{ matrix.architecture }}.zip"
           "artifact=$artifact" >> $env:GITHUB_OUTPUT
           Compress-Archive -Path * -DestinationPath "$artifact"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## The hole

The four `dotnet publish` calls in the Publish step share one `run:` block, and on `windows-latest` that block runs under `pwsh`. PowerShell does not stop at a native command that fails, and Actions judges the step by `$LASTEXITCODE` once, after the whole block. Only the last publish was ever able to fail the build.

That is not hypothetical. `LibationWinForms` stopped compiling on 24 Aug and every run since stayed green. From the `Windows-classic-x64 (WinForms)` job on master at the time:

```
##[error]...\Form1.VisibleBooks.cs(55,3): error CS0103: The name 'visible' does not exist in the current context
...
  WindowsConfigApp -> ...\bin\
  LibationCli      -> ...\bin\
  HangoverWinForms -> ...\bin\
```

The WinForms publish errored, the three after it succeeded, the step exited on the last one's code, and the job passed. `upload-artifact`'s `if-no-files-found: error` did not help either, because it only proves the zip exists, not that anything useful is in it. Downloading what that green run uploaded:

```
Libation-Classic.13.7.10-windows-classic-x64.zip -- 308 entries
  Libation.exe        -> MISSING
  Libation.dll        -> MISSING
  Libation.deps.json  -> MISSING
  Hangover.exe        -> present
  LibationCli.exe     -> present
```

A Libation Classic package with no Libation Classic in it. No shipped release was affected - v13.7.10 was published on 17 Aug, a week before the breakage - but the next release cut from master would have been that zip.

## The change

Two nets, in the two places that each failed to catch it:

- **Publish**: loop the projects and check `$LASTEXITCODE` after each, so any one of them fails the step. Checking explicitly rather than relying on `$PSNativeCommandUseErrorActionPreference`, whose default has moved between PowerShell versions.
- **Zip artifact**: refuse to package a directory with no `Libation.exe` in it. Both UIs publish under that name, so one assertion covers the whole matrix. This is the net that catches the next variant of "green build, empty package", whatever its cause.

Linux and macOS are unaffected and unchanged: their publish steps are bash, which Actions runs with `-e`, so the first failure already stops them.

## Testing

Before merging the compile fix, this branch's own CI **failed** on exactly the intended job, which is the clearest evidence the change works:

```
##[error]...\Form1.VisibleBooks.cs(55,3): error CS0103: The name 'visible' does not exist ...
Exception: ...ps1:22
  22 | ... ($LASTEXITCODE -ne 0) { throw "dotnet publish failed for $project" }
##[error]Process completed with exit code 1.
```

Same compiler error as the green run above, now a red build.

With [#1994](https://github.com/rmcrackan/Libation/pull/1994) merged and master brought into this branch, all 11 checks pass, and the artifact that same job produced now contains what it should:

```
Libation-Classic.13.7.10-windows-classic-x64.zip -- 322 entries
  Libation.exe        -> present
  Libation.dll        -> present
  Libation.deps.json  -> present
  Hangover.exe        -> present
  LibationCli.exe     -> present
```

Locally, the workflow's own `run:` blocks were extracted from the YAML, had the matrix expressions substituted for the WinForms row, and were executed under `pwsh` 7 against a stub `dotnet`, so what ran is the real text rather than a paraphrase:

| scenario | before | after |
|---|---|---|
| first project fails (what happened) | exit 0 | **exit 1**, `dotnet publish failed for LibationWinForms/LibationWinForms.csproj` |
| middle project fails | exit 0 | **exit 1** |
| last project fails | exit 1 | exit 1 |
| all succeed | exit 0 | exit 0 |
| zip with no `Libation.exe` (what shipped) | packaged and uploaded | **exit 1**, `Libation.exe is missing from the publish output` |
| zip with `Libation.exe` | zip produced | zip produced |

All twelve workflow files still parse as YAML.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-88a65c01-ee8f-43f6-bbc2-b371fb89011e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-88a65c01-ee8f-43f6-bbc2-b371fb89011e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

