### PR TITLE
Rename the "Not Downloaded" status label to "Download Pending"

### DIFF
--- a/Source/ApplicationServices/BulkSetDownloadStatus.cs
+++ b/Source/ApplicationServices/BulkSetDownloadStatus.cs
@@ -60,7 +60,7 @@ public class BulkSetDownloadStatus
 
 			if (books2change.Any())
 				actionSets.Add((
-					$"{"book".PluralizeWithCount(books2change.Count)} to 'Not Downloaded'",
+					$"{"book".PluralizeWithCount(books2change.Count)} to 'Download Pending'",
 					LiberatedStatus.NotLiberated,
 					books2change));
 		}

--- a/Source/FileLiberator/DownloadPdf.cs
+++ b/Source/FileLiberator/DownloadPdf.cs
@@ -112,7 +112,7 @@ public class DownloadPdf : Processable, IProcessable<DownloadPdf>, ILicensedDown
 	/// Audible granted a license and it carried no supplement link, which is Audible saying this title has no
 	/// PDF to give. Written off the way the audiobook download writes off a title it should not attempt again:
 	/// <see cref="LiberatedStatus.Error"/> means "don't retry" for a supplement exactly as it does for audio,
-	/// and the same controls - a forced or named <c>liberate</c> run, Set PDF Not Downloaded - set it back.
+	/// and the same controls - a forced or named <c>liberate</c> run, Mark PDF as Download Pending - set it back.
 	/// <para>
 	/// Reported as a completed step and not as a failure. Nothing went wrong and nothing is left to attempt, and
 	/// a failure here would put the queue's Abort / Retry / Ignore question to the user about a book whose audio
@@ -122,7 +122,7 @@ public class DownloadPdf : Processable, IProcessable<DownloadPdf>, ILicensedDown
 	private async Task<StatusHandler> noSupplementAvailableAsync(LibraryBook libraryBook)
 	{
 		const string explanation = "Audible has no PDF for this title, although the library listing says it has one. "
-			+ "Its PDF will not be asked for again; set the PDF status back to Not Downloaded to try once more.";
+			+ "Its PDF will not be asked for again; mark the PDF 'Download Pending' to try once more.";
 
 		Serilog.Log.Logger.Information(
 			"Audible granted a license for {libraryBook} that carried no supplement link, so it has no PDF to download. {explanation}",

--- a/Source/LibationAvalonia/Dialogs/BookDetailsDialog.axaml
+++ b/Source/LibationAvalonia/Dialogs/BookDetailsDialog.axaml
@@ -71,7 +71,7 @@
 					FontSize="12"
 					VerticalAlignment="Top"
 					Margin="10,10,0,0"
-					Text="To download again next time: change to Not Downloaded&#xA;To not download: change to Downloaded" />
+					Text="To download again next time: change to Download Pending&#xA;To not download: change to Downloaded" />
 
 				<Grid Margin="0,10,0,5" ColumnDefinitions="Auto,Auto,50,Auto,Auto,*">
 					

--- a/Source/LibationAvalonia/Dialogs/BookDetailsDialog.axaml.cs
+++ b/Source/LibationAvalonia/Dialogs/BookDetailsDialog.axaml.cs
@@ -147,7 +147,7 @@ public partial class BookDetailsDialog : DialogWindow
 				var status = libraryBook.Book.UserDefinedItem.BookStatus;
 
 				BookLiberatedItems.Add(new() { Status = LiberatedStatus.Liberated, Text = "Downloaded" });
-				BookLiberatedItems.Add(new() { Status = LiberatedStatus.NotLiberated, Text = "Not Downloaded" });
+				BookLiberatedItems.Add(new() { Status = LiberatedStatus.NotLiberated, Text = "Download Pending" });
 
 				if (status == LiberatedStatus.Error)
 					BookLiberatedItems.Add(new() { Status = LiberatedStatus.Error, Text = "Error" });
@@ -162,7 +162,7 @@ public partial class BookDetailsDialog : DialogWindow
 				if (status is not null)
 				{
 					PdfLiberatedItems.Add(new() { Status = LiberatedStatus.Liberated, Text = "Downloaded" });
-					PdfLiberatedItems.Add(new() { Status = LiberatedStatus.NotLiberated, Text = "Not Downloaded" });
+					PdfLiberatedItems.Add(new() { Status = LiberatedStatus.NotLiberated, Text = "Download Pending" });
 
 					PdfLiberatedSelectedItem = PdfLiberatedItems.SingleOrDefault(s => s.Status == status);
 				}

--- a/Source/LibationAvalonia/Dialogs/FindBetterQualityBooksDialog.axaml.cs
+++ b/Source/LibationAvalonia/Dialogs/FindBetterQualityBooksDialog.axaml.cs
@@ -136,8 +136,8 @@ public partial class FindBetterQualityBooksDialog : DialogWindow
 		}
 		catch (Exception ex)
 		{
-			Serilog.Log.Error(ex, "Failed to mark books as Not Liberated");
-			await MessageBox.Show(this, "An error occurred while marking books as Not Liberated. Please see the logs for more information.", "Error Marking Books", MessageBoxButtons.OK, MessageBoxIcon.Error);
+			Serilog.Log.Error(ex, "Failed to mark books as Download Pending");
+			await MessageBox.Show(this, "An error occurred while marking books as Download Pending. Please see the logs for more information.", "Error Marking Books", MessageBoxButtons.OK, MessageBoxIcon.Error);
 		}
 		finally
 		{

--- a/Source/LibationAvalonia/Dialogs/LiberatedStatusBatchAutoDialog.axaml
+++ b/Source/LibationAvalonia/Dialogs/LiberatedStatusBatchAutoDialog.axaml
@@ -25,7 +25,7 @@
 
 				<TextBlock
 					TextWrapping="Wrap"
-					Text="If the audio file can be found, set download status to 'Downloaded'" />
+					Text="If the audio file can be found, mark the book 'Downloaded'" />
 			</CheckBox>
 			<CheckBox
 				Margin="0,0,0,10"
@@ -33,7 +33,7 @@
 
 				<TextBlock
 					TextWrapping="Wrap"
-					Text="If the audio file cannot be found, set download status to 'Not Downloaded'" />
+					Text="If the audio file cannot be found, mark the book 'Download Pending'" />
 			</CheckBox>
 		</StackPanel>
 		

--- a/Source/LibationAvalonia/Dialogs/LiberatedStatusBatchManualDialog.axaml
+++ b/Source/LibationAvalonia/Dialogs/LiberatedStatusBatchManualDialog.axaml
@@ -18,7 +18,7 @@
 		<TextBlock
 			Grid.ColumnSpan="2"
 			Margin="10"
-			Text="To download again next time: change to Not Downloaded&#xa;To not download: change to Downloaded"/>
+			Text="To download again next time: change to Download Pending&#xa;To not download: change to Downloaded"/>
 		
 		<StackPanel
 			Margin="10,0"

--- a/Source/LibationAvalonia/Dialogs/LiberatedStatusBatchManualDialog.axaml.cs
+++ b/Source/LibationAvalonia/Dialogs/LiberatedStatusBatchManualDialog.axaml.cs
@@ -30,7 +30,7 @@ public partial class LiberatedStatusBatchManualDialog : DialogWindow
 	public List<liberatedComboBoxItem> BookStatuses { get; } =
 	[
 		new liberatedComboBoxItem { Status = LiberatedStatus.Liberated, Text = "Downloaded" },
-		new liberatedComboBoxItem { Status = LiberatedStatus.NotLiberated, Text = "Not Downloaded" },
+		new liberatedComboBoxItem { Status = LiberatedStatus.NotLiberated, Text = "Download Pending" },
 	];
 
 	public LiberatedStatusBatchManualDialog(bool isPdf) : this()

--- a/Source/LibationCli/Options/SetDownloadStatusOptions.cs
+++ b/Source/LibationCli/Options/SetDownloadStatusOptions.cs
@@ -18,8 +18,19 @@ public class SetDownloadStatusOptions : OptionsBase
 	[Option(shortName: 'd', longName: "downloaded", Group = "Download Status", HelpText = "if the audio file can be found, mark the book 'Downloaded'")]
 	public bool SetDownloaded { get; set; }
 
-	[Option(shortName: 'n', longName: "not-downloaded", Group = "Download Status", HelpText = "if the audio file cannot be found, mark the book 'Download Pending' (previously 'Not Downloaded')")]
-	public bool SetNotDownloaded { get; set; }
+	[Option(shortName: 'p', longName: "download-pending", Group = "Download Status", HelpText = "if the audio file cannot be found, mark the book 'Download Pending' (previously 'Not Downloaded')")]
+	public bool SetDownloadPending { get; set; }
+
+	/// <summary>
+	/// What <see cref="SetDownloadPending"/> was called while the status was named "Not Downloaded". Kept
+	/// working so scripts written against the old name survive the rename, and kept out of the help so the
+	/// new name is the only one offered. <see cref="SetPending"/> is what the verb acts on.
+	/// </summary>
+	[Option(shortName: 'n', longName: "not-downloaded", Group = "Download Status", Hidden = true)]
+	public bool SetNotDownloadedLegacy { get; set; }
+
+	/// <summary>Whether the run was asked for 'Download Pending', under either flag name.</summary>
+	internal bool SetPending => SetDownloadPending || SetNotDownloadedLegacy;
 
 	[Option('f', "force", HelpText = "Set the download status regardless of whether the book's audio file can be found. Only one download status option may be used with this option.")]
 	public bool Force { get; set; }
@@ -29,7 +40,7 @@ public class SetDownloadStatusOptions : OptionsBase
 
 	protected override async Task ProcessAsync()
 	{
-		if (Force && SetDownloaded && SetNotDownloaded)
+		if (Force && SetDownloaded && SetPending)
 		{
 			PrintVerbUsage("ERROR:\nWhen run with --force option, only one download status option may be used.");
 			return;
@@ -58,7 +69,7 @@ public class SetDownloadStatusOptions : OptionsBase
 		}
 		else
 		{
-			var bulkSetStatus = new BulkSetDownloadStatus(libraryBooks, SetDownloaded, SetNotDownloaded);
+			var bulkSetStatus = new BulkSetDownloadStatus(libraryBooks, SetDownloaded, SetPending);
 			await Task.Run(() => bulkSetStatus.Discover());
 			await bulkSetStatus.ExecuteAsync();
 

--- a/Source/LibationCli/Options/SetDownloadStatusOptions.cs
+++ b/Source/LibationCli/Options/SetDownloadStatusOptions.cs
@@ -15,10 +15,10 @@ namespace LibationCli;
 public class SetDownloadStatusOptions : OptionsBase
 {
 	//https://github.com/commandlineparser/commandline/wiki/Option-Groups
-	[Option(shortName: 'd', longName: "downloaded", Group = "Download Status", HelpText = "set download status to 'Downloaded'")]
+	[Option(shortName: 'd', longName: "downloaded", Group = "Download Status", HelpText = "if the audio file can be found, mark the book 'Downloaded'")]
 	public bool SetDownloaded { get; set; }
 
-	[Option(shortName: 'n', longName: "not-downloaded", Group = "Download Status", HelpText = "set download status to 'Not Downloaded'")]
+	[Option(shortName: 'n', longName: "not-downloaded", Group = "Download Status", HelpText = "if the audio file cannot be found, mark the book 'Download Pending' (previously 'Not Downloaded')")]
 	public bool SetNotDownloaded { get; set; }
 
 	[Option('f', "force", HelpText = "Set the download status regardless of whether the book's audio file can be found. Only one download status option may be used with this option.")]

--- a/Source/LibationCli/Program.cs
+++ b/Source/LibationCli/Program.cs
@@ -44,7 +44,7 @@ class Program
 #if DEBUG
 		string input = "";
 
-		//input = "  set-status -n --force B017V4IM1G";
+		//input = "  set-status -p --force B017V4IM1G";
 		//input = "  liberate B017V4IM1G";
 		//input = "  convert B017V4IM1G";
 		//input = "  search \"-liberated\"";

--- a/Source/LibationUiBase/FindBetterQualityBooksViewModel.cs
+++ b/Source/LibationUiBase/FindBetterQualityBooksViewModel.cs
@@ -32,7 +32,7 @@ public class FindBetterQualityBooksViewModel : ReactiveObject
 
 		Click 'Scan Audible for Higher Quality Audio' to begin.
 
-		When done, click the 'Mark X books as Not Liberated' to allow Libation to re-download those books in the higher.
+		When done, click the 'Mark X books as Download Pending' to allow Libation to re-download those books in the higher.
 
 		Note: make sure you adjust your download quality settings before re-liberating the books.
 
@@ -50,8 +50,8 @@ public class FindBetterQualityBooksViewModel : ReactiveObject
 		{
 			RaiseAndSetIfChanged(ref field, value);
 			MarkBooksButtonText = value == 0 ? null
-				: value == 1 ? "Mark 1 book as 'Not Liberated'"
-				: $"Mark {value} books as 'Not Liberated'";
+				: value == 1 ? "Mark 1 book as 'Download Pending'"
+				: $"Mark {value} books as 'Download Pending'";
 		}
 	}
 	public bool IsScanning { get => field; set { RaiseAndSetIfChanged(ref field, value); ScanButtonText = field ? StopScanBtnText : StartScanBtnText; } }

--- a/Source/LibationUiBase/GridView/EntryStatus.cs
+++ b/Source/LibationUiBase/GridView/EntryStatus.cs
@@ -148,14 +148,14 @@ public class EntryStatus : ReactiveObject, IComparable
 		{
 			LiberatedStatus.Liberated => "Liberated",
 			LiberatedStatus.PartialDownload => "File has been at least\r\npartially downloaded",
-			LiberatedStatus.NotLiberated => "Book NOT downloaded",
+			LiberatedStatus.NotLiberated => "Book download pending",
 			_ => throw new Exception("Unexpected liberation state")
 		};
 
 		string pdfState = PdfStatus switch
 		{
 			LiberatedStatus.Liberated => "\r\nPDF downloaded",
-			LiberatedStatus.NotLiberated => "\r\nPDF NOT downloaded",
+			LiberatedStatus.NotLiberated => "\r\nPDF download pending",
 			// Set when Audible granted a license carrying no PDF link, which is by far the likeliest way a
 			// title arrives here, and says more than "ERROR" about why Libation has stopped asking.
 			LiberatedStatus.Error => "\r\nPDF could not be downloaded\r\nand will not be tried again",

--- a/Source/LibationUiBase/GridView/GridContextMenu.cs
+++ b/Source/LibationUiBase/GridView/GridContextMenu.cs
@@ -17,10 +17,10 @@ public class GridContextMenu
 {
 	public string CopyCellText => $"{Accelerator}Copy Cell Contents";
 	public string LiberateEpisodesText => $"{Accelerator}Liberate All Episodes";
-	public string SetDownloadedText => $"Set Download status to '{Accelerator}Downloaded'";
-	public string SetNotDownloadedText => $"Set Download status to '{Accelerator}Not Downloaded'";
-	public string SetPdfDownloadedText => "Set PDF status to 'Downloaded'";
-	public string SetPdfNotDownloadedText => "Set PDF status to 'Not Downloaded'";
+	public string SetDownloadedText => $"Mark as '{Accelerator}Downloaded'";
+	public string SetNotDownloadedText => $"Mark as 'Download {Accelerator}Pending'";
+	public string SetPdfDownloadedText => "Mark PDF as 'Downloaded'";
+	public string SetPdfNotDownloadedText => "Mark PDF as 'Download Pending'";
 	public string RemoveText => $"{Accelerator}Remove from library";
 	public string RemoveFromAudibleText => $"Remove Plus {(GridEntries.Count(e => e.LibraryBook.IsAudiblePlus) == 1 ? "Book" : "Books")} from Audible Library";
 	public string LocateFileText => $"{Accelerator}Locate file...";

--- a/Source/LibationUiBase/ProcessQueue/BackupRequest.cs
+++ b/Source/LibationUiBase/ProcessQueue/BackupRequest.cs
@@ -20,7 +20,7 @@ internal sealed class BackupRequest
 	internal sealed record SkipReason(string Label, string Advice = "")
 	{
 		public static readonly SkipReason AlreadyDownloaded = new("Already downloaded");
-		public static readonly SkipReason PreviousError = new("Previously failed to download", "set the download status to 'Not Downloaded' to try again");
+		public static readonly SkipReason PreviousError = new("Previously failed to download", "mark it 'Download Pending' to try again");
 		public static readonly SkipReason AbsentFromLastScan = new(AbsentFromLastScanUserMessage.Label, AbsentFromLastScanUserMessage.Advice);
 		public static readonly SkipReason WaitingToRetry = new("Waiting before trying again after a recent failure", "download the title on its own to try it now");
 

--- a/Source/LibationUiBase/ProcessQueue/ProcessQueueViewModel.cs
+++ b/Source/LibationUiBase/ProcessQueue/ProcessQueueViewModel.cs
@@ -327,7 +327,7 @@ public class ProcessQueueViewModel : ReactiveObject
 			{
 				await MessageBoxBase.Show(
 					"Libation could not queue a download for this title.\n\n"
-					+ "If it should be downloadable: confirm it is not already liberated, try \"Set download status\" to Not downloaded, or check whether a library scan is required.",
+					+ "If it should be downloadable: confirm it is not already liberated, try marking it \"Download Pending\", or check whether a library scan is required.",
 					"Download not queued",
 					MessageBoxButtons.OK,
 					MessageBoxIcon.Information);

--- a/Source/LibationWinForms/Dialogs/BookDetailsDialog.Designer.cs
+++ b/Source/LibationWinForms/Dialogs/BookDetailsDialog.Designer.cs
@@ -142,15 +142,15 @@
 			// 
 			pdfLiberatedCb.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
 			pdfLiberatedCb.FormattingEnabled = true;
-			pdfLiberatedCb.Location = new System.Drawing.Point(244, 86);
+			pdfLiberatedCb.Location = new System.Drawing.Point(259, 86);
 			pdfLiberatedCb.Name = "pdfLiberatedCb";
-			pdfLiberatedCb.Size = new System.Drawing.Size(121, 23);
+			pdfLiberatedCb.Size = new System.Drawing.Size(150, 23);
 			pdfLiberatedCb.TabIndex = 4;
 			// 
 			// pdfLiberatedLbl
 			// 
 			pdfLiberatedLbl.AutoSize = true;
-			pdfLiberatedLbl.Location = new System.Drawing.Point(210, 89);
+			pdfLiberatedLbl.Location = new System.Drawing.Point(225, 89);
 			pdfLiberatedLbl.Name = "pdfLiberatedLbl";
 			pdfLiberatedLbl.Size = new System.Drawing.Size(28, 15);
 			pdfLiberatedLbl.TabIndex = 3;
@@ -162,7 +162,7 @@
 			bookLiberatedCb.FormattingEnabled = true;
 			bookLiberatedCb.Location = new System.Drawing.Point(47, 86);
 			bookLiberatedCb.Name = "bookLiberatedCb";
-			bookLiberatedCb.Size = new System.Drawing.Size(121, 23);
+			bookLiberatedCb.Size = new System.Drawing.Size(150, 23);
 			bookLiberatedCb.TabIndex = 2;
 			// 
 			// bookLiberatedLbl
@@ -181,7 +181,7 @@
 			liberatedDescLbl.Name = "liberatedDescLbl";
 			liberatedDescLbl.Size = new System.Drawing.Size(312, 30);
 			liberatedDescLbl.TabIndex = 0;
-			liberatedDescLbl.Text = "To download again next time: change to Not Downloaded\r\nTo not download: change to Downloaded";
+			liberatedDescLbl.Text = "To download again next time: change to Download Pending\r\nTo not download: change to Downloaded";
 			// 
 			// audibleLink
 			// 

--- a/Source/LibationWinForms/Dialogs/BookDetailsDialog.cs
+++ b/Source/LibationWinForms/Dialogs/BookDetailsDialog.cs
@@ -91,7 +91,7 @@ public partial class BookDetailsDialog : Form
 			var status = Book.UserDefinedItem.BookStatus;
 			this.bookLiberatedCb.Items.Clear();
 			this.bookLiberatedCb.Items.Add(new liberatedComboBoxItem { Status = LiberatedStatus.Liberated, Text = "Downloaded" });
-			this.bookLiberatedCb.Items.Add(new liberatedComboBoxItem { Status = LiberatedStatus.NotLiberated, Text = "Not Downloaded" });
+			this.bookLiberatedCb.Items.Add(new liberatedComboBoxItem { Status = LiberatedStatus.NotLiberated, Text = "Download Pending" });
 
 			// this should only appear if is already an error. User should not be able to set status to error, only away from error
 			if (status == LiberatedStatus.Error)
@@ -107,7 +107,7 @@ public partial class BookDetailsDialog : Form
 			if (status is not null)
 			{
 				this.pdfLiberatedCb.Items.Add(new liberatedComboBoxItem { Status = LiberatedStatus.Liberated, Text = "Downloaded" });
-				this.pdfLiberatedCb.Items.Add(new liberatedComboBoxItem { Status = LiberatedStatus.NotLiberated, Text = "Not Downloaded" });
+				this.pdfLiberatedCb.Items.Add(new liberatedComboBoxItem { Status = LiberatedStatus.NotLiberated, Text = "Download Pending" });
 
 				setDefaultComboBox(this.pdfLiberatedCb, status);
 			}

--- a/Source/LibationWinForms/Dialogs/FindBetterQualityBooksDialog.Designer.cs
+++ b/Source/LibationWinForms/Dialogs/FindBetterQualityBooksDialog.Designer.cs
@@ -196,11 +196,11 @@ partial class FindBetterQualityBooksDialog
 		// btnMarkBooks
 		// 
 		btnMarkBooks.Anchor = System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right;
-		btnMarkBooks.Location = new System.Drawing.Point(699, 415);
+		btnMarkBooks.Location = new System.Drawing.Point(669, 415);
 		btnMarkBooks.Name = "btnMarkBooks";
-		btnMarkBooks.Size = new System.Drawing.Size(210, 23);
+		btnMarkBooks.Size = new System.Drawing.Size(240, 23);
 		btnMarkBooks.TabIndex = 4;
-		btnMarkBooks.Text = "Mark 1,000 books as 'Not Liberated'";
+		btnMarkBooks.Text = "Mark 1,000 books as 'Download Pending'";
 		btnMarkBooks.UseVisualStyleBackColor = true;
 		btnMarkBooks.Click += btnMarkBooks_Click;
 		// 

--- a/Source/LibationWinForms/Dialogs/FindBetterQualityBooksDialog.cs
+++ b/Source/LibationWinForms/Dialogs/FindBetterQualityBooksDialog.cs
@@ -158,8 +158,8 @@ public partial class FindBetterQualityBooksDialog : Form
 		}
 		catch (Exception ex)
 		{
-			Serilog.Log.Error(ex, "Failed to mark books as Not Liberated");
-			MessageBox.Show(this, "An error occurred while marking books as Not Liberated. Please see the logs for more information.", "Error Marking Books", MessageBoxButtons.OK, MessageBoxIcon.Error);
+			Serilog.Log.Error(ex, "Failed to mark books as Download Pending");
+			MessageBox.Show(this, "An error occurred while marking books as Download Pending. Please see the logs for more information.", "Error Marking Books", MessageBoxButtons.OK, MessageBoxIcon.Error);
 		}
 		finally
 		{

--- a/Source/LibationWinForms/Dialogs/LiberatedStatusBatchAutoDialog.Designer.cs
+++ b/Source/LibationWinForms/Dialogs/LiberatedStatusBatchAutoDialog.Designer.cs
@@ -41,7 +41,7 @@
             this.setDownloadedCb.Name = "setDownloadedCb";
             this.setDownloadedCb.Size = new System.Drawing.Size(379, 19);
             this.setDownloadedCb.TabIndex = 0;
-            this.setDownloadedCb.Text = "If the audio file can be found, set download status to \'Downloaded\'";
+            this.setDownloadedCb.Text = "If the audio file can be found, mark the book \'Downloaded\'";
             this.setDownloadedCb.UseVisualStyleBackColor = true;
             // 
             // setNotDownloadedCb
@@ -51,7 +51,7 @@
             this.setNotDownloadedCb.Name = "setNotDownloadedCb";
             this.setNotDownloadedCb.Size = new System.Drawing.Size(412, 19);
             this.setNotDownloadedCb.TabIndex = 1;
-            this.setNotDownloadedCb.Text = "If the audio file cannot be found, set download status to \'Not Downloaded\'";
+            this.setNotDownloadedCb.Text = "If the audio file cannot be found, mark the book \'Download Pending\'";
             this.setNotDownloadedCb.UseVisualStyleBackColor = true;
             // 
             // okBtn

--- a/Source/LibationWinForms/Dialogs/LiberatedStatusBatchManualDialog.Designer.cs
+++ b/Source/LibationWinForms/Dialogs/LiberatedStatusBatchManualDialog.Designer.cs
@@ -41,7 +41,7 @@
             this.bookLiberatedCb.FormattingEnabled = true;
             this.bookLiberatedCb.Location = new System.Drawing.Point(52, 54);
             this.bookLiberatedCb.Name = "bookLiberatedCb";
-            this.bookLiberatedCb.Size = new System.Drawing.Size(121, 23);
+            this.bookLiberatedCb.Size = new System.Drawing.Size(150, 23);
             this.bookLiberatedCb.TabIndex = 7;
             // 
             // bookLiberatedLbl
@@ -60,8 +60,8 @@
             this.liberatedDescLbl.Name = "liberatedDescLbl";
             this.liberatedDescLbl.Size = new System.Drawing.Size(312, 30);
             this.liberatedDescLbl.TabIndex = 5;
-            this.liberatedDescLbl.Text = "To download again next time: change to Not Downloaded\r\nTo not download: change to" +
-    " Downloaded";
+            this.liberatedDescLbl.Text = "To download again next time: change to Download Pending\r\nTo not download: change t" +
+    "o Downloaded";
             // 
             // cancelBtn
             // 

--- a/Source/LibationWinForms/Dialogs/LiberatedStatusBatchManualDialog.cs
+++ b/Source/LibationWinForms/Dialogs/LiberatedStatusBatchManualDialog.cs
@@ -27,7 +27,7 @@ public partial class LiberatedStatusBatchManualDialog : Form
 		this.SetLibationIcon();
 
 		this.bookLiberatedCb.Items.Add(new liberatedComboBoxItem { Status = LiberatedStatus.Liberated, Text = "Downloaded" });
-		this.bookLiberatedCb.Items.Add(new liberatedComboBoxItem { Status = LiberatedStatus.NotLiberated, Text = "Not Downloaded" });
+		this.bookLiberatedCb.Items.Add(new liberatedComboBoxItem { Status = LiberatedStatus.NotLiberated, Text = "Download Pending" });
 
 		this.bookLiberatedCb.SelectedIndex = 0;
 	}

--- a/Source/_Tests/LibationCli.Tests/SetDownloadStatusOptionsTests.cs
+++ b/Source/_Tests/LibationCli.Tests/SetDownloadStatusOptionsTests.cs
@@ -1,0 +1,91 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.IO;
+using System.Linq;
+
+namespace LibationCli.Tests;
+
+/// <summary>
+/// The 'Not Downloaded' status was renamed 'Download Pending', so the flag that asks for it is now
+/// --download-pending. The old --not-downloaded has to keep working: it is what years of scripts, forum
+/// answers and issue comments tell people to run.
+/// </summary>
+[TestClass]
+public class SetDownloadStatusOptionsTests
+{
+	private static SetDownloadStatusOptions Parse(params string[] args)
+	{
+		using var error = new StringWriter();
+		var options = Program.ParseInvocation(args, error).Result?.Value as SetDownloadStatusOptions;
+		Assert.IsNotNull(options);
+		return options;
+	}
+
+	[TestMethod]
+	[DataRow("--download-pending")]
+	[DataRow("-p")]
+	public void The_new_flag_asks_for_download_pending(string flag)
+	{
+		var options = Parse("set-status", flag);
+		Assert.IsTrue(options.SetPending);
+		Assert.IsFalse(options.SetDownloaded);
+	}
+
+	[TestMethod]
+	[DataRow("--not-downloaded")]
+	[DataRow("-n")]
+	public void The_legacy_flag_still_asks_for_the_same_thing(string flag)
+	{
+		var options = Parse("set-status", flag);
+		Assert.IsTrue(options.SetPending);
+		Assert.IsFalse(options.SetDownloaded);
+	}
+
+	[TestMethod]
+	public void Downloaded_on_its_own_asks_for_nothing_pending()
+	{
+		var options = Parse("set-status", "--downloaded");
+		Assert.IsTrue(options.SetDownloaded);
+		Assert.IsFalse(options.SetPending);
+	}
+
+	[TestMethod]
+	[DataRow("--download-pending")]
+	[DataRow("--not-downloaded")]
+	public void Both_statuses_can_still_be_set_in_one_run(string pendingFlag)
+	{
+		var options = Parse("set-status", "--downloaded", pendingFlag);
+		Assert.IsTrue(options.SetDownloaded);
+		Assert.IsTrue(options.SetPending);
+	}
+
+	[TestMethod]
+	public void A_run_naming_no_status_is_still_rejected()
+	{
+		// The two names live in one option group, so adding the legacy alias must not make the group
+		// satisfiable by nothing at all.
+		using var error = new StringWriter();
+		var outcome = Program.ParseInvocation(["set-status"], error);
+
+		Assert.AreEqual(ExitCode.ParseError, outcome.ExitCode);
+	}
+
+	[TestMethod]
+	public void Help_offers_the_new_name_and_keeps_the_legacy_one_out_of_sight()
+	{
+		var help = new HelpVerb { HelpType = "set-status" }.GetHelpText().ToString();
+
+		StringAssert.Contains(help, "--download-pending");
+		Assert.IsFalse(
+			help.Contains("--not-downloaded"),
+			"The legacy alias should keep working without being advertised as a second way to do this.");
+	}
+
+	[TestMethod]
+	public void Asins_are_still_read_alongside_the_new_flag()
+	{
+		var options = Parse("set-status", "-p", "B017V4IM1G");
+
+		Assert.IsTrue(options.SetPending);
+		CollectionAssert.AreEqual(new[] { "B017V4IM1G" }, options.Asins?.ToArray());
+	}
+}

--- a/docs/advanced/command-line-interface.md
+++ b/docs/advanced/command-line-interface.md
@@ -284,8 +284,8 @@ libationcli export -p "C:\foo\bar\my.xlsx" -x
 
 Set download statuses throughout library based on whether each book's audio file can be found.  
 Must include at least one flag: --downloaded , --not-downloaded.  
-Downloaded: If the audio file can be found, set download status to 'Downloaded'.  
-Not Downloaded: If the audio file cannot be found, set download status to 'Not Downloaded'  
+`--downloaded`: If the audio file can be found, mark the book **Downloaded**.  
+`--not-downloaded`: If the audio file cannot be found, mark the book **Download Pending** (previously "Not Downloaded"). The flag name still says `not-downloaded`.  
 UI: Visible Books \> Set 'Downloaded' status automatically. Visible books. Prompts before saving changes  
 CLI: Full library. No prompt
 

--- a/docs/advanced/command-line-interface.md
+++ b/docs/advanced/command-line-interface.md
@@ -283,16 +283,17 @@ libationcli export -p "C:\foo\bar\my.xlsx" -x
 ## Set Download Status
 
 Set download statuses throughout library based on whether each book's audio file can be found.  
-Must include at least one flag: --downloaded , --not-downloaded.  
-`--downloaded`: If the audio file can be found, mark the book **Downloaded**.  
-`--not-downloaded`: If the audio file cannot be found, mark the book **Download Pending** (previously "Not Downloaded"). The flag name still says `not-downloaded`.  
+Must include at least one flag: --downloaded , --download-pending.  
+`-d`, `--downloaded`: If the audio file can be found, mark the book **Downloaded**.  
+`-p`, `--download-pending`: If the audio file cannot be found, mark the book **Download Pending** (previously "Not Downloaded").  
+`-n`, `--not-downloaded`: legacy alias for `--download-pending`, from when the status was called "Not Downloaded". It still works, so existing scripts keep running, but it is no longer listed in `--help`.  
 UI: Visible Books \> Set 'Downloaded' status automatically. Visible books. Prompts before saving changes  
 CLI: Full library. No prompt
 
 ```console
 libationcli set-status -d
-libationcli set-status -n
-libationcli set-status -d -n
+libationcli set-status -p
+libationcli set-status -d -p
 ```
 
 ## Get a Content License Without Downloading

--- a/docs/advanced/troubleshoot.md
+++ b/docs/advanced/troubleshoot.md
@@ -262,7 +262,7 @@ These errors come from Audible refusing to grant a download license. Common caus
 3. **Spatial / Dolby Atmos requested (older Libation versions)** -- Audible now requires Widevine L1 for many spatial titles. Libation 13.1.3+ no longer offers spatial download. See [Spatial Audio & DRM](/docs/advanced/spatial-audio).
 4. **You no longer have rights to the title** -- it was returned, it left the Plus catalog, or the account that owned it is no longer active. Check the title in the Audible app or website.
 
-After a refusal Libation waits before asking about that title again, so you see the explanation once rather than on every run. It attempts the title again by itself; to try it sooner, name it (`libationcli liberate <ASIN>`) or set its download status to Not Downloaded. See [Retrying titles Audible refuses](/docs/features/retrying-refused-downloads).
+After a refusal Libation waits before asking about that title again, so you see the explanation once rather than on every run. It attempts the title again by itself; to try it sooner, name it (`libationcli liberate <ASIN>`) or mark it **Download Pending** (previously "Not Downloaded"). See [Retrying titles Audible refuses](/docs/features/retrying-refused-downloads).
 
 Attach your log file when opening a GitHub issue.
 
@@ -279,7 +279,7 @@ The lookup finds nothing in two situations, and the second is worth checking:
 1. The audio files are not on this machine — the title is marked downloaded but the files live elsewhere, or were deleted.
 2. **Your folder and file templates have no `<id>` tag.** Then no file Libation writes has the ASIN in its path, so Libation cannot recognise its own output for any title. Add `<id>` back in Settings \> Download/Decrypt; the defaults are `<title short> [<id>]` for folders and `<title> [<id>]` for files. This also explains PDFs with no ASIN in the name: the file name comes from your file template.
 
-Already-misplaced PDFs are not moved. Move them into their book folders yourself, or set the affected titles' PDF status to Not Downloaded and download them again.
+Already-misplaced PDFs are not moved. Move them into their book folders yourself, or mark the affected titles' PDFs **Download Pending** and download them again.
 
 ## The log file is too large to attach to a bug report
 

--- a/docs/features/retrying-refused-downloads.md
+++ b/docs/features/retrying-refused-downloads.md
@@ -42,8 +42,8 @@ again:
 - `libationcli liberate <ASIN>` — naming a title always attempts it.
 - `libationcli liberate --force` — attempts everything, including the refused titles.
 - In the app, selecting a single title and downloading it.
-- Setting a title's download status to **Not Downloaded** (grid context menu, book details, or
-  `libationcli set-status`).
+- Marking a title **Download Pending** (previously "Not Downloaded") from the grid context menu, book
+  details, or `libationcli set-status`.
 - A successful download, which forgets the title's history entirely.
 
 ## What you see
@@ -93,8 +93,8 @@ title, attempt them regardless.
 
 Some titles are listed as having a PDF that Audible will not deliver: the license comes back granted, with no
 link in it. Libation marks that title's PDF as an error and stops asking, because nothing about asking again
-would change the answer. The grid says "PDF could not be downloaded and will not be tried again", and setting
-the PDF status back to **Not Downloaded** tries once more.
+would change the answer. The grid says "PDF could not be downloaded and will not be tried again", and marking
+the PDF **Download Pending** tries once more.
 
 ## Relationship to marking a book as an error
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -97,9 +97,9 @@ The stoplights will tell you a title's status:
 
 - Green: downloaded and decrypted
 - Yellow: downloaded but still encrypted with DRM
-- Red: not downloaded
+- Red: download pending
 - PDF icon without arrow: downloaded
-- PDF with arrow: not downloaded
+- PDF with arrow: download pending
 - Orange plus badge in the upper-right corner: an Audible Plus title rather than one you purchased
 
 Or hover over the button to see the status.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why

"Not Downloaded" describes the file on disk, but the status it names is really an instruction about the future: "Libation should fetch this." That mismatch is why telling someone to set a finished audiobook to "Not Downloaded" so they can get it again reliably produces a follow-up question - they are being asked to assert something they know is false, and they hesitate over whether it will delete their file.

"Download Pending" says the same thing about intent without saying anything untrue about the file. It also stands alone: "mark it Download Pending" is complete in a dropdown, a tooltip, or a support reply, where bare "Pending" leaves a beat of "pending what?".

## What changed

The label for `LiberatedStatus.NotLiberated` everywhere it faces the user, in both GUIs and the CLI.

The context menu carriers move from `Set Download status to 'X'` to `Mark as 'X'`, because the two-word label otherwise lands twice in one breath ("Set Download status to 'Download Pending'"). The accelerator moves to the `P` so it stays distinct from the `D` of Downloaded. The batch-auto checkboxes and the CLI `-d` help text pick up the same "mark the book ..." phrasing.

Two layouts needed room for the longer string:

- WinForms status combo boxes: 121px -> 150px. In Book Details the PDF label and combo shift right by 15px to keep their gap from the widened Book combo.
- `btnMarkBooks` in the WinForms better-quality dialog: 210px -> 240px, moved left 30px to stay inside the client area.

The persisted enum and its DB values, and the `IsLiberated` / `Liberated` search tags, are untouched, so saved quick filters keep working.

### CLI flag

`-p` / `--download-pending` is now the flag that asks for this status, and the only one `--help` lists.

`-n` / `--not-downloaded` keeps working as a legacy alias. It is what years of scripts, forum answers and issue comments tell people to run, so breaking it would cost more than the inconsistency is worth. It is `Hidden` from help, and both flags feed one `SetPending` property that the verb acts on. All three names stay in the `Download Status` option group, so "at least one status flag is required" still holds.

One seam worth knowing about: CommandLineParser builds the group error from the group's member names, so `libationcli set-status` with no flag prints `At least one option from group 'Download Status' (d, downloaded, p, download-pending, n, not-downloaded) is required` - the one place the legacy name is still visible. Say the word and I can suppress it.

## Keeping the old name findable

Years of Reddit threads and GitHub issues answer this question with the phrase "Not Downloaded", and people arrive at the docs holding it. Each affected docs page carries `(previously "Not Downloaded")` on its first mention only, which keeps the phrase in the page text for site search without making the pages read like a migration notice. The CLI page documents `--not-downloaded` explicitly as a legacy alias, and `--download-pending`'s own help text carries the same parenthetical.

## Testing

`dotnet build Source/Libation.slnx` succeeds with 0 errors; the 3 warnings are pre-existing and unrelated. `LibationWinForms` and `HangoverWinForms` were compile-checked individually, both clean.

`dotnet test` from `Source/`: 1613 tests, 0 failed, 23 skipped (the opt-in OS secret store tests). Ten of those are new, in `SetDownloadStatusOptionsTests`, covering both flag names, both together, the group still rejecting a run that names no status, and help offering the new name while keeping the alias out of sight.

The Avalonia GUI was exercised against a seeded demo library. The recording covers the user story end to end: right-click a downloaded book, mark it "Download Pending", watch the Liberate icon change, hover for the reworded tooltip, and open Book Details to see the dropdown.

[mark_book_download_pending_context_menu_tooltip_and_book_details.mp4](https://cursor.com/agents/bc-e4ded1da-7dcf-4de4-8c8c-ad48906256c9/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fmark_book_download_pending_context_menu_tooltip_and_book_details.mp4)

The Visible Books batch-auto dialog, whose two checkboxes now use parallel "mark the book ..." wording:

[Set Downloaded status automatically dialog with both checkboxes reworded](https://cursor.com/agents/bc-e4ded1da-7dcf-4de4-8c8c-ad48906256c9/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshot_set_status_automatically_dialog.png)

The skip-reason advice in the download-not-queued dialog:

[Download not queued dialog reading mark it Download Pending to try again](https://cursor.com/agents/bc-e4ded1da-7dcf-4de4-8c8c-ad48906256c9/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshot_download_not_queued_advice.png)

CLI evidence, including the legacy alias doing the work and reporting it under the new label ("11 books to 'Download Pending'"): see `cli_set_status_download_pending_flag.log` on the agent run.

**WinForms was compiled but never rendered**, since it has no Linux runtime. The resized controls and the `Alt+P` accelerator still need a look on Windows; the agent summary carries a click-by-click checklist.


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e4ded1da-7dcf-4de4-8c8c-ad48906256c9?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e4ded1da-7dcf-4de4-8c8c-ad48906256c9&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

