### PR TITLE
Let users turn off the startup update check

### DIFF
--- a/Source/AppScaffolding/LibationScaffolding.cs
+++ b/Source/AppScaffolding/LibationScaffolding.cs
@@ -332,7 +332,8 @@ public static class LibationScaffolding
 			config.ImportEpisodes,
 			config.ImportPlusTitles,
 			config.DownloadEpisodes,
-			config.BetaOptIn,
+			// Off means no startup upgrade prompt, which is otherwise indistinguishable from a broken check
+			config.CheckForUpgradesAtStartup,
 			config.UseCoverAsFolderIcon,
 			config.LibationFiles,
 			AudibleFileStorage.BooksDirectory,

--- a/Source/LibationAvalonia/Controls/Settings/Important.axaml
+++ b/Source/LibationAvalonia/Controls/Settings/Important.axaml
@@ -69,21 +69,30 @@
 			</StackPanel>
 
 		</controls:GroupBox>
-		<CheckBox
+		<StackPanel
 			Grid.Row="1"
 			Margin="10,5"
-			IsEnabled="{Binding !UseWebViewSettingDisabled}"
-			IsChecked="{Binding UseWebView, Mode=TwoWay}">
-			<StackPanel>
-				<TextBlock Text="{Binding UseWebViewText}" />
-				<TextBlock
-					IsVisible="{Binding UseWebViewSettingDisabled}"
-					FontStyle="Italic"
-					Opacity="0.8"
-					Margin="0,2,0,0"
-					Text="{Binding UseWebViewSnapMessage}" />
-			</StackPanel>
-		</CheckBox>
+			Spacing="5">
+			<CheckBox
+				IsEnabled="{Binding !UseWebViewSettingDisabled}"
+				IsChecked="{Binding UseWebView, Mode=TwoWay}">
+				<StackPanel>
+					<TextBlock Text="{Binding UseWebViewText}" />
+					<TextBlock
+						IsVisible="{Binding UseWebViewSettingDisabled}"
+						FontStyle="Italic"
+						Opacity="0.8"
+						Margin="0,2,0,0"
+						Text="{Binding UseWebViewSnapMessage}" />
+				</StackPanel>
+			</CheckBox>
+
+			<CheckBox
+				IsChecked="{Binding CheckForUpgradesAtStartup, Mode=TwoWay}"
+				ToolTip.Tip="{Binding CheckForUpgradesAtStartupTip}">
+				<TextBlock Text="{Binding CheckForUpgradesAtStartupText}" />
+			</CheckBox>
+		</StackPanel>
 
 		<controls:GroupBox
 			Grid.Row="2"

--- a/Source/LibationAvalonia/Dialogs/UpgradeNotificationDialog.axaml.cs
+++ b/Source/LibationAvalonia/Dialogs/UpgradeNotificationDialog.axaml.cs
@@ -14,6 +14,7 @@ public partial class UpgradeNotificationDialog : DialogWindow
 	public string? ReleaseNotes { get; }
 	public string? OkText { get; }
 	private string? PackageUrl { get; }
+	private bool CanUpgrade { get; } = true;
 	public UpgradeNotificationDialog()
 	{
 		if (Design.IsDesignMode)
@@ -33,6 +34,7 @@ public partial class UpgradeNotificationDialog : DialogWindow
 	public UpgradeNotificationDialog(UpgradeProperties upgradeProperties, bool canUpgrade, string? upgradeUnavailableReason = null) : this()
 	{
 		Title = $"Libation version {upgradeProperties.LatestRelease.ToVersionString()} is now available.";
+		CanUpgrade = canUpgrade;
 		PackageUrl = upgradeProperties.ZipUrl;
 		DownloadLinkText = upgradeProperties.ZipName;
 		ReleaseNotes = upgradeProperties.Notes;
@@ -41,7 +43,11 @@ public partial class UpgradeNotificationDialog : DialogWindow
 		DataContext = this;
 	}
 
-	public void OK_Click(object sender, Avalonia.Interactivity.RoutedEventArgs e) => Close(DialogResult.OK);
+	// When Libation cannot install the upgrade itself, this button reads "OK" and the dialog is a
+	// notice with a download link. Reporting OK there would be read as "yes, install it", starting a
+	// download and an install that was never on offer, so acknowledging a notice closes and no more.
+	public void OK_Click(object sender, Avalonia.Interactivity.RoutedEventArgs e)
+		=> Close(CanUpgrade ? DialogResult.OK : DialogResult.Cancel);
 	public void DontRemind_Click(object sender, Avalonia.Interactivity.RoutedEventArgs e) => Close(DialogResult.Ignore);
 	public void Download_Tapped(object sender, Avalonia.Input.TappedEventArgs e)
 		=> Go.To.Url(PackageUrl);

--- a/Source/LibationAvalonia/ViewModels/Settings/ImportantSettingsVM.cs
+++ b/Source/LibationAvalonia/ViewModels/Settings/ImportantSettingsVM.cs
@@ -35,6 +35,7 @@ public class ImportantSettingsVM : ViewModelBase
 		CreationTime = DateTimeSources.SingleOrDefault(v => v.Value == config.CreationTime) ?? DateTimeSources[0];
 		LastWriteTime = DateTimeSources.SingleOrDefault(v => v.Value == config.LastWriteTime) ?? DateTimeSources[0];
 		UseWebView = config.UseWebView;
+		CheckForUpgradesAtStartup = config.CheckForUpgradesAtStartup;
 		LoggingLevel = config.LogLevel;
 		GridScaleFactor = scaleFactorToLinearRange(config.GridScaleFactor);
 		GridFontScaleFactor = scaleFactorToLinearRange(config.GridFontScaleFactor);
@@ -77,6 +78,7 @@ public class ImportantSettingsVM : ViewModelBase
 		config.CreationTime = CreationTime.Value;
 		config.LastWriteTime = LastWriteTime.Value;
 		config.UseWebView = UseWebView;
+		config.CheckForUpgradesAtStartup = CheckForUpgradesAtStartup;
 		config.LogLevel = LoggingLevel;
 		config.TokenStorageMethod = SelectedTokenStorageMethod;
 		initialTokenStorageMethod = SelectedTokenStorageMethod;
@@ -145,10 +147,11 @@ public class ImportantSettingsVM : ViewModelBase
 	/// <summary>When true, the Use WebView setting is disabled (e.g. when running in Linux Snap to avoid portal/sandbox crashes).</summary>
 	public bool UseWebViewSettingDisabled => Configuration.IsRunningUnderSnap;
 	public string UseWebViewSnapMessage { get; } = Configuration.IsRunningUnderSnap ? "Disabled when running in Linux Snap (avoids login crash). Use external browser instead." : "";
+	public string CheckForUpgradesAtStartupText { get; } = Configuration.GetDescription(nameof(Configuration.CheckForUpgradesAtStartup));
+	public string CheckForUpgradesAtStartupTip { get; } = Configuration.GetHelpText(nameof(Configuration.CheckForUpgradesAtStartup));
 	public Serilog.Events.LogEventLevel[] LoggingLevels { get; } = Enum.GetValues<Serilog.Events.LogEventLevel>();
 	public string GridScaleFactorText { get; } = Configuration.GetDescription(nameof(Configuration.GridScaleFactor));
 	public string GridFontScaleFactorText { get; } = Configuration.GetDescription(nameof(Configuration.GridFontScaleFactor));
-	public string BetaOptInText { get; } = Configuration.GetDescription(nameof(Configuration.BetaOptIn));
 	public EnumDisplay<Configuration.Theme>[] Themes { get; }
 		= Enum.GetValues<Configuration.Theme>()
 		.Select(v => new EnumDisplay<Configuration.Theme>(v))
@@ -171,6 +174,7 @@ public class ImportantSettingsVM : ViewModelBase
 	public EnumDisplay<Configuration.DateTimeSource> CreationTime { get; set; }
 	public EnumDisplay<Configuration.DateTimeSource> LastWriteTime { get; set; }
 	public bool UseWebView { get; set; }
+	public bool CheckForUpgradesAtStartup { get; set; }
 	public Serilog.Events.LogEventLevel LoggingLevel { get; set; }
 
 	public bool EncryptTokens

--- a/Source/LibationAvalonia/Views/MainWindow.axaml.cs
+++ b/Source/LibationAvalonia/Views/MainWindow.axaml.cs
@@ -278,7 +278,7 @@ public partial class MainWindow : ReactiveWindow<MainVM>
 		upgrader.UpgradeFailed += async (_, message) => await Dispatcher.UIThread.InvokeAsync(() => { setProgressVisible(false); MessageBox.Show(this, message, "Upgrade Failed", MessageBoxButtons.OK, MessageBoxIcon.Error); });
 
 #if !DEBUG
-		Opened += async (_, _) => await upgrader.CheckForUpgradeAsync(upgradeAvailable);
+		Opened += async (_, _) => await upgrader.CheckForUpgradeAtStartupAsync(upgradeAvailable);
 #endif
 	}
 

--- a/Source/LibationFileManager/Configuration.HelpText.cs
+++ b/Source/LibationFileManager/Configuration.HelpText.cs
@@ -168,6 +168,17 @@ public partial class Configuration
 			When enabled, books from the Audible Plus catalog (titles you stream or borrow under your membership, not purchased) are imported into Libation.
 
 			Downloading or liberating many Plus titles in a short time can cause Audible to temporarily deny content licenses ("license denied") for a day or two. That limit is enforced by Audible, not Libation — waiting and retrying usually fixes it. If problems persist after several days, report on Libation's GitHub with logs.
+			""" },
+		{nameof(CheckForUpgradesAtStartup), """
+			When enabled, Libation asks GitHub whether a newer
+			release exists each time it starts, and offers it to
+			you if there is one.
+
+			Turn this off if something else keeps Libation up to
+			date, such as a package manager or an AppImage
+			updater. You can still check whenever you like:
+			Help > About has a "Check for Upgrade" button that
+			works either way.
 			""" }
 	}.AsReadOnly();
 

--- a/Source/LibationFileManager/Configuration.HelpText.cs
+++ b/Source/LibationFileManager/Configuration.HelpText.cs
@@ -177,8 +177,8 @@ public partial class Configuration
 			Turn this off if something else keeps Libation up to
 			date, such as a package manager or an AppImage
 			updater. You can still check whenever you like:
-			Help > About has a "Check for Upgrade" button that
-			works either way.
+			Settings > About has a "Check for Upgrade" button
+			that works either way.
 			""" }
 	}.AsReadOnly();
 

--- a/Source/LibationFileManager/Configuration.PersistentSettings.cs
+++ b/Source/LibationFileManager/Configuration.PersistentSettings.cs
@@ -117,8 +117,8 @@ public partial class Configuration
 	[Description("Book display font size")]
 	public float GridFontScaleFactor { get => float.Min(2, float.Max(0.5f, GetNonString(defaultValue: 1f))); set => SetNonString(value); }
 
-	[Description("Use the beta version of Libation\r\nNew and experimental features, but probably buggy.\r\n(requires restart to take effect)")]
-	public bool BetaOptIn { get => GetNonString(defaultValue: false); set => SetNonString(value); }
+	[Description("Check for new Libation versions at startup")]
+	public bool CheckForUpgradesAtStartup { get => GetNonString(defaultValue: true); set => SetNonString(value); }
 
 	[Description("Location for book storage. Includes destination of newly liberated books")]
 	public LongPath? Books

--- a/Source/LibationUiBase/Upgrader.cs
+++ b/Source/LibationUiBase/Upgrader.cs
@@ -227,6 +227,15 @@ public abstract class UpgraderBase
 			: new(platformCanUpgrade, null, null);
 
 	/// <summary>
+	/// Whether the flow may go on to download and install. The dialog's answer is not enough on its
+	/// own: when Libation cannot install the upgrade itself, the prompt is a notice with a download
+	/// link, so a UI that reports acceptance anyway must not be able to start an install that was
+	/// never on offer - or, under Application Control, one that leaves Libation unable to start.
+	/// </summary>
+	internal static bool MayInstallUpgrade(bool userAccepted, bool capUpgrade)
+		=> userAccepted && capUpgrade;
+
+	/// <summary>
 	/// The check both GUIs run when their main window opens, skipped when the user has turned off
 	/// <see cref="Configuration.CheckForUpgradesAtStartup"/>. Only this automatic check is optional:
 	/// the About window's "Check for Upgrade" button asks for a check outright and calls
@@ -283,13 +292,14 @@ public abstract class UpgraderBase
 			if (upgradeEventArgs.Ignore)
 				config.SetString(upgradeProperties.LatestRelease.ToString(), ignoreUpgrade);
 
-			if (!upgradeEventArgs.InstallUpgrade) return result;
-
-			// A second stop, because a UI that ignores CapUpgrade must not be able to start an
-			// upgrade that ends with Libation unable to start.
-			if (applicationControlBlocksUpgrade)
+			if (!MayInstallUpgrade(upgradeEventArgs.InstallUpgrade, capability.CapUpgrade))
 			{
-				Serilog.Log.Logger.Information("Skipped the in-app upgrade to {LatestRelease}: Windows Application Control is enforcing.", upgradeProperties.LatestRelease);
+				if (upgradeEventArgs.InstallUpgrade)
+					Serilog.Log.Logger.Information(
+						"Skipped the in-app upgrade to {LatestRelease}: {Reason}.",
+						upgradeProperties.LatestRelease,
+						applicationControlBlocksUpgrade ? "Windows Application Control is enforcing" : "this install cannot upgrade itself");
+
 				return result;
 			}
 

--- a/Source/LibationUiBase/Upgrader.cs
+++ b/Source/LibationUiBase/Upgrader.cs
@@ -226,6 +226,23 @@ public abstract class UpgraderBase
 			? new(false, ApplicationControlUpgradeMessage, ApplicationControlUpgradeSummary)
 			: new(platformCanUpgrade, null, null);
 
+	/// <summary>
+	/// The check both GUIs run when their main window opens, skipped when the user has turned off
+	/// <see cref="Configuration.CheckForUpgradesAtStartup"/>. Only this automatic check is optional:
+	/// the About window's "Check for Upgrade" button asks for a check outright and calls
+	/// <see cref="CheckForUpgradeAsync(Func{UpgradeEventArgs, Task})"/> regardless of the setting.
+	/// </summary>
+	public async Task CheckForUpgradeAtStartupAsync(Func<UpgradeEventArgs, Task> upgradeAvailableHandler)
+	{
+		if (!Configuration.Instance.CheckForUpgradesAtStartup)
+		{
+			Serilog.Log.Logger.Information("Skipping the startup upgrade check: {Setting} is off.", nameof(Configuration.CheckForUpgradesAtStartup));
+			return;
+		}
+
+		await CheckForUpgradeAsync(upgradeAvailableHandler);
+	}
+
 	/// <summary>Check for upgrade and invoke <paramref name="upgradeAvailableHandler"/> if an update is available. Returns the check outcome so the UI can show "up to date", "update available", or "unable to determine".</summary>
 	public async Task<VersionCheckResult> CheckForUpgradeAsync(Func<UpgradeEventArgs, Task> upgradeAvailableHandler)
 	{

--- a/Source/LibationWinForms/Dialogs/SettingsDialog.Designer.cs
+++ b/Source/LibationWinForms/Dialogs/SettingsDialog.Designer.cs
@@ -69,6 +69,7 @@
 			absFolderLbl = new System.Windows.Forms.Label();
 			absFolderCb = new System.Windows.Forms.ComboBox();
 			tab1ImportantSettings = new System.Windows.Forms.TabPage();
+			checkForUpgradesCbox = new System.Windows.Forms.CheckBox();
 			themeLbl = new System.Windows.Forms.Label();
 			themeCb = new System.Windows.Forms.ComboBox();
 			label22 = new System.Windows.Forms.Label();
@@ -405,6 +406,16 @@
 			loggingLevelCb.Size = new System.Drawing.Size(129, 23);
 			loggingLevelCb.TabIndex = 4;
 			// 
+			// checkForUpgradesCbox
+			// 
+			checkForUpgradesCbox.AutoSize = true;
+			checkForUpgradesCbox.Location = new System.Drawing.Point(6, 569);
+			checkForUpgradesCbox.Name = "checkForUpgradesCbox";
+			checkForUpgradesCbox.Size = new System.Drawing.Size(300, 19);
+			checkForUpgradesCbox.TabIndex = 13;
+			checkForUpgradesCbox.Text = "[Check for upgrades at startup]";
+			checkForUpgradesCbox.UseVisualStyleBackColor = true;
+			// 
 			// tabControl
 			// 
 			tabControl.Anchor = System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right;
@@ -423,6 +434,7 @@
 			// 
 			tab1ImportantSettings.AutoScroll = true;
 			tab1ImportantSettings.BackColor = System.Drawing.SystemColors.Window;
+			tab1ImportantSettings.Controls.Add(checkForUpgradesCbox);
 			tab1ImportantSettings.Controls.Add(themeLbl);
 			tab1ImportantSettings.Controls.Add(themeCb);
 			tab1ImportantSettings.Controls.Add(label22);
@@ -1926,6 +1938,7 @@
 		private System.Windows.Forms.CheckBox createCueSheetCbox;
 		private System.Windows.Forms.CheckBox autoScanCb;
 		private System.Windows.Forms.CheckBox useWebViewCb;
+		private System.Windows.Forms.CheckBox checkForUpgradesCbox;
 		private System.Windows.Forms.CheckBox downloadCoverArtCbox;
 		private System.Windows.Forms.CheckBox autoDownloadEpisodesCb;
 		private System.Windows.Forms.CheckBox saveEpisodesToSeriesFolderCbox;

--- a/Source/LibationWinForms/Dialogs/SettingsDialog.Important.cs
+++ b/Source/LibationWinForms/Dialogs/SettingsDialog.Important.cs
@@ -42,6 +42,8 @@ public partial class SettingsDialog
 		lastWriteTimeLbl.Text = desc(nameof(config.LastWriteTime));
 		gridScaleFactorLbl.Text = desc(nameof(config.GridScaleFactor));
 		gridFontScaleFactorLbl.Text = desc(nameof(config.GridFontScaleFactor));
+		checkForUpgradesCbox.Text = desc(nameof(config.CheckForUpgradesAtStartup));
+		toolTip.SetToolTip(checkForUpgradesCbox, Configuration.GetHelpText(nameof(config.CheckForUpgradesAtStartup)));
 
 		var dateTimeSources = Enum.GetValues<Configuration.DateTimeSource>().Select(v => new EnumDisplay<Configuration.DateTimeSource>(v)).ToArray();
 		creationTimeCb.Items.AddRange(dateTimeSources);
@@ -70,6 +72,7 @@ public partial class SettingsDialog
 
 		saveEpisodesToSeriesFolderCbox.Checked = config.SavePodcastsToParentFolder;
 		overwriteExistingCbox.Checked = config.OverwriteExisting;
+		checkForUpgradesCbox.Checked = config.CheckForUpgradesAtStartup;
 		gridScaleFactorTbar.Value = scaleFactorToLinearRange(config.GridScaleFactor);
 		gridFontScaleFactorTbar.Value = scaleFactorToLinearRange(config.GridFontScaleFactor);
 
@@ -195,6 +198,7 @@ public partial class SettingsDialog
 
 		config.SavePodcastsToParentFolder = saveEpisodesToSeriesFolderCbox.Checked;
 		config.OverwriteExisting = overwriteExistingCbox.Checked;
+		config.CheckForUpgradesAtStartup = checkForUpgradesCbox.Checked;
 
 		config.CreationTime = (creationTimeCb.SelectedItem as EnumDisplay<Configuration.DateTimeSource>)?.Value ?? Configuration.DateTimeSource.File;
 		config.LastWriteTime = (lastWriteTimeCb.SelectedItem as EnumDisplay<Configuration.DateTimeSource>)?.Value ?? Configuration.DateTimeSource.File;

--- a/Source/LibationWinForms/Form1.Upgrade.cs
+++ b/Source/LibationWinForms/Form1.Upgrade.cs
@@ -27,7 +27,7 @@ public partial class Form1
 		upgrader.UpgradeFailed += (_, message) => Invoke(() => { setProgressVisible(false); MessageBox.Show(this, message, "Upgrade Failed", MessageBoxButtons.OK, MessageBoxIcon.Error); });
 
 #if !DEBUG
-		Shown += async (_, _) => await upgrader.CheckForUpgradeAsync(upgradeAvailable);
+		Shown += async (_, _) => await upgrader.CheckForUpgradeAtStartupAsync(upgradeAvailable);
 #endif
 	}
 

--- a/Source/_Tests/LibationFileManager.Tests/UpgradeCheckSettingTests.cs
+++ b/Source/_Tests/LibationFileManager.Tests/UpgradeCheckSettingTests.cs
@@ -1,0 +1,52 @@
+using AssertionHelper;
+using LibationFileManager;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace UpgradeCheckSettingTests;
+
+[TestClass]
+[DoNotParallelize]
+public class UpgradeCheckSettingTests
+{
+	[TestCleanup]
+	public void Cleanup()
+	{
+		Configuration.RestoreSingletonInstance();
+	}
+
+	// The update check is opt-out, so every install that predates the setting has to keep checking
+	// without anything having written the key.
+	[TestMethod]
+	public void Default_when_missing_is_enabled()
+	{
+		var config = Configuration.CreateMockInstance();
+
+		config.Exists(nameof(Configuration.CheckForUpgradesAtStartup)).Should().BeFalse();
+		Assert.IsTrue(config.CheckForUpgradesAtStartup);
+	}
+
+	[TestMethod]
+	public void Round_trips_off_and_on()
+	{
+		var config = Configuration.CreateMockInstance();
+
+		config.CheckForUpgradesAtStartup = false;
+		Assert.IsFalse(config.CheckForUpgradesAtStartup);
+		Assert.IsFalse(config.CreateEphemeralCopy().CheckForUpgradesAtStartup);
+
+		config.CheckForUpgradesAtStartup = true;
+		Assert.IsTrue(config.CheckForUpgradesAtStartup);
+		Assert.IsTrue(config.CreateEphemeralCopy().CheckForUpgradesAtStartup);
+	}
+
+	// get-setting and the -o override both reflect over Configuration properties carrying
+	// [Description], so a missing attribute would silently drop the setting from the CLI.
+	[TestMethod]
+	public void Has_a_description_so_the_cli_can_see_it()
+	{
+		var description = Configuration.GetDescription(nameof(Configuration.CheckForUpgradesAtStartup));
+
+		Assert.AreNotEqual($"[{nameof(Configuration.CheckForUpgradesAtStartup)}]", description);
+		StringAssert.Contains(description, "startup");
+	}
+}

--- a/Source/_Tests/LibationUiBase.Tests/StartupUpgradeCheckTests.cs
+++ b/Source/_Tests/LibationUiBase.Tests/StartupUpgradeCheckTests.cs
@@ -1,0 +1,81 @@
+using LibationFileManager;
+
+namespace LibationUiBase.Tests;
+
+/// <summary>
+/// Covers the one thing the CheckForUpgradesAtStartup setting has to do: keep the startup check off
+/// the network when it is off, and leave it alone when it is on.
+/// <para>
+/// <see cref="MockUpgrader"/> is the seam. With <see cref="MockUpgrader.CheckForUpgradeSucceeds"/>
+/// false, the check reports its own distinctive failure and the flow returns before reaching
+/// <c>InteropFactory</c>, whose <c>CanUpgrade</c> throws off-platform. That failure message is
+/// therefore proof that the check ran, and its absence proof that it did not.
+/// </para>
+/// </summary>
+[TestClass]
+[DoNotParallelize]
+public class StartupUpgradeCheckTests
+{
+	private const string CheckRanMessage = "Mock Check For Upgrade Failed";
+
+	[TestCleanup]
+	public void Cleanup()
+	{
+		Configuration.RestoreSingletonInstance();
+	}
+
+	[TestMethod]
+	public async Task Startup_checks_when_the_setting_is_on()
+	{
+		var config = Configuration.CreateMockInstance();
+		config.CheckForUpgradesAtStartup = true;
+
+		var (upgrader, failures) = BuildUpgraderThatFailsItsCheck();
+		await upgrader.CheckForUpgradeAtStartupAsync(ShouldNotBeCalled);
+
+		Assert.AreEqual(1, failures.Count);
+		StringAssert.Contains(failures[0], CheckRanMessage);
+	}
+
+	[TestMethod]
+	public async Task Startup_does_not_check_when_the_setting_is_off()
+	{
+		var config = Configuration.CreateMockInstance();
+		config.CheckForUpgradesAtStartup = false;
+
+		var (upgrader, failures) = BuildUpgraderThatFailsItsCheck();
+		await upgrader.CheckForUpgradeAtStartupAsync(ShouldNotBeCalled);
+
+		Assert.AreEqual(0, failures.Count);
+	}
+
+	// Turning the automatic check off must not disable the About window's "Check for Upgrade"
+	// button, which calls CheckForUpgradeAsync directly.
+	[TestMethod]
+	public async Task A_requested_check_still_runs_when_the_setting_is_off()
+	{
+		var config = Configuration.CreateMockInstance();
+		config.CheckForUpgradesAtStartup = false;
+
+		var (upgrader, failures) = BuildUpgraderThatFailsItsCheck();
+		var result = await upgrader.CheckForUpgradeAsync(ShouldNotBeCalled);
+
+		Assert.AreEqual(AppScaffolding.VersionCheckOutcome.UnableToDetermine, result.Outcome);
+		Assert.AreEqual(1, failures.Count);
+		StringAssert.Contains(failures[0], CheckRanMessage);
+	}
+
+	private static (MockUpgrader Upgrader, List<string> Failures) BuildUpgraderThatFailsItsCheck()
+	{
+		var upgrader = new MockUpgrader { CheckForUpgradeSucceeds = false };
+		List<string> failures = [];
+		upgrader.UpgradeFailed += (_, message) => failures.Add(message);
+		return (upgrader, failures);
+	}
+
+	private static Task ShouldNotBeCalled(UpgradeEventArgs e)
+	{
+		Assert.Fail("The upgrade-available handler ran, but the check was supposed to fail before an update could be offered.");
+		return Task.CompletedTask;
+	}
+}

--- a/Source/_Tests/LibationUiBase.Tests/UpgradeCapabilityTests.cs
+++ b/Source/_Tests/LibationUiBase.Tests/UpgradeCapabilityTests.cs
@@ -51,4 +51,24 @@ public class UpgradeCapabilityTests
 		Assert.IsNull(capability.Reason);
 		Assert.IsNull(capability.Summary);
 	}
+
+	[TestMethod]
+	public void An_accepted_upgrade_installs_when_the_platform_can()
+		=> Assert.IsTrue(UpgraderBase.MayInstallUpgrade(userAccepted: true, capUpgrade: true));
+
+	// Chardonnay's prompt relabels its button to "OK" when Libation cannot install the upgrade
+	// itself, but still reported acceptance, so acknowledging a download-link notice began a
+	// download and an install that was never on offer and could only fail.
+	[TestMethod]
+	public void Acceptance_is_not_enough_when_libation_cannot_install_the_upgrade()
+		=> Assert.IsFalse(UpgraderBase.MayInstallUpgrade(userAccepted: true, capUpgrade: false));
+
+	// InstallUpgrade defaults to true, so a UI that never answers must not be taken as a yes on a
+	// platform that cannot install.
+	[TestMethod]
+	public void Declining_never_installs()
+	{
+		Assert.IsFalse(UpgraderBase.MayInstallUpgrade(userAccepted: false, capUpgrade: true));
+		Assert.IsFalse(UpgraderBase.MayInstallUpgrade(userAccepted: false, capUpgrade: false));
+	}
 }

--- a/docs/advanced/advanced.md
+++ b/docs/advanced/advanced.md
@@ -12,7 +12,7 @@ To make upgrades and reinstalls easier, Libation separates all of its responsibi
 
 ## Settings
 
-- Check for new Libation versions at startup. Enabled by default: each time Libation starts it asks GitHub whether a newer release exists, and offers it to you if there is one. Turn it off if something else keeps Libation up to date, such as a package manager or an AppImage updater. Turning it off only stops the automatic check - Help > About still has a "Check for Upgrade" button that works either way.
+- Check for new Libation versions at startup. Enabled by default: each time Libation starts it asks GitHub whether a newer release exists, and offers it to you if there is one. Turn it off if something else keeps Libation up to date, such as a package manager or an AppImage updater. Turning it off only stops the automatic check - Settings > About still has a "Check for Upgrade" button that works either way.
 
 - Allow Libation to fix up audiobook metadata. After decrypting a title, Libation attempts to fix details like chapters and cover art. Some power users and/or control freaks prefer to manage this themselves. By unchecking this setting, Libation will only decrypt the book and will leave metadata as-is, warts and all.
 

--- a/docs/advanced/advanced.md
+++ b/docs/advanced/advanced.md
@@ -12,6 +12,8 @@ To make upgrades and reinstalls easier, Libation separates all of its responsibi
 
 ## Settings
 
+- Check for new Libation versions at startup. Enabled by default: each time Libation starts it asks GitHub whether a newer release exists, and offers it to you if there is one. Turn it off if something else keeps Libation up to date, such as a package manager or an AppImage updater. Turning it off only stops the automatic check - Help > About still has a "Check for Upgrade" button that works either way.
+
 - Allow Libation to fix up audiobook metadata. After decrypting a title, Libation attempts to fix details like chapters and cover art. Some power users and/or control freaks prefer to manage this themselves. By unchecking this setting, Libation will only decrypt the book and will leave metadata as-is, warts and all.
 
 In addition to the options that are enabled if you allow Libation to "fix up" the audiobook, it does the following:

--- a/docs/installation/linux.md
+++ b/docs/installation/linux.md
@@ -62,7 +62,9 @@ sudo dnf5 install ./libation.rpm
   am -i libation
   ```
 Thanks to Package Forge dev [Samuel](https://github.com/Samueru-sama) for [AppImage](https://github.com/pkgforge-dev/Libation-AppImage) maintenence.
-  
+
+When your package manager updates Libation for you, the startup update check has nothing useful to tell you. Turn off "Check for new Libation versions at startup" on the Important settings tab to stop it. Help > About still has a "Check for Upgrade" button whenever you want to look.
+
 ### Arch Linux
 
 ```bash

--- a/docs/installation/linux.md
+++ b/docs/installation/linux.md
@@ -63,7 +63,7 @@ sudo dnf5 install ./libation.rpm
   ```
 Thanks to Package Forge dev [Samuel](https://github.com/Samueru-sama) for [AppImage](https://github.com/pkgforge-dev/Libation-AppImage) maintenence.
 
-When your package manager updates Libation for you, the startup update check has nothing useful to tell you. Turn off "Check for new Libation versions at startup" on the Important settings tab to stop it. Help > About still has a "Check for Upgrade" button whenever you want to look.
+When your package manager updates Libation for you, the startup update check has nothing useful to tell you. Turn off "Check for new Libation versions at startup" on the Important settings tab to stop it. Settings > About still has a "Check for Upgrade" button whenever you want to look.
 
 ### Arch Linux
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes #1999.

Libation asked GitHub for a newer release every time it started, with no way to stop it. That is noise for anyone whose install is updated by something else - a package manager, or an AppImage updater - because the prompt it raises is one they can do nothing useful with.

The issue asked for this opt-in. It ships opt-out instead: `CheckForUpgradesAtStartup` defaults to on, so nothing changes for the people who rely on the prompt, and the users who want silence are the ones who go looking for the checkbox.

## What is gated, and what is not

Only the automatic startup check. The About window's "Check for Upgrade" button and the CLI's `version --check` ask for a check outright, so they run either way. That is why the setting is read in a new `UpgraderBase.CheckForUpgradeAtStartupAsync` rather than inside `CheckForUpgradeAsync`, which the startup path and the About button share.

Existing installs need no migration. `PersistentDictionary.GetNonString` returns the getter's default when the key is absent, so a `Settings.json` written before this change behaves as enabled without being rewritten.

The setting appears on the Important settings tab in both GUIs, and `get-setting` picks it up automatically by reflecting over `[Description]` properties.

## `BetaOptIn` is deleted

The new setting takes its slot. It was declared, described and logged, but no axaml or designer ever bound it and nothing read the value: `GetLatestRelease` only ever asks GitHub for the stable release, so there was no beta channel for it to select. A stale `BetaOptIn` key in an existing `Settings.json` needs no cleanup migration, since `PersistentDictionary` ignores keys with no matching property.

## Also fixed: a download-only notice could start an install

Found while testing the above, and fixed here in its own commit.

When Libation cannot install an upgrade itself - a portable or AppImage install, a Linux build with no package-manager symlink, macOS outside `/Applications` - the prompt is a notice with a download link, and Chardonnay relabels its button from "Yes" to "OK" to say so. The button still closed with `DialogResult.OK`, which `MainWindow` and the About window both read as "yes, install it", so acknowledging the notice downloaded the release and ran the auto-upgrader anyway. That could only fail, and it failed loudly: an "Upgrade Failed" error box in answer to dismissing a notice.

The button now closes with `Cancel` when there was no upgrade on offer. Classic already did the equivalent, hiding its Yes button and relabelling No. `UpgraderBase` gets the matching guard: it already refused to install under Windows Application Control on the grounds that a UI ignoring `CapUpgrade` must not be able to start an upgrade that leaves Libation unable to start, and that reasoning covers every capped upgrade, so the stop is now keyed on `CapUpgrade` itself via `MayInstallUpgrade`.

## Evidence

Settings UI in Chardonnay: on by default, tooltip, toggled off, persists across reopen, and the About window's manual check still working with the setting off.

[startup_update_check_setting_default_on_toggle_off_manual_check_still_works.mp4](https://cursor.com/agents/bc-ef155d19-d7fb-4428-9744-434f5f5cefc8/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fstartup_update_check_setting_default_on_toggle_off_manual_check_still_works.mp4)

The gate itself, measured on a Release build (the startup check is compiled in only for non-DEBUG) deliberately versioned 1.0.0 so GitHub's 13.7.11 really is newer. With the setting on, the startup check runs and prompts:

[Startup upgrade prompt with the setting on](https://cursor.com/agents/bc-ef155d19-d7fb-4428-9744-434f5f5cefc8/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fstartup_upgrade_prompt_when_setting_is_on.webp)

Two consecutive startups of that same build, differing only in the setting. With it off, nothing reaches GitHub:

```
=== startup 2026-08-25 21:44:14   CheckForUpgradesAtStartup = true ===
    build version 1.0.0.0
    logged   Update available
    logged   Can't perform upgrade automatically

=== startup 2026-08-25 21:45:39   CheckForUpgradesAtStartup = false ===
    build version 1.0.0.0
    logged   Skipping the startup upgrade check: CheckForUpgradesAtStartup is off.
    logged   (no 'Update available' line - GitHub was never contacted)
```

For the install bug, clicking "OK" on the download-only notice now simply closes it:

[acknowledging_download_only_upgrade_notice_no_longer_attempts_an_install.mp4](https://cursor.com/agents/bc-ef155d19-d7fb-4428-9744-434f5f5cefc8/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Facknowledging_download_only_upgrade_notice_no_longer_attempts_an_install.mp4)

The same click, before and after, in the log:

```
BEFORE the fix - acknowledging the notice began a download and a doomed install:
  21:27:49]  Update available
  21:27:49]  Can't perform upgrade automatically
  21:28:45]  Downloading /tmp/Libation-upgrade-j6pw6k/Libation.13.7.11-linux-chardonnay-amd64.deb
  21:28:45]  Begin running auto-upgrader
  21:28:45]  Auto-upgrader did not complete successfully

AFTER the fix - the same click just closes the notice:
  22:03:30]  Update available
  22:03:30]  Can't perform upgrade automatically
  (no Downloading, no auto-upgrader, no "Upgrade Failed" dialog)
```

## Tests

Eight new tests; the full suite is 1632 passing, 23 skipped (the opt-in OS-secret-store ones). The gate tests were checked against a deliberately inverted condition and both failed, so they are load-bearing rather than tautological.

`LibationFileManager.Tests/UpgradeCheckSettingTests` covers the opt-out default with the key absent, the round trip, and the presence of `[Description]` that the CLI depends on. `LibationUiBase.Tests/StartupUpgradeCheckTests` drives `MockUpgrader` to assert that the startup path checks when the setting is on, does not when it is off, and that a requested check still runs when it is off. `UpgradeCapabilityTests` gains three cases for `MayInstallUpgrade`, including that `InstallUpgrade` defaulting to true cannot be taken as a yes on a platform that cannot install.

## Not verified here

The Classic (WinForms) checkbox compiles but was not run: WinForms has no Linux runtime, so its placement on the Important tab needs an eye on Windows. Classic's half of the install fix is a no-op by inspection, since its dialog already returned `No` for the acknowledge button.


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ef155d19-d7fb-4428-9744-434f5f5cefc8?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ef155d19-d7fb-4428-9744-434f5f5cefc8&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

