### PR TITLE
test: cover a title made of digits and punctuation

### DIFF
--- a/Source/_Tests/LibationSearchEngine.Tests/PunctuatedNumericTitleTests.cs
+++ b/Source/_Tests/LibationSearchEngine.Tests/PunctuatedNumericTitleTests.cs
@@ -1,0 +1,128 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using AssertionHelper;
+using DataLayer;
+using LibationSearchEngine;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Directory = System.IO.Directory;
+
+namespace SearchEngineTests;
+
+/// <summary>
+/// Stephen King's <i>11/22/63</i>, whose title is nothing but digits and punctuation. It sits either side of the
+/// line the number handling draws: the analyzer keeps a date like this as one token, so it is text and must not
+/// be zero-padded, while <c>title:11*</c> is a bare number in a text field and must not be padded either.
+/// <para>
+/// Audible lists it with slashes; a hyphenated spelling turns up in filenames and in some catalogues, so both
+/// are covered. Every query here is also checked against books whose <em>length</em> is 11, 22 or 63 minutes,
+/// so nothing can pass by matching a number field instead of the title.
+/// </para>
+/// </summary>
+[TestClass]
+public class PunctuatedNumericTitleTests
+{
+	private const string HYPHEN = "B0KINGHYPH1";
+	private const string SLASH = "B0KINGSLSH1";
+	private const string ELEVEN_MIN = "B0DECOY11MN";
+	private const string TWENTYTWO_MIN = "B0DECOY22MN";
+	private const string SIXTYTHREE_MIN = "B0DECOY63MN";
+	private const string SHINING = "B0OTHERBOOK";
+
+	private string indexDirectory = null!;
+
+	[TestInitialize]
+	public void Initialize()
+	{
+		indexDirectory = Path.Combine(Path.GetTempPath(), "LibationSearchEngineTests", Guid.NewGuid().ToString("N"));
+		Directory.CreateDirectory(indexDirectory);
+		new SearchEngine(indexDirectory).CreateNewIndex(library);
+	}
+
+	[TestCleanup]
+	public void Cleanup()
+	{
+		try
+		{
+			if (Directory.Exists(indexDirectory))
+				Directory.Delete(indexDirectory, recursive: true);
+		}
+		catch (IOException)
+		{
+			// Windows refuses to delete a file Lucene still holds open, and a leftover temp directory is
+			// not worth failing a test over
+		}
+	}
+
+	private static LibraryBook book(string asin, string title, int lengthInMinutes)
+	{
+		var b = new Book(new AudibleProductId(asin), title, null, null, lengthInMinutes, ContentType.Product,
+			[new Contributor("Stephen King")], [new Contributor("Craig Wasson")], "us");
+		return new LibraryBook(b, new DateTime(2026, 8, 15), "account");
+	}
+
+	private static readonly List<LibraryBook> library =
+	[
+		book(HYPHEN, "11-22-63", lengthInMinutes: 1849),
+		book(SLASH, "11/22/63", lengthInMinutes: 1849),
+		book(ELEVEN_MIN, "The Eleven Minute Book", lengthInMinutes: 11),
+		book(TWENTYTWO_MIN, "The Twenty Two Minute Book", lengthInMinutes: 22),
+		book(SIXTYTHREE_MIN, "The Sixty Three Minute Book", lengthInMinutes: 63),
+		book(SHINING, "The Shining", lengthInMinutes: 950)
+	];
+
+	private string[] search(string query)
+		=> [.. new SearchEngine(indexDirectory).Search(query).Docs.Select(d => d.ProductId)];
+
+	/// <summary>
+	/// Typing the title finds the book. The hyphens must not be read as Lucene's exclusion operator either,
+	/// which would turn this into "11, but not 22 or 63" and return most of the library.
+	/// </summary>
+	[TestMethod]
+	[DataRow("11-22-63", HYPHEN)]
+	[DataRow("11/22/63", SLASH)]
+	public void the_title_finds_the_book(string query, string expected)
+		=> search(query).Should().BeEquivalentTo([expected]);
+
+	/// <summary>Naming the field, and quoting, reach it the same way.</summary>
+	[TestMethod]
+	[DataRow("title:11-22-63", HYPHEN)]
+	[DataRow("title:\"11-22-63\"", HYPHEN)]
+	[DataRow("\"11-22-63\"", HYPHEN)]
+	[DataRow("title:11/22/63", SLASH)]
+	[DataRow("title:\"11/22/63\"", SLASH)]
+	public void the_title_is_reachable_through_the_title_field(string query, string expected)
+		=> search(query).Should().BeEquivalentTo([expected]);
+
+	/// <summary>
+	/// A wildcard reaches it, which is what a bare number in a text field could not do while every number in
+	/// a query was zero-padded: <c>title:11*</c> used to go looking for <c>00000011.00*</c>.
+	/// </summary>
+	[TestMethod]
+	public void a_wildcard_on_the_leading_number_reaches_both_spellings()
+		=> search("title:11*").Should().BeEquivalentTo([HYPHEN, SLASH]);
+
+	/// <summary>
+	/// The date is one token, not three, so its parts are not separately searchable. Searching 11 finds the
+	/// book that is eleven minutes long and nothing else. Worth pinning: it reads like a bug otherwise, and
+	/// the fix for it would be to split the token, which would cost the exact-title match above.
+	/// </summary>
+	[TestMethod]
+	public void a_single_part_of_the_date_is_not_a_search_for_the_book()
+	{
+		search("11").Should().BeEquivalentTo([ELEVEN_MIN]);
+		search("22").Should().BeEquivalentTo([TWENTYTWO_MIN]);
+		search("63").Should().BeEquivalentTo([SIXTYTHREE_MIN]);
+	}
+
+	/// <summary>And the number fields still answer for themselves, on a book whose title is a number too.</summary>
+	[TestMethod]
+	public void the_length_of_the_book_is_still_its_own_search()
+	{
+		search("1849").Should().BeEquivalentTo([HYPHEN, SLASH]);
+		search("LengthInMinutes:1849").Should().BeEquivalentTo([HYPHEN, SLASH]);
+		search("title:1849").Should().BeEquivalentTo([]);
+		search("LengthInMinutes:[1800 TO 1900]").Should().BeEquivalentTo([HYPHEN, SLASH]);
+	}
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Tests only, no production change. Stephen King's *11/22/63* is a good probe for the numeric search handling because its title is nothing but digits and punctuation, so it sits either side of the line that handling draws.

All nine assertions pass on master.

## What it establishes

The analyzer keeps a date like this as **one token**, not three - confirmed directly against the token stream - so the title never reaches the number path at all and is matched as ordinary text:

```
analyzer tokens for "11-22-63": [11-22-63]
analyzer tokens for "11/22/63": [11/22/63]
```

That single fact drives the whole class:

- Typing the title finds the book, bare, field-qualified, and quoted. The hyphens are not read as Lucene's exclusion operator, which would have turned `11-22-63` into "11, but not 22 or 63" and returned most of the library. Each of these returns exactly one book.
- Audible lists the novel with slashes; a hyphenated spelling turns up in filenames and some catalogues. Both are covered, and they are distinct tokens, so each finds only its own spelling.
- `title:11*` reaches both. This is the one assertion that is a genuine regression test: reverting `QuerySanitizer` to the commit before the numeric fix makes it, and only it, fail, because the bare `11` in a text field was zero-padded and the query went looking for `title:00000011.00*`.
- Searching `11` alone does **not** find the novel, because the date is one token. It finds the book that is eleven minutes long. This is pinned deliberately: it reads like a bug otherwise, and the obvious "fix" - splitting the token - would cost the exact-title match above.
- The number fields still answer for themselves on a book whose title is also numeric: `1849` and `LengthInMinutes:1849` find it by running time, `title:1849` finds nothing, and the range still works.

Every query is checked against books whose *length* is 11, 22 or 63 minutes, so none of these can pass by matching a number field instead of the title. That guard has already caught one false pass in this area: an earlier draft of `NumericTitleTests` gave the novel *14* a length of 866 minutes and passed against the bug, because `Hours` is indexed too and 866 minutes is fourteen hours.

## Testing

`LibationSearchEngine.Tests`: 123 passed, 0 failed. Full suite from `Source/`: 1590 passed, 23 skipped, 0 failed.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-88a65c01-ee8f-43f6-bbc2-b371fb89011e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-88a65c01-ee8f-43f6-bbc2-b371fb89011e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

