### PR TITLE
Honor directory separators written in tag format strings

### DIFF
--- a/Source/FileManager/NamingTemplate/CommonFormatters.cs
+++ b/Source/FileManager/NamingTemplate/CommonFormatters.cs
@@ -70,13 +70,17 @@ public static partial class CommonFormatters
 		// if this function is called from toString implementation of the IFormattable interface, we only get a IFormatProvider
 		var culture = GetCultureInfo(provider);
 		var oldUiCulture = Thread.CurrentThread.CurrentUICulture;
-		var result = CollapseSpacesAndTrimRegex().Replace(TagFormatRegex().ReplaceWithGaps(templateString, GetValueForMatchingTag, Unescape), string.Empty);
+		var result = CollapseSpacesAndTrimRegex().Replace(TagFormatRegex().ReplaceWithGaps(templateString, GetValueForMatchingTag, UnescapeGap), string.Empty);
 		Thread.CurrentThread.CurrentUICulture = oldUiCulture;
 		return result;
+
+		// Everything between the tags belongs to the template, so its separators ask for a directory level.
+		static string UnescapeGap(string gap) => MarkSeparators(Unescape(gap));
 
 		string GetValueForMatchingTag(Match m)
 		{
 			var tag = m.Groups["tag"].Value;
+			// An unrecognized tag is passed through verbatim, escapes and all, so it is left unmarked.
 			if (!replacements.TryGetValue(tag, out var getter)) return m.Value;
 
 			var lang = m.ResolveValue("lang");
@@ -91,7 +95,9 @@ public static partial class CommonFormatters
 				IFormattable formattable => formattable.ToString(format, cultureToUse),
 				_ => _StringFormatter(value?.ToString(), format, cultureToUse),
 			};
-			return formatted.IsNullOrEmpty() ? string.Empty : m.UnescapeValue("pre") + formatted + m.UnescapeValue("post");
+			return formatted.IsNullOrEmpty()
+				? string.Empty
+				: MarkSeparators(m.UnescapeValue("pre")) + RemoveSeparatorMarks(formatted) + MarkSeparators(m.UnescapeValue("post"));
 		}
 	}
 
@@ -243,6 +249,46 @@ public static partial class CommonFormatters
 	{
 		return Unescape(valueSpan, ['\'', '"']);
 	}
+
+	#region Separator marks
+
+	/*
+	 * A directory separator means different things depending on where it came from. Written into a
+	 * template it asks for a new directory level; arriving inside a book property it is just a
+	 * character that has no business in a file name. Formatters fuse both into one string, and
+	 * IFormattable.ToString cannot hand back anything richer, so the two are told apart by marking
+	 * the separators that came from the template with a private use character. Templates resolves
+	 * the marks once the property values have been through ReplacementCharacters.
+	 */
+
+	public const char TemplateBackSlash = '\uE000';
+	public const char TemplateForwardSlash = '\uE001';
+
+	/// <summary>Mark the directory separators in text taken verbatim from a template's format string.</summary>
+	public static string MarkSeparators(string? literal)
+		=> string.IsNullOrEmpty(literal)
+			? string.Empty
+			: literal.Replace('\\', TemplateBackSlash).Replace('/', TemplateForwardSlash);
+
+	/// <summary>Drop separator marks from a property value so that metadata cannot forge a directory level.</summary>
+	public static string RemoveSeparatorMarks(string? value)
+		=> string.IsNullOrEmpty(value)
+			? string.Empty
+			: value.IndexOfAny(separatorMarks) < 0
+				? value
+				: value.Replace($"{TemplateBackSlash}", "").Replace($"{TemplateForwardSlash}", "");
+
+	/// <summary>Replace separator marks with the text that each one should become.</summary>
+	public static string ResolveSeparators(string? text, string backSlash, string forwardSlash)
+		=> string.IsNullOrEmpty(text)
+			? string.Empty
+			: text.IndexOfAny(separatorMarks) < 0
+				? text
+				: text.Replace($"{TemplateBackSlash}", backSlash).Replace($"{TemplateForwardSlash}", forwardSlash);
+
+	private static readonly char[] separatorMarks = [TemplateBackSlash, TemplateForwardSlash];
+
+	#endregion
 
 	public static string Unescape(ReadOnlySpan<char> valueSpan, ReadOnlySpan<char> quoteChars, bool unquoteBackslash = true, bool unescapeDoubleQuotesInsideQuotes = true)
 	{

--- a/Source/LibationFileManager/Templates/IListFormat[TList].cs
+++ b/Source/LibationFileManager/Templates/IListFormat[TList].cs
@@ -96,7 +96,8 @@ internal partial interface IListFormat<TList> where TList : IListFormat<TList>
 		if (separator is null)
 			return formattedItems;
 
-		var joined = Join(separator, formattedItems);
+		// The separator comes from the template, so its directory separators ask for a directory level.
+		var joined = Join(CommonFormatters.MarkSeparators(separator), formattedItems);
 		return joined is null ? [] : [joined];
 
 		string ItemFormatter(T n) => n.ToString(format, culture);

--- a/Source/LibationFileManager/Templates/Templates.cs
+++ b/Source/LibationFileManager/Templates/Templates.cs
@@ -109,7 +109,8 @@ public abstract class Templates
 	{
 		ArgumentValidator.EnsureNotNull(libraryBookDto, nameof(libraryBookDto));
 		ArgumentValidator.EnsureNotNull(multiChapProps, nameof(multiChapProps));
-		return string.Concat(NamingTemplate.Evaluate(culture, libraryBookDto, multiChapProps, new CombinedDto(libraryBookDto, multiChapProps)).Select(p => p.Value));
+		var parts = NamingTemplate.Evaluate(culture, libraryBookDto, multiChapProps, new CombinedDto(libraryBookDto, multiChapProps));
+		return RestoreSeparators(string.Concat(parts.Select(p => p.Value)));
 	}
 
 	public LongPath GetFilename(LibraryBookDto libraryBookDto, string baseDir, string fileExtension, ReplacementCharacters? replacements = null, bool returnFirstExisting = false)
@@ -141,7 +142,24 @@ public abstract class Templates
 	}
 
 	protected virtual IEnumerable<string> GetTemplatePartsStrings(List<TemplatePart> parts, ReplacementCharacters replacements)
-		=> parts.Select(p => replacements.ReplaceFilenameChars(p.Value));
+	{
+		//A single file name has no levels to create, so a separator asked for by the template is
+		//replaced just as a literal one would be.
+		var backSlash = replacements.ReplaceFilenameChars("\\");
+		var forwardSlash = replacements.ReplaceFilenameChars("/");
+
+		return parts.Select(p => CommonFormatters.ResolveSeparators(replacements.ReplaceFilenameChars(p.Value), backSlash, forwardSlash));
+	}
+
+	/// <summary>The directory separator that the template asked for, once it is time to build a path.</summary>
+	private static string ResolveToDirectorySeparator(string value)
+		=> CommonFormatters.ResolveSeparators(value, DirectorySeparator, DirectorySeparator);
+
+	/// <summary>Restore the characters the user typed, for templates whose output is metadata rather than a path.</summary>
+	private static string RestoreSeparators(string value)
+		=> CommonFormatters.ResolveSeparators(value, "\\", "/");
+
+	private static readonly string DirectorySeparator = Path.DirectorySeparatorChar.ToString();
 
 	private LongPath GetFilename(string baseDir, string fileExtension, ReplacementCharacters replacements, bool returnFirstExisting, LibraryBookDto lbDto, CultureInfo? culture,
 		MultiConvertFileProperties? multiDto = null)
@@ -414,9 +432,20 @@ public abstract class Templates
 			=> parts
 			.Select(tp => tp.TemplateTag is null
 				//FolderTemplate literals can have directory separator characters
-				? replacements.ReplacePathChars(tp.Value.Replace(Path.AltDirectorySeparatorChar, Path.DirectorySeparatorChar))
+				? replacements.ReplacePathChars(NormalizeLiteralSeparators(tp.Value))
 				: replacements.ReplaceFilenameChars(tp.Value)
-			).ToList();
+			)
+			//A separator that came from a format string survives ReplaceFilenameChars as a mark, so
+			//it becomes a directory level here while one that came from the metadata stays replaced.
+			.Select(ResolveToDirectorySeparator)
+			.ToList();
+
+		/// <summary>Accept either slash as a directory separator, so the same template works on every platform.</summary>
+		private static string NormalizeLiteralSeparators(string literal)
+			=> literal
+			.Replace(Path.AltDirectorySeparatorChar, Path.DirectorySeparatorChar)
+			.Replace('\\', Path.DirectorySeparatorChar)
+			.Replace('/', Path.DirectorySeparatorChar);
 	}
 
 	public class FileTemplate : Templates, ITemplate
@@ -449,6 +478,6 @@ public abstract class Templates
 		public static IEnumerable<TagCollection> TagCollections { get; } = chapterPropertyTags.Append(conditionalTags).Append(combinedConditionalTags);
 
 		protected override IEnumerable<string> GetTemplatePartsStrings(List<TemplatePart> parts, ReplacementCharacters replacements)
-			=> parts.Select(p => p.Value);
+			=> parts.Select(p => RestoreSeparators(p.Value));
 	}
 }

--- a/Source/_Tests/FileManager.Tests/CommonFormattersTests.cs
+++ b/Source/_Tests/FileManager.Tests/CommonFormattersTests.cs
@@ -109,6 +109,69 @@ public class CommonFormattersTests
 	}
 
 	[TestMethod]
+	public void TemplateStringFormatter_MarksSeparatorsFromTheTemplate()
+	{
+		// GIVEN a template whose literal text asks for a directory level.
+		// '\' escapes the next character, so an actual separator is written '\\'.
+		var template = @"\\{AUTHOR}\\{TITLE}\\";
+		var replacements = new Dictionary<string, Func<TestClass, object?>>
+		{
+			["AUTHOR"] = obj => obj.Author,
+			["TITLE"] = obj => obj.Title
+		};
+		var testObj = new TestClass { Author = "John Doe", Title = "Test Book" };
+
+		// WHEN
+		var result = CommonFormatters.TemplateStringFormatter(testObj, template, CultureInfo.InvariantCulture, replacements);
+
+		// THEN each separator is marked so that it can outlive the file name replacement
+		var mark = CommonFormatters.TemplateBackSlash;
+		Assert.AreEqual($"{mark}John Doe{mark}Test Book{mark}", result);
+	}
+
+	[TestMethod]
+	public void TemplateStringFormatter_LeavesSeparatorsFromAValueAlone()
+	{
+		// GIVEN a value that happens to contain both slashes
+		var replacements = new Dictionary<string, Func<TestClass, object?>> { ["AUTHOR"] = obj => obj.Author };
+		var testObj = new TestClass { Author = @"AC\DC/Live" };
+
+		// WHEN
+		var result = CommonFormatters.TemplateStringFormatter(testObj, "{AUTHOR}", CultureInfo.InvariantCulture, replacements);
+
+		// THEN they stay as they are, for ReplacementCharacters to deal with
+		Assert.AreEqual(@"AC\DC/Live", result);
+	}
+
+	[TestMethod]
+	public void TemplateStringFormatter_DropsMarksForgedInAValue()
+	{
+		// GIVEN a value carrying the marks that only template text is allowed to use
+		var replacements = new Dictionary<string, Func<TestClass, object?>> { ["AUTHOR"] = obj => obj.Author };
+		var testObj = new TestClass { Author = $"AC{CommonFormatters.TemplateBackSlash}DC{CommonFormatters.TemplateForwardSlash}Live" };
+
+		// WHEN
+		var result = CommonFormatters.TemplateStringFormatter(testObj, "{AUTHOR}", CultureInfo.InvariantCulture, replacements);
+
+		// THEN the marks are dropped, so metadata cannot forge a directory level
+		Assert.AreEqual("ACDCLive", result);
+	}
+
+	[TestMethod]
+	public void ResolveSeparators_ReplacesEachMarkWithItsOwnText()
+	{
+		var marked = CommonFormatters.MarkSeparators(@"a\b/c");
+
+		Assert.AreEqual("a-b+c", CommonFormatters.ResolveSeparators(marked, "-", "+"));
+	}
+
+	[TestMethod]
+	public void MarkSeparators_LeavesOtherCharactersAlone()
+	{
+		Assert.AreEqual("a:b*c", CommonFormatters.MarkSeparators("a:b*c"));
+	}
+
+	[TestMethod]
 	public void StringFormatter_Uppercase()
 	{
 		// GIVEN

--- a/Source/_Tests/LibationFileManager.Tests/TemplatesTests.cs
+++ b/Source/_Tests/LibationFileManager.Tests/TemplatesTests.cs
@@ -1544,3 +1544,103 @@ namespace Templates_ChapterFile_Tests
 		}
 	}
 }
+
+namespace Templates_FormatStringSeparators
+{
+	/// <summary>
+	/// A directory separator written into a tag's format string asks for a directory level, exactly as
+	/// one written into the surrounding template text does. A separator arriving from the metadata is
+	/// still replaced.
+	/// </summary>
+	[TestClass]
+	public class FormatStringSeparators
+	{
+		private static readonly ReplacementCharacters Replacements = ReplacementCharacters.Default(Environment.OSVersion.Platform == PlatformID.Win32NT);
+		private static readonly string Sep = Path.DirectorySeparatorChar.ToString();
+		private static readonly string BaseDir = OperatingSystem.IsWindows() ? @"C:\base" : "/base";
+
+		private const string FormatTemplate = @"<first series[\{{N}\}\\]><title short>";
+		private const string LiteralTemplate = @"{<first series>}\<title short>";
+
+		private static readonly SeriesDto[] TwoSeries =
+			[new("Sherlock Holmes", "1", "B08376S3R2"), new("Book Collection", "1", "B000000000")];
+
+		private static string FolderPath(string template, IEnumerable<SeriesDto>? series = null)
+			=> RelativePath<Templates.FolderTemplate>(template, series);
+
+		private static string FileName(string template, IEnumerable<SeriesDto>? series = null)
+			=> RelativePath<Templates.FileTemplate>(template, series);
+
+		private static string RelativePath<T>(string template, IEnumerable<SeriesDto>? series)
+			where T : Templates, ITemplate, new()
+		{
+			var lbDto = GetLibraryBook(series ?? [new SeriesDto("Sherlock Holmes", "1", "B08376S3R2")]);
+
+			Templates.TryGetTemplate<T>(template, out var parsed).Should().BeTrue();
+
+			var path = parsed.GetFilename(lbDto, BaseDir, "", culture: null, replacements: Replacements).PathWithoutPrefix;
+			StringAssert.StartsWith(path, BaseDir + Sep);
+			return Path.GetRelativePath(BaseDir, path);
+		}
+
+		[TestMethod]
+		public void format_string_separator_creates_a_folder_level()
+			=> FolderPath(FormatTemplate).Should().Be($"{{Sherlock Holmes}}{Sep}A Study in Scarlet");
+
+		[TestMethod]
+		public void format_string_separator_matches_a_literal_one_in_a_folder()
+			=> FolderPath(FormatTemplate).Should().Be(FolderPath(LiteralTemplate));
+
+		[TestMethod]
+		public void list_separator_creates_one_folder_level_per_entry()
+			=> FolderPath(@"<series[format(\{{N}\})separator(\\)]>\<title short>", TwoSeries)
+			.Should().Be($"{{Sherlock Holmes}}{Sep}{{Book Collection}}{Sep}A Study in Scarlet");
+
+		[TestMethod]
+		public void a_missing_property_leaves_no_empty_folder_level()
+			=> FolderPath(FormatTemplate, series: []).Should().Be("A Study in Scarlet");
+
+		[TestMethod]
+		public void a_file_name_replaces_the_separator_instead_of_splitting()
+		{
+			var fileName = FileName(FormatTemplate);
+
+			fileName.Should().Be(FileName(LiteralTemplate));
+			fileName.Should().Be($"{{Sherlock Holmes}}{Replacements.ReplaceFilenameChars("\\")}A Study in Scarlet");
+			Assert.IsFalse(fileName.Contains(Sep), $"a file name must not gain a directory level: {fileName}");
+		}
+
+		[TestMethod]
+		public void a_separator_in_the_metadata_is_still_replaced()
+			=> FolderPath(FormatTemplate, [new SeriesDto("Sherlock/Holmes", "1", "id")])
+			.Should().Be($"{{Sherlock∕Holmes}}{Sep}A Study in Scarlet");
+
+		[TestMethod]
+		public void metadata_cannot_climb_out_of_the_base_directory()
+			=> FolderPath(FormatTemplate, [new SeriesDto("../../etc", "1", "id")])
+			.Should().Be($"{{..∕..∕etc}}{Sep}A Study in Scarlet");
+
+		[TestMethod]
+		public void metadata_cannot_root_the_path()
+			=> FolderPath(FormatTemplate, [new SeriesDto(@"C:\Windows", "1", "id")])
+			.Split(Sep).Should().HaveCount(2);
+
+		[TestMethod]
+		public void a_forged_separator_mark_in_the_metadata_is_dropped()
+			=> FolderPath(FormatTemplate, [new SeriesDto($"Sher{CommonFormatters.TemplateBackSlash}lock", "1", "id")])
+			.Should().Be($"{{Sherlock}}{Sep}A Study in Scarlet");
+
+		[TestMethod]
+		public void a_chapter_title_keeps_the_character_that_was_typed()
+		{
+			Templates.TryGetTemplate<Templates.ChapterTitleTemplate>(@"<first series[\{{N}\}\\]><ch title>", out var chapterTitle).Should().BeTrue();
+
+			var name = chapterTitle.GetName(GetLibraryBook(), new MultiConvertFileProperties { OutputFileName = "", PartsPosition = 1, PartsTotal = 1, Title = "chap" });
+
+			name.Should().Be(@"{Sherlock Holmes}\chap");
+			Assert.IsFalse(
+				name.Contains(CommonFormatters.TemplateBackSlash) || name.Contains(CommonFormatters.TemplateForwardSlash),
+				$"a separator mark must never reach the output: {name}");
+		}
+	}
+}

--- a/docs/features/naming-templates.md
+++ b/docs/features/naming-templates.md
@@ -310,6 +310,28 @@ Not all elements of a property are always present or have content. In this case,
 <!-- VitePress compiles each .md as a Vue SFC: a literal `{{` inside normal backtick `code` is treated as Vue interpolation and breaks the build. Elsewhere this doc uses backticks for inline examples; this line is HTML `code` with `v-pre` so `{{` can be written literally and still render like the other snippets, without additional hacks such as obscure invisible characters (like &#200B : 0-width space). -->
 <code v-pre>&lt;narrator[format({{F} }{({M}') '}{L})]&gt;</code> -> <code>Stephen Fry, Arthur (Conan) Doyle</code>
 
+### Directory Separators
+
+In the **Folder Template**, a directory separator starts another directory level. It works in the template text and inside a format template alike, so either of these gives you an author directory holding a title directory:
+
+`<first author>\<title short>`
+
+`<first author[{F} {L}\\]><title short>`
+
+Both `\` and `/` are accepted, on every platform. Inside a format template remember that `\` escapes the next character, so a separator has to be written `\\` there. That also lets a level appear only when the property has a value, which the surrounding template text cannot do on its own:
+
+<code v-pre>&lt;first series[\{{N}\}\\]&gt;&lt;title short&gt;</code> -> <code>{Sherlock Holmes}/A Study in Scarlet</code>
+
+A book with no series produces no empty directory level, just <code>A Study in Scarlet</code>.
+
+`separator()` behaves the same way, so a book can be filed under every one of its series at once:
+
+`<series[format({N}) separator(\\)]>\<title short>`
+
+A separator that arrives in the audiobook's own metadata is a different matter: it is not a request for a directory level, so it is replaced using your [replacement characters](/docs/advanced/command-line-interface#set-custom-replacement-characters) as any other character illegal in a file name would be. A series named `Faith/Void` therefore gives you one directory, not two.
+
+In the **File Template** and **Chapter File Template** there is no level to create, so a separator is replaced no matter where it came from.
+
 ### Checks
 
 There are two formats for checks, with slightly different syntax for specifying parameters:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Addresses [#1764](https://github.com/rmcrackan/Libation/issues/1764).

## Problem

A directory separator typed into a folder template asks for a directory level. One that arrives inside a book property is just a character that cannot go in a file name. `FolderTemplate.GetTemplatePartsStrings` told the two apart using the only provenance that survives evaluation, `TemplatePart.TemplateTag is null`:

```csharp
.Select(tp => tp.TemplateTag is null
    //FolderTemplate literals can have directory separator characters
    ? replacements.ReplacePathChars(tp.Value.Replace(Path.AltDirectorySeparatorChar, Path.DirectorySeparatorChar))
    : replacements.ReplaceFilenameChars(tp.Value)
)
```

A format string is consumed inside the tag, so `<first series[\{{N}\}\\]>` returned the resolved series name and the user's `\` fused into a single `TemplatePart.Value` carrying a non-null `TemplateTag`. The whole thing took the `ReplaceFilenameChars` branch and the separator was replaced along with the metadata. On the Windows default preset the backslash maps to an empty string, so it disappeared without a trace. Meanwhile the same character in `<has first series->{<first series>}\<-has>` is parsed as a literal part and survives, which is the asymmetry reported in the issue.

## Approach

`TemplatePart.Value` cannot become a list of runs: `SeriesDto`, `ContributorDto`, `LocaleDto`, `CultureInfoDto` and `StringDto` all reach `CommonFormatters.TemplateStringFormatter` through `IFormattable.ToString(format, provider)`, whose return type is locked to `string`. The run boundaries therefore travel in-band as a private use character.

- Separators in text taken verbatim from a format string are marked (`MarkSeparators`). `ReplaceWithGaps` already separates the `{tag}` matches from the surrounding text, so the split points existed.
- Separators in a resolved property value are left alone, and any marks the value carries are dropped (`RemoveSeparatorMarks`) so metadata cannot forge a directory level.
- The marks are resolved once the values have been through `ReplacementCharacters`, at the existing sanitize step: to a directory separator for the folder template, to the configured slash replacement for file names, and back to the character the user typed for metadata templates.

Marks pass through `ReplaceFilenameChars` untouched, since `\uE000` is absent from `Path.GetInvalidFileNameChars()` on both platforms and matches no entry in `Replacements`.

`separator()` on a list tag gets the same treatment, so a book can be filed under each of its series at once.

The folder template now also accepts `\` as a separator on Linux. The existing `Replace(Path.AltDirectorySeparatorChar, Path.DirectorySeparatorChar)` is a no-op there because both characters are `/`, which meant `<a>\<b>` produced one directory on Windows and a literal backslash in a file name on Linux. Without this, the same template would behave differently depending on whether the separator came from template text or from a format string.

## What is not covered

.NET number and date format strings are processed by .NET itself, so a separator escaped inside one (for example `<series#[00\\]>`) is still replaced. This is noted in the docs.

## Verification

Ten cases in `TemplatesTests` and five in `CommonFormattersTests`. Five of the new cases fail without the marking; `remove_slashes` and `Test_trim_to_max_path` are untouched and still pass, which is what pins the metadata behaviour. Full suite from `Source/`: 1638 tests, 0 failures. `Source/Libation.slnx` builds with 0 errors, and `LibationWinForms` and `HangoverWinForms` were compile-checked (they have no Linux runtime, so their behaviour is unverified here, though neither was modified).

Every example added to the docs was run against the template engine rather than written from reading the code.

The Edit Folder Template dialog previews this live. A directory level from plain template text, then the same level from inside a format string, then one level per series via `separator()`:

[folder_template_levels_from_format_strings.mp4](https://cursor.com/agents/bc-6ebc29a2-d19d-42f2-8eb6-35aa7a43124a/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Ffolder_template_levels_from_format_strings.mp4)

The reporter's own template, `<first series[\{{N}\}\\]><title short>`, producing a `{Sherlock Holmes}` directory holding an `A Study in Scarlet` directory:

[Edit Folder Template preview showing a {Sherlock Holmes} directory containing an A Study in Scarlet directory](https://cursor.com/agents/bc-6ebc29a2-d19d-42f2-8eb6-35aa7a43124a/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Ffolder_template_level_from_format_string.png)

`<series[format({N}) separator(\\)]>\<title short>` nesting one directory per series:

[Edit Folder Template preview showing Sherlock Holmes, Book Collection and A Study in Scarlet as nested directories](https://cursor.com/agents/bc-6ebc29a2-d19d-42f2-8eb6-35aa7a43124a/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Ffolder_template_one_level_per_series.png)

## Note on the other thread in the issue

The `01-06 - A Study in Scarlet` sub-thread is unrelated to separators and is not a bug. Audible reports a collection's order as the string `1-6`; `SeriesOrder.Parse` splits it into `[1, "-", 6]` and `SeriesOrder.ToString` formats each numeric part independently, so `[00]` yields `01-06`. `SeriesOrder_formatters` already pins this. Selecting only the first number would need a new format option and would be better tracked separately.


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6ebc29a2-d19d-42f2-8eb6-35aa7a43124a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6ebc29a2-d19d-42f2-8eb6-35aa7a43124a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

