### PR TITLE
Adopt Dinah.* 10.2.6.1 and AudibleApi 11.0.5.1

### DIFF
--- a/Source/AudibleUtilities/AudibleUtilities.csproj
+++ b/Source/AudibleUtilities/AudibleUtilities.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AudibleApi" Version="11.0.4.1" />
+    <PackageReference Include="AudibleApi" Version="11.0.5.1" />
     <PackageReference Include="Google.Protobuf" Version="3.34.1" />
   </ItemGroup>
 

--- a/Source/DataLayer/DataLayer.csproj
+++ b/Source/DataLayer/DataLayer.csproj
@@ -12,7 +12,7 @@
   
   <ItemGroup>
     <PackageReference Include="Dinah.Core" Version="10.2.6.1" />
-    <PackageReference Include="Dinah.EntityFrameworkCore" Version="10.2.5.1" />
+    <PackageReference Include="Dinah.EntityFrameworkCore" Version="10.2.6.1" />
 	<PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.0.1" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.0.11" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.11">

--- a/Source/DataLayer/DataLayer.csproj
+++ b/Source/DataLayer/DataLayer.csproj
@@ -11,7 +11,7 @@
   </PropertyGroup>
   
   <ItemGroup>
-    <PackageReference Include="Dinah.Core" Version="10.2.5.1" />
+    <PackageReference Include="Dinah.Core" Version="10.2.6.1" />
     <PackageReference Include="Dinah.EntityFrameworkCore" Version="10.2.5.1" />
 	<PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.0.1" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.0.11" />

--- a/Source/FileManager/FileManager.csproj
+++ b/Source/FileManager/FileManager.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Dinah.Core" Version="10.2.5.1" />
+    <PackageReference Include="Dinah.Core" Version="10.2.6.1" />
     <PackageReference Include="Polly" Version="8.6.6" />
   </ItemGroup>
 

--- a/Source/LibationFileManager/LibationFileManager.csproj
+++ b/Source/LibationFileManager/LibationFileManager.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AudibleApi" Version="11.0.4.1" />
+    <PackageReference Include="AudibleApi" Version="11.0.5.1" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="10.0.11" />
     <PackageReference Include="NameParserSharp" Version="1.5.0" />
     <PackageReference Include="Serilog.Exceptions" Version="8.4.0" />

--- a/Source/LibationWinForms/LibationWinForms.csproj
+++ b/Source/LibationWinForms/LibationWinForms.csproj
@@ -41,7 +41,7 @@
 
 
 	<ItemGroup>
-		<PackageReference Include="Dinah.Core.WindowsDesktop" Version="10.2.5.1" />
+		<PackageReference Include="Dinah.Core.WindowsDesktop" Version="10.2.6.1" />
 		<PackageReference Include="Microsoft.Web.WebView2" Version="1.0.3912.50" />
 	</ItemGroup>
 

--- a/Source/_Demos/LoadByOS/CrossPlatformClientExe/CrossPlatformClientExe.csproj
+++ b/Source/_Demos/LoadByOS/CrossPlatformClientExe/CrossPlatformClientExe.csproj
@@ -19,7 +19,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Dinah.Core" Version="10.2.5.1" />
+    <PackageReference Include="Dinah.Core" Version="10.2.6.1" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adopts the full dependency tree for the Dinah.Core 10.2.6.1 release, all published and indexed on nuget.org:

- `Dinah.Core` 10.2.6.1 in `FileManager`, `DataLayer`, and the `CrossPlatformClientExe` demo
- `Dinah.EntityFrameworkCore` 10.2.6.1 in `DataLayer` (versioned in step, no code change)
- `Dinah.Core.WindowsDesktop` 10.2.6.1 in `LibationWinForms` (versioned in step, no code change)
- `AudibleApi` 11.0.5.1 in `AudibleUtilities` and `LibationFileManager` (carries the Dinah.Core 10.2.6.1 dependency floor, no code change)

No code change needed here. Dinah.Core 10.2.6.1 replaces its Pluralize.NET dependency with an internal pluralizer ([Dinah.Core #31](https://github.com/rmcrackan/Dinah.Core/pull/31)); the `Pluralize`/`PluralizeWithCount` extensions this repo uses behave the same.

Verified against the real nuget.org packages: full solution builds with 0 warnings (including the WinForms projects via `EnableWindowsTargeting` - compile-checked only, not run), and the whole test suite passes (1609 passed, 23 skipped). Several suites assert on `PluralizeWithCount` output strings, so the new pluralizer is exercised at real call sites.

Independent of [#2004](https://github.com/rmcrackan/Libation/pull/2004) (CsvHelper removal); the two can merge in either order.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7d349814-02ec-41d6-b818-75b6a93ab4c7?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7d349814-02ec-41d6-b818-75b6a93ab4c7&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

