### PR TITLE
Survive an install folder that cannot load Serilog (#2001)

### DIFF
--- a/Source/AppScaffolding/LibationScaffolding.cs
+++ b/Source/AppScaffolding/LibationScaffolding.cs
@@ -208,12 +208,34 @@ public static class LibationScaffolding
 	private static void ensureSerilogConfig(Configuration config)
 		=> config.EnsureSerilogConfig();
 
+	/// <summary>
+	/// Hands everything <see cref="StartupLog"/> collected before this point to Serilog, and points it at
+	/// Serilog from here on. Startup runs long before logging exists, so without this those diagnostics are
+	/// simply dropped. This is also the only place in Libation that maps a startup entry onto a Serilog level.
+	/// </summary>
+	private static void replayStartupLog()
+		=> StartupLog.ReplayTo(entry =>
+		{
+			var level = entry.Level switch
+			{
+				StartupLogLevel.Debug => Serilog.Events.LogEventLevel.Debug,
+				StartupLogLevel.Warning => Serilog.Events.LogEventLevel.Warning,
+				StartupLogLevel.Error => Serilog.Events.LogEventLevel.Error,
+				_ => Serilog.Events.LogEventLevel.Information,
+			};
+
+			// The message is already rendered: startup cannot build a Serilog template without
+			// referencing Serilog, which is the whole point of StartupLog. See issue #2001.
+			Log.Logger.Write(level, entry.Exception, "[startup {StartupTimestamp:HH:mm:ss.fff}] {StartupMessage}", entry.Timestamp, entry.Message);
+		});
+
 	// to restore original: Console.SetOut(origOut);
 	private static TextWriter origOut { get; } = Console.Out;
 
 	private static void configureLogging(Configuration config)
 	{
 		config.ConfigureLogging();
+		replayStartupLog();
 		Log.Information(
 			"Paths: LibationFiles={LibationFiles} AppsettingsJson={AppsettingsJson} SQLiteDb={SqliteDb}",
 			config.LibationFiles.Location,

--- a/Source/LibationAvalonia/App.axaml.cs
+++ b/Source/LibationAvalonia/App.axaml.cs
@@ -34,7 +34,10 @@ public class App : Application
 	/// Set by <see cref="Program"/> when startup rolled back an incomplete in-app upgrade. The restored
 	/// files on disk no longer match the assemblies this process loaded, so it shows this and quits.
 	/// </summary>
-	public static FatalStartupMessage? StartupRecoveryMessage { get; set; }
+	public static StartupRecoveryNotice? StartupRecoveryNotice { get; set; }
+
+	/// <summary>Set when the user accepted the offer to start Libation again. Read by <see cref="Program"/> after shutdown.</summary>
+	public static bool RestartRequested { get; private set; }
 	public static ChardonnayTheme? DefaultThemeColors { get; private set; }
 	public static MainWindow? MainWindow { get; private set; }
 	public static Uri AssetUriBase { get; } = new("avares://Libation/Assets/");
@@ -57,9 +60,9 @@ public class App : Application
 				MessageBox.Show(owner as Window, message, caption, buttons, icon, defaultButton, saveAndRestorePosition);
 
 			// The install folder was just rolled back underneath us. See issue #2001.
-			if (StartupRecoveryMessage is { } recovery)
+			if (StartupRecoveryNotice is { } recovery)
 			{
-				_ = ShowThenShutdownAsync(desktop, recovery.Body, recovery.Title);
+				_ = ShowRecoveryThenShutdownAsync(desktop, recovery);
 				base.OnFrameworkInitializationCompleted();
 				return;
 			}
@@ -94,6 +97,40 @@ public class App : Application
 		}
 
 		base.OnFrameworkInitializationCompleted();
+	}
+
+	/// <summary>
+	/// Reports the rollback and shuts down. When the restored install is worth going back into, the user is
+	/// asked whether to start Libation again, and <see cref="Program"/> does it after this shuts down.
+	/// </summary>
+	private static async Task ShowRecoveryThenShutdownAsync(IClassicDesktopStyleApplicationLifetime desktop, StartupRecoveryNotice recovery)
+	{
+		if (!recovery.OfferRestart)
+		{
+			await ShowThenShutdownAsync(desktop, recovery.Body, recovery.Title);
+			return;
+		}
+
+		try
+		{
+			var answer = await MessageBox.Show(
+				recovery.Body,
+				recovery.Title,
+				MessageBoxButtons.YesNo,
+				MessageBoxIcon.Warning,
+				MessageBoxDefaultButton.Button1);
+
+			RestartRequested = answer is DialogResult.Yes;
+		}
+		catch (Exception ex)
+		{
+			// Serilog is unavailable on this path, and shutting down matters more than the question.
+			StartupLog.Error(ex, "Failed to ask whether to restart after the rollback");
+		}
+		finally
+		{
+			desktop.Shutdown();
+		}
 	}
 
 	/// <summary>

--- a/Source/LibationAvalonia/App.axaml.cs
+++ b/Source/LibationAvalonia/App.axaml.cs
@@ -29,6 +29,12 @@ public class App : Application
 
 	/// <summary>Set by <see cref="Program"/> when another Libation instance already holds this folder's lock.</summary>
 	public static bool IsAnotherInstanceRunning { get; set; }
+
+	/// <summary>
+	/// Set by <see cref="Program"/> when startup rolled back an incomplete in-app upgrade. The restored
+	/// files on disk no longer match the assemblies this process loaded, so it shows this and quits.
+	/// </summary>
+	public static FatalStartupMessage? StartupRecoveryMessage { get; set; }
 	public static ChardonnayTheme? DefaultThemeColors { get; private set; }
 	public static MainWindow? MainWindow { get; private set; }
 	public static Uri AssetUriBase { get; } = new("avares://Libation/Assets/");
@@ -50,17 +56,27 @@ public class App : Application
 			MessageBoxBase.ShowAsyncImpl = (owner, message, caption, buttons, icon, defaultButton, saveAndRestorePosition) =>
 				MessageBox.Show(owner as Window, message, caption, buttons, icon, defaultButton, saveAndRestorePosition);
 
-			// Another instance already owns this folder. No database work has been done in this process,
-			// so just tell the user and shut down instead of racing on shared files. See issue #1931.
-			if (IsAnotherInstanceRunning)
+			// The install folder was just rolled back underneath us. See issue #2001.
+			if (StartupRecoveryMessage is { } recovery)
 			{
-				_ = ShowAlreadyRunningThenShutdownAsync(desktop);
+				_ = ShowThenShutdownAsync(desktop, recovery.Body, recovery.Title);
 				base.OnFrameworkInitializationCompleted();
 				return;
 			}
 
-			if (InstallUpgradeManager.TakeStartupRecoveryAlert() is { } recovery)
-				_ = MessageBox.Show(null, recovery.Body, recovery.Title, MessageBoxButtons.OK, MessageBoxIcon.Warning);
+			// Another instance already owns this folder. No database work has been done in this process,
+			// so just tell the user and shut down instead of racing on shared files. See issue #1931.
+			if (IsAnotherInstanceRunning)
+			{
+				_ = ShowThenShutdownAsync(
+					desktop,
+					"Libation is already running.\r\n\r\n"
+						+ "Please use the Libation window that is already open. Running more than one copy of "
+						+ "Libation against the same folder at the same time can corrupt your library.",
+					"Libation is already running");
+				base.OnFrameworkInitializationCompleted();
+				return;
+			}
 
 			BadBookActionDialogBase.ShowAsyncImpl = (owner, message, caption) =>
 				Dialogs.BadBookActionDialog.ShowAsync(owner as Window, message, caption);
@@ -80,21 +96,20 @@ public class App : Application
 		base.OnFrameworkInitializationCompleted();
 	}
 
-	private static async Task ShowAlreadyRunningThenShutdownAsync(IClassicDesktopStyleApplicationLifetime desktop)
+	/// <summary>
+	/// Shows one modal and then shuts the app down without opening the main window, for the cases where
+	/// Libation has decided at startup that it must not keep running.
+	/// </summary>
+	private static async Task ShowThenShutdownAsync(IClassicDesktopStyleApplicationLifetime desktop, string body, string title)
 	{
 		try
 		{
-			await MessageBox.Show(
-				"Libation is already running.\r\n\r\n"
-					+ "Please use the Libation window that is already open. Running more than one copy of "
-					+ "Libation against the same folder at the same time can corrupt your library.",
-				"Libation is already running",
-				MessageBoxButtons.OK,
-				MessageBoxIcon.Warning);
+			await MessageBox.Show(body, title, MessageBoxButtons.OK, MessageBoxIcon.Warning);
 		}
 		catch (Exception ex)
 		{
-			Serilog.Log.Logger.Error(ex, "Failed to show the 'already running' message");
+			// Serilog is unavailable on the rollback path, and shutting down matters more than the message.
+			StartupLog.Error(ex, $"Failed to show the startup message '{title}'");
 		}
 		finally
 		{

--- a/Source/LibationAvalonia/Dialogs/MessageBoxAlertAdminDialog.axaml
+++ b/Source/LibationAvalonia/Dialogs/MessageBoxAlertAdminDialog.axaml
@@ -4,8 +4,8 @@
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
         mc:Ignorable="d" d:DesignWidth="600" d:DesignHeight="450"
 		MinWidth="600" MinHeight="450"
-		MaxWidth="600" MaxHeight="450"
-		Width="600" Height="450"
+		MaxWidth="600" MaxHeight="620"
+		Width="600" Height="560"
         x:Class="LibationAvalonia.Dialogs.MessageBoxAlertAdminDialog"
 		xmlns:controls="clr-namespace:LibationAvalonia.Controls"
 		xmlns:dialogs="clr-namespace:LibationAvalonia.Dialogs"
@@ -20,12 +20,22 @@
 			Margin="10,10,10,0"
 			ColumnDefinitions="Auto,*">
 			
-			<Image Grid.Column="0" Width="64" Height="64" Source="/Assets/MBIcons/Error_64.png" />
-			<TextBlock
+			<Image Grid.Column="0" Width="64" Height="64" VerticalAlignment="Top" Source="/Assets/MBIcons/Error_64.png" />
+
+			<!--
+			Scrolled and capped: a startup failure that names the file, its version and the recovery steps
+			runs far longer than the two lines this dialog was built for, and without a bound on the
+			description the rows below it were pushed out of the window. See issue #2001.
+			-->
+			<ScrollViewer
 				Grid.Column="1"
-				Margin="10"
-				TextWrapping="Wrap"
-				Text="{Binding ErrorDescription}" />
+				MaxHeight="260"
+				VerticalScrollBarVisibility="Auto">
+				<TextBlock
+					Margin="10"
+					TextWrapping="Wrap"
+					Text="{Binding ErrorDescription}" />
+			</ScrollViewer>
 		</Grid>
 
 		<TextBox

--- a/Source/LibationAvalonia/FormSaveExtension.cs
+++ b/Source/LibationAvalonia/FormSaveExtension.cs
@@ -70,7 +70,9 @@ public static class FormSaveExtension
 		}
 		catch (Exception ex)
 		{
-			Serilog.Log.Logger.Error(ex, "Failed to save {form} size and location", form.GetType().Name);
+			// The crash dialog restores its own position, so this runs while the install may be broken.
+			// Logging through Serilog here took the dialog down with it. See issue #2001.
+			StartupLog.Error(ex, $"Failed to restore {form.GetType().Name} size and location");
 		}
 	}
 	public static void SaveSizeAndLocation(this Window form, Configuration config)
@@ -99,7 +101,7 @@ public static class FormSaveExtension
 		}
 		catch (Exception ex)
 		{
-			Serilog.Log.Logger.Error(ex, "Failed to save {form} size and location", form.GetType().Name);
+			StartupLog.Error(ex, $"Failed to save {form.GetType().Name} size and location");
 		}
 	}
 

--- a/Source/LibationAvalonia/Program.cs
+++ b/Source/LibationAvalonia/Program.cs
@@ -3,14 +3,12 @@ using AppScaffolding;
 using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Threading;
-using FileManager;
 using LibationAvalonia.Dialogs;
 using LibationFileManager;
 using LibationUiBase.Forms;
 using ReactiveUI.Avalonia;
 using System;
 using System.Diagnostics;
-using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
 
@@ -56,20 +54,28 @@ static class Program
 		try
 		{
 			var config = LibationScaffolding.RunPreConfigMigrations();
-			StartupAssemblyBootstrap.RecoverFromIncompleteUpgradeIfNeeded();
 
-			// Prevent a second instance from racing on the same database, search index, and log file.
-			// Hold the lock for the whole process; skip all database access when we are not the first
-			// instance so the running copy's state is never touched. See issue #1931.
-			SingleInstanceLock = SingleInstance.TryAcquire(config.LibationFiles.Location);
-			App.IsAnotherInstanceRunning = !SingleInstanceLock.IsFirstInstance;
+			// A rollback swaps install files out from under assemblies this process has already loaded, so
+			// it must not go on to touch the database or open a window. App shows the message and shuts
+			// down instead. See issue #2001.
+			App.StartupRecoveryMessage = StartupAssemblyBootstrap.RecoverFromIncompleteUpgradeIfNeeded();
 
-			if (SingleInstanceLock.IsFirstInstance && config.LibationFiles.SettingsAreValid)
+			if (App.StartupRecoveryMessage is null)
 			{
-				App.RunMigrations(config);
-				StartupAssemblyBootstrap.PrepareForBackgroundDataAccess();
-				App.LibraryTask = Task.Run(() => DbContexts.GetLibrary_Flat_NoTracking(includeParents: true));
+				// Prevent a second instance from racing on the same database, search index, and log file.
+				// Hold the lock for the whole process; skip all database access when we are not the first
+				// instance so the running copy's state is never touched. See issue #1931.
+				SingleInstanceLock = SingleInstance.TryAcquire(config.LibationFiles.Location);
+				App.IsAnotherInstanceRunning = !SingleInstanceLock.IsFirstInstance;
+
+				if (SingleInstanceLock.IsFirstInstance && config.LibationFiles.SettingsAreValid)
+				{
+					App.RunMigrations(config);
+					StartupAssemblyBootstrap.PrepareForBackgroundDataAccess();
+					App.LibraryTask = Task.Run(() => DbContexts.GetLibrary_Flat_NoTracking(includeParents: true));
+				}
 			}
+
 			BuildAvaloniaApp()?.StartWithClassicDesktopLifetime([], ShutdownMode.OnExplicitShutdown);
 		}
 		catch (Exception ex)
@@ -112,13 +118,14 @@ static class Program
 
 	private static void LogAndShowCrashMessage(Exception exception)
 	{
+		string? crashLogFile = null;
 		try
 		{
 			//Try to log the error message before displaying the crash dialog
 			if (Configuration.Instance.SerilogInitialized)
 				Serilog.Log.Logger.Error(exception, "CRASH");
 			else
-				LogErrorWithoutSerilog(exception);
+				crashLogFile = PreLoggingCrashLog.TryWrite(exception, [("ReleaseIdentifier", LibationScaffolding.ReleaseIdentifier.ToString())]);
 		}
 		catch { /* continue to show the crash dialog even if logging fails */ }
 
@@ -127,7 +134,7 @@ static class Program
 
 		try
 		{
-			Dispatcher.UIThread.Invoke(() => DisplayErrorMessage(exception));
+			Dispatcher.UIThread.Invoke(() => DisplayErrorMessage(exception, crashLogFile));
 		}
 		catch (Exception ex)
 		{
@@ -135,7 +142,7 @@ static class Program
 		}
 	}
 
-	private static void DisplayErrorMessage(Exception exception)
+	private static void DisplayErrorMessage(Exception exception, string? crashLogFile)
 	{
 		var dispatcher = new DispatcherFrame();
 
@@ -143,10 +150,10 @@ static class Program
 			exception,
 			new FatalStartupMessage(
 				"Libation Crash",
-				"""
+				$"""
 				Libation encountered a fatal error and must close.
 
-				Please consider reporting this issue on GitHub, including the contents of the LibationCrash.log file created in your user folder.
+				{DescribeCrashLog(crashLogFile)}
 				"""));
 
 		var mbAlert = new MessageBoxAlertAdminDialog(fatalMessage.Body, fatalMessage.Title, exception);
@@ -155,68 +162,17 @@ static class Program
 		Dispatcher.UIThread.PushFrame(dispatcher);
 	}
 
-	private static void LogErrorWithoutSerilog(object exceptionObject)
-	{
-		var logError = $"""
-		{DateTime.Now} - Libation Crash
-		 OS                    {Configuration.OS}
-		 Version               {LibationScaffolding.BuildVersion}
-		 ReleaseIdentifier     {LibationScaffolding.ReleaseIdentifier}
-		 InteropFunctionsType  {InteropFactory.InteropFunctionsType}
-		 LibationFiles         {getConfigValue(c => c.LibationFiles.Location)}
-		 Books Folder          {getConfigValue(c => c.Books)}
-		 === EXCEPTION ===
-		 {exceptionObject}
-		""";
+	/// <summary>
+	/// Names the file the crash was actually written to. This used to name LibationCrash.log
+	/// unconditionally, which is not where the record goes when a Log*.log already exists, so reporters
+	/// went looking for a file that was not there and attached nothing. See issue #2001.
+	/// </summary>
+	private static string DescribeCrashLog(string? crashLogFile)
+		=> crashLogFile is null
+		? "Please consider reporting this issue on GitHub. Libation could not write this error to a log file, so please include the text below."
+		: $"""
+			Please consider reporting this issue on GitHub, including the contents of this file:
+			{crashLogFile}
+			""";
 
-		LongPath logFile;
-		try
-		{
-			//Try to add crash message to the newest existing Libation log file
-			//then to LibationFiles/LibationCrash.log
-			//then to %UserProfile%/LibationCrash.log
-			string logDir = Configuration.Instance.LibationFiles.Location;
-			var existingLogFiles = Directory.GetFiles(logDir, "Log*.log");
-
-			logFile = existingLogFiles.Length == 0 ? getFallbackLogFile()
-				: existingLogFiles.Select(f => new FileInfo(f)).OrderByDescending(f => f.CreationTimeUtc).First().FullName;
-		}
-		catch
-		{
-			logFile = getFallbackLogFile();
-		}
-
-
-		using var sw = new StreamWriter(logFile, true);
-		sw.WriteLine(logError);
-
-		static string getConfigValue(Func<Configuration, string?> selector)
-		{
-			try
-			{
-				return selector(Configuration.Instance) ?? "[null]";
-			}
-			catch (Exception ex)
-			{
-				return ex.ToString();
-			}
-		}
-
-		static string getFallbackLogFile()
-		{
-			try
-			{
-
-				string logDir = Configuration.Instance.LibationFiles.Location;
-				if (!Directory.Exists(logDir))
-					logDir = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
-
-				return Path.Combine(logDir, "LibationCrash.log");
-			}
-			catch
-			{
-				return Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), "LibationCrash.log");
-			}
-		}
-	}
 }

--- a/Source/LibationAvalonia/Program.cs
+++ b/Source/LibationAvalonia/Program.cs
@@ -56,11 +56,11 @@ static class Program
 			var config = LibationScaffolding.RunPreConfigMigrations();
 
 			// A rollback swaps install files out from under assemblies this process has already loaded, so
-			// it must not go on to touch the database or open a window. App shows the message and shuts
-			// down instead. See issue #2001.
-			App.StartupRecoveryMessage = StartupAssemblyBootstrap.RecoverFromIncompleteUpgradeIfNeeded();
+			// it must not go on to touch the database or open a window. App reports it and shuts down
+			// instead. See issue #2001.
+			App.StartupRecoveryNotice = StartupAssemblyBootstrap.RecoverFromIncompleteUpgradeIfNeeded();
 
-			if (App.StartupRecoveryMessage is null)
+			if (App.StartupRecoveryNotice is null)
 			{
 				// Prevent a second instance from racing on the same database, search index, and log file.
 				// Hold the lock for the whole process; skip all database access when we are not the first
@@ -77,6 +77,11 @@ static class Program
 			}
 
 			BuildAvaloniaApp()?.StartWithClassicDesktopLifetime([], ShutdownMode.OnExplicitShutdown);
+
+			// After the lifetime ends, so the new process starts into a folder this one has finished with
+			// and does not race it for the single-instance lock.
+			if (App.RestartRequested)
+				InstallRelauncher.TryRelaunch();
 		}
 		catch (Exception ex)
 		{

--- a/Source/LibationFileManager/CloudSyncedFolders.cs
+++ b/Source/LibationFileManager/CloudSyncedFolders.cs
@@ -52,7 +52,8 @@ public static class CloudSyncedFolders
 		catch (Exception ex)
 		{
 			// cldapi.dll is absent before Windows 10 1709, where there are no sync roots to find.
-			Serilog.Log.Logger.Debug(ex, "Could not read cloud sync root information for {Path}", path);
+			// Reached while building a crash message, so it must not need Serilog. See issue #2001.
+			StartupLog.Debug(ex, $"Could not read cloud sync root information for {path}");
 			return CloudSyncStatus.NotSynced;
 		}
 	}

--- a/Source/LibationFileManager/EssentialFileValidator.cs
+++ b/Source/LibationFileManager/EssentialFileValidator.cs
@@ -67,7 +67,8 @@ public static class EssentialFileValidator
 					// ensure we can open for read and write
 				}
 
-				Log.Logger.Debug("Essential file validated: {DisplayName} at \"{Path}\"", displayName, path);
+				// A Serilog failure here would be caught below and retried as if the file itself were bad.
+				StartupLog.Debug($"Essential file validated: {displayName} at \"{path}\"");
 				return (true, null);
 			}
 			catch (Exception ex)

--- a/Source/LibationFileManager/InstallAssemblyFailure.cs
+++ b/Source/LibationFileManager/InstallAssemblyFailure.cs
@@ -1,0 +1,16 @@
+using System;
+
+namespace LibationFileManager;
+
+/// <summary>
+/// An assembly the runtime could not bind to a usable file in Libation's install folder, with the version
+/// the build was compiled against and the version actually on disk (null when the file is not there).
+/// </summary>
+public sealed record InstallAssemblyFailure(
+	string AssemblyName,
+	Version RequestedVersion,
+	Version? InstalledVersion,
+	string ExpectedPath)
+{
+	public string FileName => System.IO.Path.GetFileName(ExpectedPath);
+}

--- a/Source/LibationFileManager/InstallRelauncher.cs
+++ b/Source/LibationFileManager/InstallRelauncher.cs
@@ -1,0 +1,78 @@
+using System;
+using System.Diagnostics;
+using System.IO;
+
+namespace LibationFileManager;
+
+/// <summary>
+/// Starts a fresh copy of Libation after startup has repaired the install folder underneath the running one.
+/// <para/>
+/// The running process cannot simply carry on: it has already loaded the assemblies that the rollback just
+/// replaced on disk. Restarting is the only way to pick up the restored files, so the user is asked whether
+/// to do it now.
+/// </summary>
+public static class InstallRelauncher
+{
+	/// <summary>
+	/// Set on the child process so it knows not to offer a restart of its own.
+	/// <para/>
+	/// A rollback deletes the pending upgrade marker before it returns, so it normally cannot happen twice.
+	/// But that delete is best-effort and swallows its own failure, and a marker that outlives a rollback
+	/// would otherwise mean every launch rolls back and offers to restart again. One relaunch, then.
+	/// </summary>
+	public const string RelaunchedEnvironmentVariable = "LIBATION_RELAUNCHED_AFTER_ROLLBACK";
+
+	/// <summary>True when this process was started by <see cref="TryRelaunch"/>.</summary>
+	public static bool WasRelaunched
+		=> Environment.GetEnvironmentVariable(RelaunchedEnvironmentVariable) == "1";
+
+	/// <summary>
+	/// Overridable so tests can assert on the decision to relaunch without starting a process.
+	/// </summary>
+	public static Func<string, bool> StartProcess { get; set; } = StartDetached;
+
+	/// <summary>
+	/// Starts a new Libation process. Best effort: if it does not work the user can start Libation
+	/// themselves, which is what the message tells them to do anyway.
+	/// </summary>
+	/// <returns>True when a new process was started.</returns>
+	public static bool TryRelaunch()
+	{
+		try
+		{
+			var executable = Environment.ProcessPath;
+			if (string.IsNullOrWhiteSpace(executable) || !File.Exists(executable))
+			{
+				StartupLog.Error($"Cannot restart Libation: no executable at '{executable}'");
+				return false;
+			}
+
+			var started = StartProcess(executable);
+			StartupLog.Information(started
+				? $"Restarting Libation from {executable}"
+				: $"Could not restart Libation from {executable}");
+
+			return started;
+		}
+		catch (Exception ex)
+		{
+			StartupLog.Error(ex, "Could not restart Libation");
+			return false;
+		}
+	}
+
+	private static bool StartDetached(string executable)
+	{
+		// UseShellExecute must stay false: setting an environment variable for the child is not allowed
+		// with the shell, and the marker is what stops a restart loop.
+		var startInfo = new ProcessStartInfo(executable)
+		{
+			// The install folder was just rewritten, so start from it rather than inheriting a stale one.
+			WorkingDirectory = Configuration.ProcessDirectory,
+			UseShellExecute = false,
+		};
+		startInfo.Environment[RelaunchedEnvironmentVariable] = "1";
+
+		return Process.Start(startInfo) is not null;
+	}
+}

--- a/Source/LibationFileManager/InstallUpgradeManager.cs
+++ b/Source/LibationFileManager/InstallUpgradeManager.cs
@@ -13,13 +13,55 @@ namespace LibationFileManager;
 public readonly record struct UpgradeVerificationResult(
 	bool Success,
 	IReadOnlyList<string> FailedFiles,
-	string Summary);
+	string Summary)
+{
+	/// <summary>
+	/// Manifest files whose on-disk content did match the upgrade package. Any of these means the overlay
+	/// got at least partway through, so files outside the manifest were probably replaced too, and putting
+	/// the backed-up files back cannot return the install to a single version.
+	/// </summary>
+	public IReadOnlyList<string> MatchedFiles { get; init; } = [];
+}
+
+/// <summary>
+/// How much of the install a rollback managed to put back, which decides how firmly Libation should push
+/// the user towards a clean reinstall and whether restarting is worth offering at all.
+/// </summary>
+public enum RollbackConfidence
+{
+	/// <summary>Nothing to report: no rollback happened.</summary>
+	NotRolledBack,
+
+	/// <summary>
+	/// Every backed-up file is back, and no manifest file matched the upgrade package, so the overlay had
+	/// not begun replacing files. The install is the version that was working before.
+	/// </summary>
+	RestoredToPreviousVersion,
+
+	/// <summary>
+	/// Every backed-up file is back, but the overlay had already replaced some, so files outside the
+	/// backup set are probably still from the new version. Libation should run, but the install is mixed.
+	/// </summary>
+	RestoredButInstallIsMixed,
+
+	/// <summary>At least one file could not be put back. Nothing about this install can be trusted.</summary>
+	RestoreIncomplete,
+}
 
 public sealed record UpgradeRecoveryResult(
 	bool RolledBack,
 	string Title,
 	string Message,
-	IReadOnlyList<string> FailedFiles);
+	IReadOnlyList<string> FailedFiles)
+{
+	public RollbackConfidence Confidence { get; init; } = RollbackConfidence.NotRolledBack;
+
+	/// <summary>
+	/// Whether restarting into this install is worth offering. False when the restore left files behind,
+	/// where inviting the user back in would be inviting them into a broken install.
+	/// </summary>
+	public bool WorthRestarting => RolledBack && Confidence is not RollbackConfidence.RestoreIncomplete;
+}
 
 /// <summary>
 /// Backups, verifies, and rolls back flat zip overlay upgrades (Windows ZipExtractor flow).
@@ -174,7 +216,13 @@ public static class InstallUpgradeManager
 		StartupLog.Error(
 			$"Incomplete in-app upgrade detected at startup. Target version {pending.TargetVersion}. {verification.Summary}");
 
-		return RollbackAndReport(installDirectory, pendingPath, pending, verification.FailedFiles, verification.Summary);
+		return RollbackAndReport(
+			installDirectory,
+			pendingPath,
+			pending,
+			verification.FailedFiles,
+			verification.Summary,
+			verification.MatchedFiles);
 	}
 
 	public static UpgradeVerificationResult VerifyInstallMatchesUpgrade(
@@ -188,6 +236,7 @@ public static class InstallUpgradeManager
 			return new UpgradeVerificationResult(true, [], "No pending upgrade verification manifest.");
 
 		var failedFiles = new List<string>();
+		var matchedFiles = new List<string>();
 		foreach (var (fileName, expectedHash) in expectedFileHashesSha256)
 		{
 			var installPath = Path.Combine(installDirectory, fileName);
@@ -198,7 +247,9 @@ public static class InstallUpgradeManager
 			}
 
 			var actualHash = ComputeSha256Hex(installPath);
-			if (!string.Equals(actualHash, expectedHash, StringComparison.OrdinalIgnoreCase))
+			if (string.Equals(actualHash, expectedHash, StringComparison.OrdinalIgnoreCase))
+				matchedFiles.Add(fileName);
+			else
 				failedFiles.Add($"{fileName}: on-disk content does not match upgrade package (file was not replaced)");
 		}
 
@@ -207,13 +258,13 @@ public static class InstallUpgradeManager
 			failedFiles.Add(typeCheckFailure);
 
 		if (failedFiles.Count == 0)
-			return new UpgradeVerificationResult(true, failedFiles, "Install folder matches upgrade package.");
+			return new UpgradeVerificationResult(true, failedFiles, "Install folder matches upgrade package.") { MatchedFiles = matchedFiles };
 
 		var summary =
 			$"Upgrade integrity check failed for {failedFiles.Count} item(s):{Environment.NewLine}"
 			+ string.Join(Environment.NewLine, failedFiles.Select(f => $"  - {f}"));
 
-		return new UpgradeVerificationResult(false, failedFiles, summary);
+		return new UpgradeVerificationResult(false, failedFiles, summary) { MatchedFiles = matchedFiles };
 	}
 
 	public static void RollbackAfterFailedUpgrade(string installDirectory, string reason)
@@ -286,12 +337,15 @@ public static class InstallUpgradeManager
 		string pendingPath,
 		PendingUpgradeState? pending,
 		IReadOnlyList<string> failedFiles,
-		string summary)
+		string summary,
+		IReadOnlyList<string>? filesTheOverlayHadReplaced = null)
 	{
-		var restoredFiles = RestoreFromBackup(installDirectory);
+		var restore = RestoreFromBackup(installDirectory);
+		var confidence = GradeRollback(restore, filesTheOverlayHadReplaced);
 
 		StartupLog.Error(
-			$"In-app upgrade failed. Rolled back {restoredFiles.Count} file(s) in {installDirectory}. {summary}");
+			$"In-app upgrade failed. Rolled back {restore.RestoredFiles.Count} file(s) in {installDirectory}, "
+			+ $"{restore.UnrestoredFiles.Count} could not be restored. Outcome: {confidence}. {summary}");
 
 		try
 		{
@@ -304,54 +358,147 @@ public static class InstallUpgradeManager
 		}
 
 		var targetVersion = pending?.TargetVersion ?? "unknown";
-		var title = "In-app upgrade failed -- Libation was restored";
+		var title = confidence is RollbackConfidence.RestoreIncomplete
+			? "In-app upgrade failed -- this install needs replacing"
+			: "In-app upgrade failed -- Libation was restored";
+
 		var message = $"""
 			Libation attempted an in-app upgrade to version {targetVersion}, but one or more install files were not updated correctly.
 
-			Libation restored your previous install files from backup.
+			{DescribeRollbackOutcome(confidence)}
 
 			Details:
 			{summary}
-
+			{DescribeUnrestoredFiles(restore.UnrestoredFiles)}
 			Install folder:
 			{installDirectory}
 
 			Your library database, accounts, and settings are stored separately and were not changed.
 
-			To upgrade safely:
-			1. Quit Libation completely.
-			2. Download the latest release zip from GitHub.
-			3. Extract it to a new folder (do not copy files on top of this install folder).
-			4. Run Libation from the new folder.
+			{DescribeRecoveryAdvice(confidence)}
 
 			More help:
 			{StartupAssemblyBootstrap.TroubleshootIncompleteUpgradeUrl}
 			""";
 
 		s_StartupRecoveryAlert = new FatalStartupMessage(title, message);
-		return new UpgradeRecoveryResult(true, title, message, failedFiles);
+		return new UpgradeRecoveryResult(true, title, message, failedFiles) { Confidence = confidence };
 	}
 
-	private static List<string> RestoreFromBackup(string installDirectory)
+	/// <summary>
+	/// A restore that could not write every file leaves an install nobody should trust. Short of that, the
+	/// question is whether the overlay had already begun replacing files: if it had, the backup covers only
+	/// the dozen names in <see cref="GetCriticalFileNames"/> out of the few hundred in the folder, so
+	/// putting those back cannot bring the install to a single version.
+	/// </summary>
+	private static RollbackConfidence GradeRollback(RestoreResult restore, IReadOnlyList<string>? filesTheOverlayHadReplaced)
+		=> restore.UnrestoredFiles.Count > 0 ? RollbackConfidence.RestoreIncomplete
+		: filesTheOverlayHadReplaced?.Count > 0 ? RollbackConfidence.RestoredButInstallIsMixed
+		: RollbackConfidence.RestoredToPreviousVersion;
+
+	private static string DescribeRollbackOutcome(RollbackConfidence confidence)
+		=> confidence switch
+		{
+			RollbackConfidence.RestoredToPreviousVersion =>
+				"Libation put your previous install files back, and checked each one afterwards. The upgrade had not started replacing files, so this install is the version you were running before.",
+
+			RollbackConfidence.RestoredButInstallIsMixed =>
+				"Libation put your previous install files back and checked each one afterwards. The upgrade had already replaced some other files though, and those are not covered by the backup, so this install is now a mixture of both versions. It should start, but installing a fresh copy is the only way to be sure of it.",
+
+			RollbackConfidence.RestoreIncomplete =>
+				"Libation could not put all of your previous install files back, so this install is incomplete. Please install a fresh copy before using Libation again.",
+
+			_ => string.Empty,
+		};
+
+	private static string DescribeUnrestoredFiles(IReadOnlyList<string> unrestoredFiles)
+		=> unrestoredFiles.Count == 0
+		? string.Empty
+		: $"""
+
+			Could not be restored:
+			{string.Join(Environment.NewLine, unrestoredFiles.Select(f => $"  - {f}"))}
+
+			""";
+
+	private static string DescribeRecoveryAdvice(RollbackConfidence confidence)
+		=> confidence is RollbackConfidence.RestoredToPreviousVersion
+		? """
+			When you next want to upgrade:
+			1. Quit Libation completely.
+			2. Download the latest release from GitHub. The setup.exe installer is the easiest option.
+			3. If you use the zip instead, extract it to a new folder (do not copy files on top of this install folder).
+			"""
+		: """
+			To get back to a clean install:
+			1. Quit Libation completely.
+			2. Download the latest release from GitHub. The setup.exe installer is the easiest option.
+			3. If you use the zip instead, extract it to a new folder (do not copy files on top of this install folder).
+			4. Run Libation from the new folder.
+			""";
+
+	private readonly record struct RestoreResult(IReadOnlyList<string> RestoredFiles, IReadOnlyList<string> UnrestoredFiles);
+
+	/// <summary>
+	/// Puts every backed-up file back, then reads each one to confirm it now matches its backup copy.
+	/// <para/>
+	/// The check is the point: the rollback used to restore, announce success and delete the pending marker
+	/// without ever looking at what it had written, so a copy that half succeeded still reported "Libation
+	/// restored your previous install files". One file failing no longer abandons the rest either.
+	/// </summary>
+	private static RestoreResult RestoreFromBackup(string installDirectory)
 	{
 		var backupDirectory = GetBackupDirectory(installDirectory);
 		var restoredFiles = new List<string>();
+		var unrestoredFiles = new List<string>();
 
 		if (!Directory.Exists(backupDirectory))
-			return restoredFiles;
+			return new RestoreResult(restoredFiles, unrestoredFiles);
 
 		foreach (var backupFile in Directory.EnumerateFiles(backupDirectory, "*", SearchOption.AllDirectories))
 		{
 			var relativePath = Path.GetRelativePath(backupDirectory, backupFile);
 			var targetPath = Path.Combine(installDirectory, relativePath);
-			Directory.CreateDirectory(Path.GetDirectoryName(targetPath)!);
-			ReplaceInstallFile(backupFile, targetPath);
-			restoredFiles.Add(relativePath);
 
+			try
+			{
+				Directory.CreateDirectory(Path.GetDirectoryName(targetPath)!);
+				ReplaceInstallFile(backupFile, targetPath);
+			}
+			catch (Exception ex)
+			{
+				unrestoredFiles.Add($"{relativePath}: could not be restored ({ex.Message})");
+				StartupLog.Error(ex, $"Upgrade rollback could not restore {relativePath}");
+				continue;
+			}
+
+			if (!FilesMatch(backupFile, targetPath))
+			{
+				unrestoredFiles.Add($"{relativePath}: restored copy does not match the backup");
+				StartupLog.Error($"Upgrade rollback wrote {relativePath}, but it does not match the backup");
+				continue;
+			}
+
+			restoredFiles.Add(relativePath);
 			StartupLog.Information($"Upgrade rollback restored {relativePath}");
 		}
 
-		return restoredFiles;
+		return new RestoreResult(restoredFiles, unrestoredFiles);
+	}
+
+	private static bool FilesMatch(string left, string right)
+	{
+		try
+		{
+			return File.Exists(left)
+				&& File.Exists(right)
+				&& string.Equals(ComputeSha256Hex(left), ComputeSha256Hex(right), StringComparison.OrdinalIgnoreCase);
+		}
+		catch (Exception ex)
+		{
+			StartupLog.Warning(ex, $"Could not compare {left} with {right}");
+			return false;
+		}
 	}
 
 	/// <summary>

--- a/Source/LibationFileManager/InstallUpgradeManager.cs
+++ b/Source/LibationFileManager/InstallUpgradeManager.cs
@@ -30,6 +30,9 @@ public static class InstallUpgradeManager
 	public const string PendingStateFileName = "pending.json";
 	public const string BackupFolderName = "backup";
 
+	/// <summary>Suffix for a loaded assembly moved out of the way so its replacement can be written.</summary>
+	public const string DisplacedFileSuffix = ".libation-old";
+
 	public const string LibationUiBaseIntegrityTypeName = "LibationUiBase.ShowBadBookDialogAsyncDelegate";
 
 	private static readonly JsonSerializerOptions JsonOptions = new()
@@ -39,12 +42,24 @@ public static class InstallUpgradeManager
 		DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
 	};
 
+	/// <summary>
+	/// Files an overlay upgrade must have replaced for Libation to start at all, so they are both backed up
+	/// and hash-verified.
+	/// <para/>
+	/// The bottom four were added after issue #2001: Libation cannot reach its own crash dialog without
+	/// them, yet they were absent from this list, so an overlay that left a stale <c>Serilog.dll</c> behind
+	/// still passed verification and the pending marker was cleared as a success.
+	/// </summary>
 	private static readonly string[] AlwaysCriticalFileNames =
 	[
 		"LibationUiBase.dll",
 		"LibationFileManager.dll",
 		"AppScaffolding.dll",
 		"Microsoft.EntityFrameworkCore.Sqlite.dll",
+		"Serilog.dll",
+		"Dinah.Core.dll",
+		"FileManager.dll",
+		"Newtonsoft.Json.dll",
 	];
 
 	private static FatalStartupMessage? s_StartupRecoveryAlert;
@@ -128,6 +143,9 @@ public static class InstallUpgradeManager
 	public static UpgradeRecoveryResult? RecoverPendingUpgradeIfNeeded(string installDirectory)
 	{
 		ArgumentException.ThrowIfNullOrWhiteSpace(installDirectory);
+
+		// A previous run's rollback left these behind because it could not delete a file it still had open.
+		DeleteDisplacedFiles(installDirectory);
 
 		var pendingPath = GetPendingStatePath(installDirectory);
 		if (!File.Exists(pendingPath))
@@ -227,6 +245,8 @@ public static class InstallUpgradeManager
 
 	public static void CompleteUpgrade(string installDirectory)
 	{
+		DeleteDisplacedFiles(installDirectory);
+
 		var stateDirectory = GetUpgradeStateDirectory(installDirectory);
 		if (!Directory.Exists(stateDirectory))
 			return;
@@ -325,13 +345,75 @@ public static class InstallUpgradeManager
 			var relativePath = Path.GetRelativePath(backupDirectory, backupFile);
 			var targetPath = Path.Combine(installDirectory, relativePath);
 			Directory.CreateDirectory(Path.GetDirectoryName(targetPath)!);
-			File.Copy(backupFile, targetPath, overwrite: true);
+			ReplaceInstallFile(backupFile, targetPath);
 			restoredFiles.Add(relativePath);
 
 			StartupLog.Information($"Upgrade rollback restored {relativePath}");
 		}
 
 		return restoredFiles;
+	}
+
+	/// <summary>
+	/// Puts <paramref name="source"/> at <paramref name="targetPath"/> even when this process has already
+	/// loaded the file it is replacing.
+	/// <para/>
+	/// Every backed-up file is an assembly, and by the time startup recovery runs, at least
+	/// LibationFileManager and AppScaffolding are loaded and memory-mapped. Writing over a mapped file
+	/// in place corrupts the mapping: <c>File.Copy(overwrite: true)</c> segfaulted the process outright on
+	/// Linux, and Windows denies the write, so the rollback could never finish. Renaming is permitted on
+	/// both, because .NET opens assemblies with <c>FileShare.Delete</c>, and the mapping keeps working off
+	/// the moved inode until the process exits. See issue #2001.
+	/// </summary>
+	private static void ReplaceInstallFile(string source, string targetPath)
+	{
+		if (File.Exists(targetPath))
+		{
+			var displaced = targetPath + DisplacedFileSuffix;
+			TryDelete(displaced);
+			File.Move(targetPath, displaced, overwrite: true);
+		}
+
+		File.Copy(source, targetPath, overwrite: true);
+	}
+
+	/// <summary>
+	/// Removes the files a previous rollback moved aside. Their replacements are on disk and the process
+	/// that was holding them has exited, so nothing needs them any more.
+	/// <para/>
+	/// Top level only: every backed-up name comes from <see cref="GetCriticalFileNames"/>, which yields
+	/// bare file names, so a displaced file can only ever sit next to the executable. That keeps this cheap
+	/// enough to run on every startup, which it has to, because the rollback that creates these files also
+	/// deletes the pending marker that would otherwise signal there is cleaning up to do.
+	/// </summary>
+	private static void DeleteDisplacedFiles(string installDirectory)
+	{
+		try
+		{
+			if (!Directory.Exists(installDirectory))
+				return;
+
+			foreach (var displaced in Directory.EnumerateFiles(installDirectory, $"*{DisplacedFileSuffix}", SearchOption.TopDirectoryOnly))
+				TryDelete(displaced);
+		}
+		catch (Exception ex)
+		{
+			StartupLog.Warning(ex, $"Could not clean up displaced install files in {installDirectory}");
+		}
+	}
+
+	private static void TryDelete(string path)
+	{
+		try
+		{
+			if (File.Exists(path))
+				File.Delete(path);
+		}
+		catch (Exception ex)
+		{
+			// Still held by something, or not ours to delete. It is inert either way.
+			StartupLog.Debug(ex, $"Could not delete {path}");
+		}
 	}
 
 	private static Dictionary<string, string> BuildExpectedHashesFromZip(string upgradeBundlePath, IReadOnlyList<string> criticalFileNames)

--- a/Source/LibationFileManager/InstallUpgradeManager.cs
+++ b/Source/LibationFileManager/InstallUpgradeManager.cs
@@ -117,12 +117,8 @@ public static class InstallUpgradeManager
 		var pendingPath = GetPendingStatePath(installDirectory);
 		File.WriteAllText(pendingPath, JsonSerializer.Serialize(pending, JsonOptions));
 
-		Serilog.Log.Logger.Information(
-			"Prepared in-app upgrade to {TargetVersion}. Backed up {BackedUpCount} files to {BackupDirectory}. Expecting {ExpectedCount} install files to match the upgrade package.",
-			targetVersion,
-			backedUpFiles.Count,
-			backupDirectory,
-			expectedHashes.Count);
+		StartupLog.Information(
+			$"Prepared in-app upgrade to {targetVersion}. Backed up {backedUpFiles.Count} files to {backupDirectory}. Expecting {expectedHashes.Count} install files to match the upgrade package.");
 	}
 
 	/// <summary>
@@ -145,7 +141,7 @@ public static class InstallUpgradeManager
 		}
 		catch (Exception ex)
 		{
-			Serilog.Log.Logger.Error(ex, "Could not read pending upgrade state at {PendingPath}. Attempting emergency rollback.", pendingPath);
+			StartupLog.Error(ex, $"Could not read pending upgrade state at {pendingPath}. Attempting emergency rollback.");
 			return RollbackAndReport(installDirectory, pendingPath, null, ["Could not read pending upgrade state."], ex.Message);
 		}
 
@@ -153,16 +149,12 @@ public static class InstallUpgradeManager
 		if (verification.Success)
 		{
 			CompleteUpgrade(installDirectory);
-			Serilog.Log.Logger.Information(
-				"In-app upgrade to {TargetVersion} verified successfully at startup.",
-				pending.TargetVersion);
+			StartupLog.Information($"In-app upgrade to {pending.TargetVersion} verified successfully at startup.");
 			return null;
 		}
 
-		Serilog.Log.Logger.Error(
-			"Incomplete in-app upgrade detected at startup. Target version {TargetVersion}. {Summary}",
-			pending.TargetVersion,
-			verification.Summary);
+		StartupLog.Error(
+			$"Incomplete in-app upgrade detected at startup. Target version {pending.TargetVersion}. {verification.Summary}");
 
 		return RollbackAndReport(installDirectory, pendingPath, pending, verification.FailedFiles, verification.Summary);
 	}
@@ -245,7 +237,7 @@ public static class InstallUpgradeManager
 		}
 		catch (Exception ex)
 		{
-			Serilog.Log.Logger.Warning(ex, "Could not delete upgrade state directory {StateDirectory}", stateDirectory);
+			StartupLog.Warning(ex, $"Could not delete upgrade state directory {stateDirectory}");
 		}
 	}
 
@@ -278,11 +270,8 @@ public static class InstallUpgradeManager
 	{
 		var restoredFiles = RestoreFromBackup(installDirectory);
 
-		Serilog.Log.Logger.Error(
-			"In-app upgrade failed. Rolled back {RestoredCount} file(s) in {InstallDirectory}. {Summary}",
-			restoredFiles.Count,
-			installDirectory,
-			summary);
+		StartupLog.Error(
+			$"In-app upgrade failed. Rolled back {restoredFiles.Count} file(s) in {installDirectory}. {summary}");
 
 		try
 		{
@@ -291,7 +280,7 @@ public static class InstallUpgradeManager
 		}
 		catch (Exception ex)
 		{
-			Serilog.Log.Logger.Warning(ex, "Could not delete pending upgrade state at {PendingPath}", pendingPath);
+			StartupLog.Warning(ex, $"Could not delete pending upgrade state at {pendingPath}");
 		}
 
 		var targetVersion = pending?.TargetVersion ?? "unknown";
@@ -339,7 +328,7 @@ public static class InstallUpgradeManager
 			File.Copy(backupFile, targetPath, overwrite: true);
 			restoredFiles.Add(relativePath);
 
-			Serilog.Log.Logger.Information("Upgrade rollback restored {FileName}", relativePath);
+			StartupLog.Information($"Upgrade rollback restored {relativePath}");
 		}
 
 		return restoredFiles;
@@ -357,7 +346,7 @@ public static class InstallUpgradeManager
 
 			if (entry is null)
 			{
-				Serilog.Log.Logger.Warning("Upgrade package does not contain expected file {FileName}", fileName);
+				StartupLog.Warning($"Upgrade package does not contain expected file {fileName}");
 				continue;
 			}
 

--- a/Source/LibationFileManager/InstallUpgradeManager.cs
+++ b/Source/LibationFileManager/InstallUpgradeManager.cs
@@ -514,14 +514,39 @@ public static class InstallUpgradeManager
 	/// </summary>
 	private static void ReplaceInstallFile(string source, string targetPath)
 	{
+		string? displaced = null;
 		if (File.Exists(targetPath))
 		{
-			var displaced = targetPath + DisplacedFileSuffix;
+			displaced = targetPath + DisplacedFileSuffix;
 			TryDelete(displaced);
 			File.Move(targetPath, displaced, overwrite: true);
 		}
 
-		File.Copy(source, targetPath, overwrite: true);
+		try
+		{
+			File.Copy(source, targetPath, overwrite: true);
+		}
+		catch
+		{
+			// Moving the old file aside and then failing to write the new one would leave nothing at all
+			// where a file used to be. Put it back and let the caller report the failure.
+			if (displaced is not null && File.Exists(displaced) && !File.Exists(targetPath))
+				TryMove(displaced, targetPath);
+
+			throw;
+		}
+	}
+
+	private static void TryMove(string from, string to)
+	{
+		try
+		{
+			File.Move(from, to, overwrite: true);
+		}
+		catch (Exception ex)
+		{
+			StartupLog.Error(ex, $"Could not put {from} back to {to}");
+		}
 	}
 
 	/// <summary>

--- a/Source/LibationFileManager/InstallUpgradeManager.cs
+++ b/Source/LibationFileManager/InstallUpgradeManager.cs
@@ -308,7 +308,7 @@ public static class InstallUpgradeManager
 		var message = $"""
 			Libation attempted an in-app upgrade to version {targetVersion}, but one or more install files were not updated correctly.
 
-			Libation restored your previous install files from backup so you can continue using the app.
+			Libation restored your previous install files from backup.
 
 			Details:
 			{summary}

--- a/Source/LibationFileManager/InteropFactory.cs
+++ b/Source/LibationFileManager/InteropFactory.cs
@@ -58,7 +58,7 @@ public static class InteropFactory
 		// nothing to load (normal for LibationCli / Docker: OS interop is optional)
 		if (configApp is null)
 		{
-			Serilog.Log.Logger.Warning($"Unable to locate *{CONFIG_APP_ENDING}; continuing without OS interop helpers");
+			StartupLog.Warning($"Unable to locate *{CONFIG_APP_ENDING}; continuing without OS interop helpers");
 			return;
 		}
 
@@ -75,7 +75,7 @@ public static class InteropFactory
 		catch (Exception e)
 		{
 			//None of the interop functions are strictly necessary for Libation to run.
-			Serilog.Log.Logger.Warning(e, "Unable to load types from assembly {configApp}; continuing without OS interop helpers", configApp);
+			StartupLog.Warning(e, $"Unable to load types from assembly {configApp}; continuing without OS interop helpers");
 		}
 	}
 	private static string? getOSConfigApp()
@@ -104,7 +104,7 @@ public static class InteropFactory
 
 		// Let the runtime handle any dll not found exceptions
 		if (assembly is null)
-			Serilog.Log.Logger.Warning($"Unable to load module {args.Name}");
+			StartupLog.Warning($"Unable to load module {args.Name}");
 
 		return assembly;
 	}

--- a/Source/LibationFileManager/LibationFiles.cs
+++ b/Source/LibationFileManager/LibationFiles.cs
@@ -1,8 +1,6 @@
-﻿using Dinah.Core.Logging;
-using FileManager;
+﻿using FileManager;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
-using Serilog;
 using System;
 using System.Diagnostics;
 using System.IO;
@@ -100,11 +98,11 @@ public class LibationFiles
 		{
 			// now it's set in the file again but no settings have moved yet
 			File.WriteAllText(AppsettingsJsonFile, endingContents);
-			Log.Logger.TryLogInformation("Libation files changed {@DebugInfo}", new { AppsettingsJsonFile, LIBATION_FILES_KEY, pathToPersist });
+			StartupLog.Information($"Libation files changed. {AppsettingsJsonFile} {LIBATION_FILES_KEY}={pathToPersist}");
 		}
 		catch (Exception ex)
 		{
-			Log.Logger.TryLogError(ex, "Failed to change Libation files location {@DebugInfo}", new { AppsettingsJsonFile, LIBATION_FILES_KEY, pathToPersist });
+			StartupLog.Error(ex, $"Failed to change Libation files location. {AppsettingsJsonFile} {LIBATION_FILES_KEY}={pathToPersist}");
 		}
 	}
 
@@ -125,12 +123,12 @@ public class LibationFiles
 		}
 		catch (Exception ex)
 		{
-			Log.Logger.Error(ex, "Failed to load settings file: {SettingsFile}", settingsFile);
+			StartupLog.Error(ex, $"Failed to load settings file: {settingsFile}");
 			try
 			{
-				Log.Logger.Information("Deleting invalid settings file: {SettingsFile}", settingsFile);
+				StartupLog.Information($"Deleting invalid settings file: {settingsFile}");
 				FileUtility.SaferDelete(settingsFile);
-				Log.Logger.Information("Creating a new, empty setting file: {SettingsFile}", settingsFile);
+				StartupLog.Information($"Creating a new, empty setting file: {settingsFile}");
 				try
 				{
 					File.WriteAllText(settingsFile, "{}");
@@ -138,12 +136,12 @@ public class LibationFiles
 				}
 				catch (Exception createEx)
 				{
-					Log.Logger.Error(createEx, "Failed to create new settings file: {SettingsFile}", settingsFile);
+					StartupLog.Error(createEx, $"Failed to create new settings file: {settingsFile}");
 				}
 			}
 			catch (Exception deleteEx)
 			{
-				Log.Logger.Error(deleteEx, "Failed to delete the invalid settings file: {SettingsFile}", settingsFile);
+				StartupLog.Error(deleteEx, $"Failed to delete the invalid settings file: {settingsFile}");
 			}
 
 			return false;
@@ -228,7 +226,7 @@ public class LibationFiles
 			}
 			catch (Exception ex)
 			{
-				Log.Logger.TryLogError(ex, $"Failed to create {appsettingsFile}");
+				StartupLog.Error(ex, $"Failed to create {appsettingsFile}");
 			}
 		}
 
@@ -298,7 +296,7 @@ public class LibationFiles
 			}
 			catch (Exception e)
 			{
-				Log.Error(e, "Failed to run shell command. {@Arguments}", psi.ArgumentList);
+				StartupLog.Error(e, $"Failed to run shell command: {string.Join(' ', psi.ArgumentList)}");
 				return null;
 			}
 		}

--- a/Source/LibationFileManager/PreLoggingCrashLog.cs
+++ b/Source/LibationFileManager/PreLoggingCrashLog.cs
@@ -1,0 +1,167 @@
+using FileManager;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+
+namespace LibationFileManager;
+
+/// <summary>
+/// Writes a crash record without Serilog, for the startup window where Serilog is not configured yet or
+/// cannot be loaded at all.
+/// <para/>
+/// Shared by both UIs. Chardonnay had a private copy of this and Classic had nothing, so a Classic user
+/// whose startup failed before logging was told, correctly, that the error could not be written anywhere.
+/// See issue #2001.
+/// </summary>
+public static class PreLoggingCrashLog
+{
+	public const string CrashFileName = "LibationCrash.log";
+
+	/// <summary>
+	/// Appends a crash record to the newest Libation log file, falling back to <see cref="CrashFileName"/>
+	/// in the Libation files folder and then in the user profile.
+	/// </summary>
+	/// <param name="exception">The failure to record.</param>
+	/// <param name="extraFields">
+	/// Anything the caller knows that this assembly cannot see, such as the release identifier.
+	/// </param>
+	/// <returns>
+	/// The file written, to be named in the crash dialog, or null when nothing could be written. Callers
+	/// used to tell users to attach <c>LibationCrash.log</c> unconditionally, which is the wrong file
+	/// whenever a <c>Log*.log</c> already exists, and no file at all when this returns null.
+	/// </returns>
+	public static string? TryWrite(Exception? exception, IEnumerable<(string Name, string Value)>? extraFields = null)
+	{
+		string record;
+		try
+		{
+			record = BuildRecord(exception, extraFields);
+		}
+		catch (Exception ex)
+		{
+			// Losing the whole record because one field could not be read is what happened before.
+			record = $"{DateTime.Now} - Libation Crash{Environment.NewLine} (crash record could not be built: {ex}){Environment.NewLine} === EXCEPTION ==={Environment.NewLine} {exception}";
+		}
+
+		foreach (var candidate in ResolveCandidateFiles())
+		{
+			if (TryAppend(candidate, record))
+				return candidate;
+		}
+
+		return null;
+	}
+
+	/// <summary>
+	/// Every value is read through <see cref="Describe"/>, so a property that throws contributes its error
+	/// text instead of taking the record down with it. <c>Books</c> genuinely does throw this early, and
+	/// <c>InteropFactory.InteropFunctionsType</c> ran a static constructor that itself needed Serilog.
+	/// </summary>
+	private static string BuildRecord(Exception? exception, IEnumerable<(string Name, string Value)>? extraFields)
+	{
+		var fields = new List<(string Name, string Value)>
+		{
+			("OS", Describe(() => Configuration.OS.ToString())),
+			("Version", Describe(() => Configuration.LibationVersion?.ToString() ?? "[null]")),
+			("InteropFunctionsType", Describe(() => InteropFactory.InteropFunctionsType?.ToString() ?? "[null]")),
+			("LibationFiles", Describe(() => Configuration.Instance.LibationFiles.Location.Path)),
+			("Books Folder", Describe(() => Configuration.Instance.Books ?? "[null]")),
+		};
+
+		if (extraFields is not null)
+			fields.AddRange(extraFields);
+
+		var width = fields.Max(f => f.Name.Length) + 2;
+		var lines = fields.Select(f => $" {f.Name.PadRight(width)}{f.Value}");
+
+		return $"""
+			{DateTime.Now} - Libation Crash
+			{string.Join(Environment.NewLine, lines)}
+			 === EXCEPTION ===
+			 {exception}
+			""";
+	}
+
+	private static string Describe(Func<string> read)
+	{
+		try
+		{
+			return read();
+		}
+		catch (Exception ex)
+		{
+			return ex.ToString();
+		}
+	}
+
+	private static IEnumerable<LongPath> ResolveCandidateFiles()
+	{
+		var logDirectory = Describe(() => Configuration.Instance.LibationFiles.Location.Path);
+
+		if (Directory.Exists(logDirectory))
+		{
+			var newestLog = NewestLogFile(logDirectory);
+			if (newestLog is not null)
+				yield return newestLog;
+
+			yield return Path.Combine(logDirectory, CrashFileName);
+		}
+
+		var userProfile = Describe(() => Environment.GetFolderPath(Environment.SpecialFolder.UserProfile));
+		if (Directory.Exists(userProfile))
+			yield return Path.Combine(userProfile, CrashFileName);
+	}
+
+	private static string? NewestLogFile(string logDirectory)
+	{
+		try
+		{
+			return Directory.GetFiles(logDirectory, "Log*.log")
+				.Select(f => new FileInfo(f))
+				.OrderByDescending(f => f.CreationTimeUtc)
+				.FirstOrDefault()
+				?.FullName;
+		}
+		catch (Exception)
+		{
+			return null;
+		}
+	}
+
+	private static bool TryAppend(LongPath path, string record)
+	{
+		try
+		{
+			// Without this the record ran straight onto the end of the last log line.
+			var separator = NeedsLeadingNewLine(path) ? Environment.NewLine : string.Empty;
+
+			using var writer = new StreamWriter(path, append: true);
+			writer.WriteLine(separator + record);
+			return true;
+		}
+		catch (Exception)
+		{
+			return false;
+		}
+	}
+
+	private static bool NeedsLeadingNewLine(LongPath path)
+	{
+		try
+		{
+			var info = new FileInfo(path);
+			if (!info.Exists || info.Length == 0)
+				return false;
+
+			using var stream = File.OpenRead(path);
+			stream.Seek(-1, SeekOrigin.End);
+			var last = stream.ReadByte();
+			return last is not ('\n' or '\r');
+		}
+		catch (Exception)
+		{
+			return false;
+		}
+	}
+}

--- a/Source/LibationFileManager/PreLoggingCrashLog.cs
+++ b/Source/LibationFileManager/PreLoggingCrashLog.cs
@@ -30,6 +30,9 @@ public static class PreLoggingCrashLog
 	/// The file written, to be named in the crash dialog, or null when nothing could be written. Callers
 	/// used to tell users to attach <c>LibationCrash.log</c> unconditionally, which is the wrong file
 	/// whenever a <c>Log*.log</c> already exists, and no file at all when this returns null.
+	/// <para/>
+	/// Reported without the Windows extended-length prefix. This path is for a person to read and to paste
+	/// into Explorer, so a <c>\\?\</c> in front of it would be noise at best.
 	/// </returns>
 	public static string? TryWrite(Exception? exception, IEnumerable<(string Name, string Value)>? extraFields = null)
 	{
@@ -47,7 +50,7 @@ public static class PreLoggingCrashLog
 		foreach (var candidate in ResolveCandidateFiles())
 		{
 			if (TryAppend(candidate, record))
-				return candidate;
+				return candidate.PathWithoutPrefix;
 		}
 
 		return null;
@@ -65,7 +68,7 @@ public static class PreLoggingCrashLog
 			("OS", Describe(() => Configuration.OS.ToString())),
 			("Version", Describe(() => Configuration.LibationVersion?.ToString() ?? "[null]")),
 			("InteropFunctionsType", Describe(() => InteropFactory.InteropFunctionsType?.ToString() ?? "[null]")),
-			("LibationFiles", Describe(() => Configuration.Instance.LibationFiles.Location.Path)),
+			("LibationFiles", Describe(() => Configuration.Instance.LibationFiles.Location.PathWithoutPrefix)),
 			("Books Folder", Describe(() => Configuration.Instance.Books ?? "[null]")),
 		};
 

--- a/Source/LibationFileManager/SingleInstance.cs
+++ b/Source/LibationFileManager/SingleInstance.cs
@@ -55,7 +55,7 @@ public sealed class SingleInstance : IDisposable
 		catch (Exception ex)
 		{
 			// Never let the guard itself prevent startup. Fail open by treating this as the first instance.
-			Serilog.Log.Logger.Warning(ex, "Could not evaluate the single-instance lock; continuing without it.");
+			StartupLog.Warning(ex, "Could not evaluate the single-instance lock; continuing without it.");
 			mutex?.Dispose();
 			return new SingleInstance(null, true);
 		}

--- a/Source/LibationFileManager/StartupAssemblyBootstrap.cs
+++ b/Source/LibationFileManager/StartupAssemblyBootstrap.cs
@@ -182,7 +182,121 @@ public static class StartupAssemblyBootstrap
 	public static bool IsInstallFolderAssemblyLoadFailure(Exception ex) =>
 		IsApplicationControlBlockedAssembly(ex)
 		|| IsMissingDependencyAssembly(ex)
-		|| IsIncompleteUpgradeAssemblyFailure(ex);
+		|| IsIncompleteUpgradeAssemblyFailure(ex)
+		|| TryGetInstallAssemblyFailure(ex, out _);
+
+	/// <summary>
+	/// Finds an assembly the runtime could not bind to a usable file in the install folder, whatever the
+	/// assembly is called.
+	/// <para/>
+	/// The name-based checks above only recognise the handful of assemblies that had already caused a bug
+	/// report, so a missing <c>Serilog.dll</c> fell through all of them to a generic "fatal error" dialog
+	/// with no rollback attempted. See issue #2001.
+	/// <para/>
+	/// A stale file reports identically to an absent one: the loader says "the system cannot find the file
+	/// specified" either way, because it rejects a file whose version is below the reference and then has
+	/// nothing left to bind. The on-disk version is therefore worth reading and telling the user about.
+	/// </summary>
+	public static bool TryGetInstallAssemblyFailure(Exception? ex, out InstallAssemblyFailure? failure)
+	{
+		failure = null;
+		for (var current = ex; current is not null; current = current.InnerException)
+		{
+			if (current is AggregateException aggregate)
+			{
+				foreach (var inner in aggregate.InnerExceptions)
+				{
+					if (TryGetInstallAssemblyFailure(inner, out failure))
+						return true;
+				}
+			}
+
+			if (current is not FileNotFoundException and not FileLoadException)
+				continue;
+
+			var fileName = (current as FileNotFoundException)?.FileName ?? (current as FileLoadException)?.FileName;
+			if (!TryParseAssemblyReference(fileName, out var assemblyName, out var requestedVersion)
+				|| assemblyName is null
+				|| requestedVersion is null)
+				continue;
+
+			var path = FindInstallAssemblyPath(assemblyName);
+			var installedVersion = path is null ? null : TryReadAssemblyVersion(path);
+
+			// Present, readable and no older than the reference: this bind failed for some other reason,
+			// so leave it to a caller that knows more rather than blaming the install folder.
+			if (installedVersion is not null && installedVersion >= requestedVersion)
+				continue;
+
+			failure = new InstallAssemblyFailure(
+				assemblyName,
+				requestedVersion,
+				installedVersion,
+				path ?? Path.Combine(Configuration.ProcessDirectory, $"{assemblyName}.dll"));
+			return true;
+		}
+
+		return false;
+	}
+
+	public static string DescribeInstallAssemblyFailure(InstallAssemblyFailure failure)
+		=> failure.InstalledVersion is null
+		? $"{failure.FileName} is missing from the install folder. This build of Libation needs version {failure.RequestedVersion}."
+		: $"{failure.FileName} in the install folder is version {failure.InstalledVersion}, but this build of Libation needs version {failure.RequestedVersion}. The upgrade did not replace this file.";
+
+	/// <summary>
+	/// True only for a genuine assembly reference, which always carries a version. This keeps the check off
+	/// the <see cref="FileNotFoundException"/>s that carry a plain file path, such as the one
+	/// <see cref="ValidateEntityFrameworkCoreSqlitePresent"/> raises.
+	/// </summary>
+	private static bool TryParseAssemblyReference(string? fileName, out string? assemblyName, out Version? version)
+	{
+		assemblyName = null;
+		version = null;
+
+		if (string.IsNullOrWhiteSpace(fileName))
+			return false;
+
+		try
+		{
+			var parsed = new AssemblyName(fileName);
+			if (string.IsNullOrWhiteSpace(parsed.Name) || parsed.Version is null)
+				return false;
+
+			assemblyName = parsed.Name;
+			version = parsed.Version;
+			return true;
+		}
+		catch (Exception)
+		{
+			return false;
+		}
+	}
+
+	private static string? FindInstallAssemblyPath(string assemblyName)
+	{
+		foreach (var extension in new[] { ".dll", ".exe" })
+		{
+			var path = Path.Combine(Configuration.ProcessDirectory, assemblyName + extension);
+			if (File.Exists(path))
+				return path;
+		}
+
+		return null;
+	}
+
+	private static Version? TryReadAssemblyVersion(string path)
+	{
+		try
+		{
+			return AssemblyName.GetAssemblyName(path).Version;
+		}
+		catch (Exception)
+		{
+			// Not a managed assembly, or unreadable. Either way we cannot name a version.
+			return null;
+		}
+	}
 
 	public static FatalStartupMessage? GetStartupFailureMessage(Exception ex)
 	{
@@ -217,6 +331,14 @@ public static class StartupAssemblyBootstrap
 				GetLibraryLoadFailureMessage());
 		}
 
+		// Last, so the checks above keep naming the specific cause they recognise.
+		if (TryGetInstallAssemblyFailure(ex, out _))
+		{
+			return new FatalStartupMessage(
+				"Libation could not load a required file",
+				GetIncompleteUpgradeFailureMessage(ex));
+		}
+
 		return null;
 	}
 
@@ -249,7 +371,9 @@ public static class StartupAssemblyBootstrap
 	/// </summary>
 	public static FatalStartupMessage GetFatalStartupMessage(Exception ex, FatalStartupMessage genericFallback)
 	{
-		if (IsIncompleteUpgradeAssemblyFailure(ex))
+		// TryEmergencyRollback is a no-op without a backup folder, so it is safe to offer it to any
+		// assembly failure that points at the install folder rather than only the named ones.
+		if (IsIncompleteUpgradeAssemblyFailure(ex) || TryGetInstallAssemblyFailure(ex, out _))
 		{
 			var recovery = InstallUpgradeManager.TryEmergencyRollback(Configuration.ProcessDirectory);
 			if (recovery.RolledBack)
@@ -265,12 +389,17 @@ public static class StartupAssemblyBootstrap
 
 	public static string GetIncompleteUpgradeFailureMessage(Exception? ex = null)
 	{
-		var detail = ex?.Message;
+		// Naming the file and both versions turns an opaque loader message into something the user, and
+		// anyone reading their bug report, can act on without guessing.
+		var detail = TryGetInstallAssemblyFailure(ex, out var assemblyFailure) && assemblyFailure is not null
+			? DescribeInstallAssemblyFailure(assemblyFailure)
+			: ex?.Message;
+
 		if (string.IsNullOrWhiteSpace(detail))
 			detail = "(no additional detail)";
 
 		return $"""
-			Libation could not load a required component after an in-app upgrade. This usually means the upgrade overlay did not replace every install file.
+			Libation could not load a required file from its install folder. This usually means an in-app upgrade, or a zip extracted over an existing install, did not replace every file.
 
 			Technical detail:
 			{detail}

--- a/Source/LibationFileManager/StartupAssemblyBootstrap.cs
+++ b/Source/LibationFileManager/StartupAssemblyBootstrap.cs
@@ -33,12 +33,12 @@ public static class StartupAssemblyBootstrap
 	/// <c>BadBookActionDialogBase.ShowAsyncImpl</c>.
 	/// </summary>
 	/// <returns>
-	/// The message to show when a rollback replaced install files, in which case the caller must show it and
+	/// The notice to show when a rollback replaced install files, in which case the caller must show it and
 	/// quit rather than continue. This process has already loaded the assemblies that were just swapped out
 	/// from under it, so what is in memory no longer matches what is on disk. Null when there was nothing to
 	/// recover, which is the normal case.
 	/// </returns>
-	public static FatalStartupMessage? RecoverFromIncompleteUpgradeIfNeeded()
+	public static StartupRecoveryNotice? RecoverFromIncompleteUpgradeIfNeeded()
 	{
 		try
 		{
@@ -47,9 +47,14 @@ public static class StartupAssemblyBootstrap
 				return null;
 
 			InstallUpgradeManager.TakeStartupRecoveryAlert();
-			return new FatalStartupMessage(
-				recovery.Title,
-				recovery.Message + Environment.NewLine + Environment.NewLine + "Libation will close now. Please start it again.");
+
+			var offerRestart = ShouldOfferRestart(recovery, InstallRelauncher.WasRelaunched);
+
+			return new StartupRecoveryNotice(
+				new FatalStartupMessage(
+					recovery.Title,
+					recovery.Message + Environment.NewLine + Environment.NewLine + DescribeRestart(offerRestart, recovery.Confidence)),
+				offerRestart);
 		}
 		catch (Exception ex)
 		{
@@ -57,6 +62,26 @@ public static class StartupAssemblyBootstrap
 			return null;
 		}
 	}
+
+	/// <summary>
+	/// Whether to ask the user about restarting: only for an install the rollback fully restored, and only
+	/// in a process that was not itself started by a restart. A rollback deletes the pending marker before
+	/// returning, but that delete swallows its own failure, and a marker that outlives one rollback would
+	/// otherwise let this repeat on every launch.
+	/// </summary>
+	public static bool ShouldOfferRestart(UpgradeRecoveryResult recovery, bool wasRelaunched)
+		=> recovery.WorthRestarting && !wasRelaunched;
+
+	/// <summary>
+	/// Libation has to close either way, because the files underneath it just changed. How warmly to suggest
+	/// coming straight back depends on what it found when it checked its own work.
+	/// </summary>
+	private static string DescribeRestart(bool offerRestart, RollbackConfidence confidence)
+		=> !offerRestart
+		? "Libation needs to close now."
+		: confidence is RollbackConfidence.RestoredButInstallIsMixed
+			? "Libation needs to close now. You can start it again if you would like to carry on for the moment, though a fresh install would be better.\n\nWould you like to start Libation again now?"
+			: "Libation needs to close now so it can load the files it just put back.\n\nWould you like to start Libation again now?";
 
 	private static void TrySyncWindowsInstallMetadata()
 	{

--- a/Source/LibationFileManager/StartupAssemblyBootstrap.cs
+++ b/Source/LibationFileManager/StartupAssemblyBootstrap.cs
@@ -32,15 +32,29 @@ public static class StartupAssemblyBootstrap
 	/// Call once immediately after <c>RunPreConfigMigrations</c>, before assigning UI assembly hooks such as
 	/// <c>BadBookActionDialogBase.ShowAsyncImpl</c>.
 	/// </summary>
-	public static void RecoverFromIncompleteUpgradeIfNeeded()
+	/// <returns>
+	/// The message to show when a rollback replaced install files, in which case the caller must show it and
+	/// quit rather than continue. This process has already loaded the assemblies that were just swapped out
+	/// from under it, so what is in memory no longer matches what is on disk. Null when there was nothing to
+	/// recover, which is the normal case.
+	/// </returns>
+	public static FatalStartupMessage? RecoverFromIncompleteUpgradeIfNeeded()
 	{
 		try
 		{
-			InstallUpgradeManager.RecoverPendingUpgradeIfNeeded(Configuration.ProcessDirectory);
+			var recovery = InstallUpgradeManager.RecoverPendingUpgradeIfNeeded(Configuration.ProcessDirectory);
+			if (recovery?.RolledBack != true)
+				return null;
+
+			InstallUpgradeManager.TakeStartupRecoveryAlert();
+			return new FatalStartupMessage(
+				recovery.Title,
+				recovery.Message + Environment.NewLine + Environment.NewLine + "Libation will close now. Please start it again.");
 		}
 		catch (Exception ex)
 		{
 			StartupLog.Error(ex, "Failed while recovering from a pending in-app upgrade");
+			return null;
 		}
 	}
 

--- a/Source/LibationFileManager/StartupAssemblyBootstrap.cs
+++ b/Source/LibationFileManager/StartupAssemblyBootstrap.cs
@@ -40,7 +40,7 @@ public static class StartupAssemblyBootstrap
 		}
 		catch (Exception ex)
 		{
-			Serilog.Log.Logger.Error(ex, "Failed while recovering from a pending in-app upgrade");
+			StartupLog.Error(ex, "Failed while recovering from a pending in-app upgrade");
 		}
 	}
 
@@ -55,7 +55,7 @@ public static class StartupAssemblyBootstrap
 		}
 		catch (Exception ex)
 		{
-			Serilog.Log.Logger.Warning(ex, "Could not run install metadata sync at startup");
+			StartupLog.Warning(ex, "Could not run install metadata sync at startup");
 		}
 	}
 

--- a/Source/LibationFileManager/StartupLog.cs
+++ b/Source/LibationFileManager/StartupLog.cs
@@ -1,0 +1,135 @@
+using System;
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+
+namespace LibationFileManager;
+
+public enum StartupLogLevel
+{
+	Debug,
+	Information,
+	Warning,
+	Error,
+}
+
+public sealed record StartupLogEntry(DateTimeOffset Timestamp, StartupLogLevel Level, string Message, Exception? Exception);
+
+/// <summary>
+/// Logging for the startup window that runs before <see cref="Configuration.ConfigureLogging"/>, where
+/// <c>Serilog.Log.Logger</c> is still Serilog's silent logger and writes nowhere.
+/// <para/>
+/// Nothing here names a Serilog type, which is the point. Libation's releases are ReadyToRun, so a
+/// Serilog reference resolves lazily when the line holding it runs; if the install folder's
+/// <c>Serilog.dll</c> is missing or older than the one this build was compiled against, that line throws.
+/// A <c>catch</c> block cannot protect its own logging call, so an install broken badly enough to need
+/// the upgrade recovery in <see cref="InstallUpgradeManager"/> was the exact case in which that recovery
+/// destroyed the real exception and aborted. See issue #2001.
+/// <para/>
+/// Entries recorded before <see cref="ReplayTo"/> are buffered and handed over in order once real logging
+/// exists, so startup diagnostics reach the log file instead of vanishing. Every method here swallows its
+/// own failures: this must never be the reason startup ends.
+/// </summary>
+public static class StartupLog
+{
+	/// <summary>
+	/// Room for a whole startup and then some. Bounded so a caller in a retry loop cannot grow this
+	/// without limit while there is still no sink to drain it.
+	/// </summary>
+	private const int MaxBufferedEntries = 500;
+
+	private static readonly object Gate = new();
+	private static readonly List<StartupLogEntry> Buffered = [];
+	private static Action<StartupLogEntry>? Sink;
+
+	public static void Debug(string message) => Record(StartupLogLevel.Debug, message, null);
+	public static void Debug(Exception? exception, string message) => Record(StartupLogLevel.Debug, message, exception);
+	public static void Information(string message) => Record(StartupLogLevel.Information, message, null);
+	public static void Warning(string message) => Record(StartupLogLevel.Warning, message, null);
+	public static void Warning(Exception? exception, string message) => Record(StartupLogLevel.Warning, message, exception);
+	public static void Error(string message) => Record(StartupLogLevel.Error, message, null);
+	public static void Error(Exception? exception, string message) => Record(StartupLogLevel.Error, message, exception);
+
+	/// <summary>
+	/// Hands every buffered entry to <paramref name="sink"/> in the order it was recorded, then sends
+	/// later entries straight through. Call once, immediately after logging is configured.
+	/// </summary>
+	public static void ReplayTo(Action<StartupLogEntry> sink)
+	{
+		ArgumentNullException.ThrowIfNull(sink);
+
+		StartupLogEntry[] pending;
+		lock (Gate)
+		{
+			Sink = sink;
+			pending = [.. Buffered];
+			Buffered.Clear();
+		}
+
+		foreach (var entry in pending)
+			Deliver(sink, entry);
+	}
+
+	/// <summary>Entries recorded but not yet handed to a sink.</summary>
+	public static IReadOnlyList<StartupLogEntry> BufferedEntries
+	{
+		get
+		{
+			lock (Gate)
+				return [.. Buffered];
+		}
+	}
+
+	/// <summary>Drops the sink and anything buffered. Test support: this is process-wide state.</summary>
+	public static void ResetForTests()
+	{
+		lock (Gate)
+		{
+			Sink = null;
+			Buffered.Clear();
+		}
+	}
+
+	private static void Record(StartupLogLevel level, string message, Exception? exception)
+	{
+		try
+		{
+			var entry = new StartupLogEntry(DateTimeOffset.Now, level, message, exception);
+
+			Action<StartupLogEntry>? sink;
+			lock (Gate)
+			{
+				sink = Sink;
+				if (sink is null)
+				{
+					if (Buffered.Count < MaxBufferedEntries)
+						Buffered.Add(entry);
+					return;
+				}
+			}
+
+			Deliver(sink, entry);
+		}
+		catch
+		{
+			// A logger that can end startup is worse than no logger at all.
+		}
+	}
+
+	/// <summary>
+	/// The sink is where Serilog lives, so it gets its own frame that is never inlined into a caller.
+	/// A load failure raised inside it is then contained here rather than surfacing in the middle of
+	/// whatever startup step asked for the log line.
+	/// </summary>
+	[MethodImpl(MethodImplOptions.NoInlining)]
+	private static void Deliver(Action<StartupLogEntry> sink, StartupLogEntry entry)
+	{
+		try
+		{
+			sink(entry);
+		}
+		catch
+		{
+			// see Record
+		}
+	}
+}

--- a/Source/LibationFileManager/StartupRecoveryNotice.cs
+++ b/Source/LibationFileManager/StartupRecoveryNotice.cs
@@ -1,0 +1,17 @@
+namespace LibationFileManager;
+
+/// <summary>
+/// What startup found and repaired before the app came up, and whether restarting into the result is worth
+/// offering the user.
+/// </summary>
+/// <param name="Message">Title and body to show.</param>
+/// <param name="OfferRestart">
+/// True when the install is worth going back into, so the user can be asked whether to restart now. False
+/// when the rollback left files behind, where the honest answer is to install a fresh copy instead, and a
+/// restart prompt would only invite the user into a broken install.
+/// </param>
+public sealed record StartupRecoveryNotice(FatalStartupMessage Message, bool OfferRestart)
+{
+	public string Title => Message.Title;
+	public string Body => Message.Body;
+}

--- a/Source/LibationWinForms/Form1.cs
+++ b/Source/LibationWinForms/Form1.cs
@@ -74,9 +74,6 @@ public partial class Form1 : Form
 
 	private async void Form1_Shown(object? sender, EventArgs e)
 	{
-		if (InstallUpgradeManager.TakeStartupRecoveryAlert() is { } recovery)
-			MessageBox.Show(this, recovery.Body, recovery.Title, MessageBoxButtons.OK, MessageBoxIcon.Warning);
-
 		if (Configuration.Instance.FirstLaunch)
 		{
 			var result = MessageBox.Show(this, "Would you like a guided tour to get started?", "Libation Walkthrough", MessageBoxButtons.YesNo, MessageBoxIcon.Question, MessageBoxDefaultButton.Button1);

--- a/Source/LibationWinForms/Program.cs
+++ b/Source/LibationWinForms/Program.cs
@@ -56,7 +56,7 @@ static class Program
 			// which makes this the safe place to stop. See issue #2001.
 			if (StartupAssemblyBootstrap.RecoverFromIncompleteUpgradeIfNeeded() is { } recovery)
 			{
-				MessageBox.Show(recovery.Body, recovery.Title, MessageBoxButtons.OK, MessageBoxIcon.Warning);
+				ReportRecoveryAndExit(recovery);
 				return;
 			}
 
@@ -139,6 +139,30 @@ static class Program
 		form1 = new Form1();
 		form1.Load += async (_, _) => await LoadLibraryIntoFormAsync(form1, libraryLoadTask);
 		Application.Run(form1);
+	}
+
+	/// <summary>
+	/// Reports what the rollback did and, when the restored install is worth going back into, offers to
+	/// start Libation again. This process cannot carry on either way: it has already loaded the assemblies
+	/// that were just replaced on disk. See issue #2001.
+	/// </summary>
+	private static void ReportRecoveryAndExit(StartupRecoveryNotice recovery)
+	{
+		if (!recovery.OfferRestart)
+		{
+			MessageBox.Show(recovery.Body, recovery.Title, MessageBoxButtons.OK, MessageBoxIcon.Warning);
+			return;
+		}
+
+		var answer = MessageBox.Show(
+			recovery.Body,
+			recovery.Title,
+			MessageBoxButtons.YesNo,
+			MessageBoxIcon.Warning,
+			MessageBoxDefaultButton.Button1);
+
+		if (answer is DialogResult.Yes)
+			InstallRelauncher.TryRelaunch();
 	}
 
 	#region Message Box Handler for LibationUiBase

--- a/Source/LibationWinForms/Program.cs
+++ b/Source/LibationWinForms/Program.cs
@@ -50,7 +50,15 @@ static class Program
 			//***********************************************//
 			// Migrations which must occur before configuration is loaded for the first time. Usually ones which alter the Configuration
 			var config = AppScaffolding.LibationScaffolding.RunPreConfigMigrations();
-			StartupAssemblyBootstrap.RecoverFromIncompleteUpgradeIfNeeded();
+
+			// A rollback swaps install files out from under assemblies this process has already loaded, so
+			// it must not go on to touch the database or open a window. Nothing here has done either yet,
+			// which makes this the safe place to stop. See issue #2001.
+			if (StartupAssemblyBootstrap.RecoverFromIncompleteUpgradeIfNeeded() is { } recovery)
+			{
+				MessageBox.Show(recovery.Body, recovery.Title, MessageBoxButtons.OK, MessageBoxIcon.Warning);
+				return;
+			}
 
 			// Prevent a second instance from racing on the same database, search index, and log file.
 			// Bail out before any database access when we are not the first instance. See issue #1931.
@@ -96,14 +104,23 @@ static class Program
 		}
 		catch (Exception ex)
 		{
-			if (Configuration.Instance.SerilogInitialized)
-				Log.Error(ex, "Fatal error during startup");
+			string? crashLogFile = null;
+			try
+			{
+				if (Configuration.Instance.SerilogInitialized)
+					Log.Error(ex, "Fatal error during startup");
+				else
+					crashLogFile = PreLoggingCrashLog.TryWrite(ex, [("ReleaseIdentifier", LibationScaffolding.ReleaseIdentifier.ToString())]);
+			}
+			catch { /* continue to show the dialog even if logging fails */ }
 
 			var fatalMessage = StartupAssemblyBootstrap.GetFatalStartupMessage(
 				ex,
 				new FatalStartupMessage(
 					"Fatal error, pre-logging",
-					"An unrecoverable error occurred. Since this error happened before logging could be initialized, this error can not be written to the log file."));
+					crashLogFile is null
+						? "An unrecoverable error occurred before logging could be initialized, and it could not be written to a log file. Please include the text below when reporting this."
+						: $"An unrecoverable error occurred before logging could be initialized.{Environment.NewLine}{Environment.NewLine}It was written to:{Environment.NewLine}{crashLogFile}"));
 
 			try
 			{

--- a/Source/_Tests/LibationFileManager.Tests/InstallRelauncherTests.cs
+++ b/Source/_Tests/LibationFileManager.Tests/InstallRelauncherTests.cs
@@ -1,0 +1,118 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.Collections.Generic;
+using System.IO;
+
+namespace LibationFileManager.Tests;
+
+/// <summary>
+/// The restart offered after a rollback. A process that restarts itself is worth being careful with, so the
+/// decision is tested here and only the Process.Start call itself goes untested.
+/// </summary>
+[TestClass]
+[DoNotParallelize]
+public class InstallRelauncherTests
+{
+	private readonly List<string> started = [];
+	private Func<string, bool> originalStarter = null!;
+
+	[TestInitialize]
+	public void Initialize()
+	{
+		originalStarter = InstallRelauncher.StartProcess;
+		InstallRelauncher.StartProcess = executable =>
+		{
+			started.Add(executable);
+			return true;
+		};
+	}
+
+	[TestCleanup]
+	public void Cleanup()
+	{
+		InstallRelauncher.StartProcess = originalStarter;
+		Environment.SetEnvironmentVariable(InstallRelauncher.RelaunchedEnvironmentVariable, null);
+		StartupLog.ResetForTests();
+	}
+
+	[TestMethod]
+	public void TryRelaunch_starts_this_same_executable()
+	{
+		Assert.IsTrue(InstallRelauncher.TryRelaunch());
+
+		Assert.AreEqual(1, started.Count);
+		Assert.AreEqual(Environment.ProcessPath, started[0]);
+	}
+
+	[TestMethod]
+	public void A_launcher_that_fails_is_reported_rather_than_thrown()
+	{
+		InstallRelauncher.StartProcess = _ => throw new InvalidOperationException("no can do");
+
+		Assert.IsFalse(InstallRelauncher.TryRelaunch());
+	}
+
+	[TestMethod]
+	public void A_launcher_that_declines_is_reported_as_not_started()
+	{
+		InstallRelauncher.StartProcess = _ => false;
+
+		Assert.IsFalse(InstallRelauncher.TryRelaunch());
+	}
+
+	// A rollback deletes the pending marker first, so it normally cannot repeat. But that delete swallows
+	// its own failure, and a marker that survives would mean every launch rolls back and offers a restart
+	// again. The child carries a marker of its own so the chain stops at one.
+	[TestMethod]
+	public void A_process_started_by_a_relaunch_knows_it()
+	{
+		Assert.IsFalse(InstallRelauncher.WasRelaunched);
+
+		Environment.SetEnvironmentVariable(InstallRelauncher.RelaunchedEnvironmentVariable, "1");
+
+		Assert.IsTrue(InstallRelauncher.WasRelaunched);
+	}
+
+	[TestMethod]
+	public void The_restart_is_offered_for_an_install_that_was_fully_restored()
+	{
+		Assert.IsTrue(StartupAssemblyBootstrap.ShouldOfferRestart(
+			Rollback(RollbackConfidence.RestoredToPreviousVersion),
+			wasRelaunched: false));
+	}
+
+	[TestMethod]
+	public void The_restart_is_still_offered_for_a_mixed_install_because_it_does_run()
+	{
+		Assert.IsTrue(StartupAssemblyBootstrap.ShouldOfferRestart(
+			Rollback(RollbackConfidence.RestoredButInstallIsMixed),
+			wasRelaunched: false));
+	}
+
+	[TestMethod]
+	public void The_restart_is_withheld_when_the_restore_did_not_finish()
+	{
+		Assert.IsFalse(StartupAssemblyBootstrap.ShouldOfferRestart(
+			Rollback(RollbackConfidence.RestoreIncomplete),
+			wasRelaunched: false));
+	}
+
+	[TestMethod]
+	public void The_restart_is_withheld_in_a_process_that_a_restart_started()
+	{
+		Assert.IsFalse(StartupAssemblyBootstrap.ShouldOfferRestart(
+			Rollback(RollbackConfidence.RestoredToPreviousVersion),
+			wasRelaunched: true));
+	}
+
+	[TestMethod]
+	public void Nothing_is_offered_when_no_rollback_happened()
+	{
+		Assert.IsFalse(StartupAssemblyBootstrap.ShouldOfferRestart(
+			new UpgradeRecoveryResult(false, string.Empty, string.Empty, []),
+			wasRelaunched: false));
+	}
+
+	private static UpgradeRecoveryResult Rollback(RollbackConfidence confidence)
+		=> new(true, "title", "body", []) { Confidence = confidence };
+}

--- a/Source/_Tests/LibationFileManager.Tests/InstallUpgradeManagerTests.cs
+++ b/Source/_Tests/LibationFileManager.Tests/InstallUpgradeManagerTests.cs
@@ -152,6 +152,84 @@ public class InstallUpgradeManagerTests
 		}
 	}
 
+	// The rollback used to restore, announce "Libation restored your previous install files" and delete the
+	// pending marker without ever reading back what it wrote. These three cover the grading that replaced
+	// that assumption, since it decides both how firmly the message pushes a reinstall and whether
+	// restarting is offered at all.
+	[TestMethod]
+	public void An_overlay_that_never_started_leaves_the_previous_version_behind()
+	{
+		WriteInstallFile("LibationUiBase.dll", "old-ui-base");
+		WriteInstallFile("LibationFileManager.dll", "old-file-manager");
+
+		var zipPath = CreateUpgradeZip(
+			("LibationUiBase.dll", "new-ui-base"),
+			("LibationFileManager.dll", "new-file-manager"));
+
+		InstallUpgradeManager.PrepareForUpgrade(_installDir, zipPath, new Version(9, 9, 9));
+
+		// Nothing was replaced: ZipExtractor never ran.
+		var recovery = InstallUpgradeManager.RecoverPendingUpgradeIfNeeded(_installDir);
+
+		Assert.IsNotNull(recovery);
+		Assert.AreEqual(RollbackConfidence.RestoredToPreviousVersion, recovery!.Confidence);
+		Assert.IsTrue(recovery.WorthRestarting);
+		StringAssert.Contains(recovery.Message, "the version you were running before");
+	}
+
+	[TestMethod]
+	public void An_overlay_that_got_partway_leaves_a_mixed_install()
+	{
+		WriteInstallFile("LibationUiBase.dll", "old-ui-base");
+		WriteInstallFile("LibationFileManager.dll", "old-file-manager");
+
+		var zipPath = CreateUpgradeZip(
+			("LibationUiBase.dll", "new-ui-base"),
+			("LibationFileManager.dll", "new-file-manager"));
+
+		InstallUpgradeManager.PrepareForUpgrade(_installDir, zipPath, new Version(9, 9, 9));
+
+		// One file was replaced and one was not, so the overlay was underway when it stopped. The backup
+		// covers a dozen names out of hundreds, so restoring them cannot undo what else it replaced.
+		WriteInstallFile("LibationFileManager.dll", "new-file-manager");
+
+		var recovery = InstallUpgradeManager.RecoverPendingUpgradeIfNeeded(_installDir);
+
+		Assert.IsNotNull(recovery);
+		Assert.AreEqual(RollbackConfidence.RestoredButInstallIsMixed, recovery!.Confidence);
+		Assert.IsTrue(recovery.WorthRestarting, "a mixed install still starts, so restarting stays on offer");
+		StringAssert.Contains(recovery.Message, "mixture of both versions");
+	}
+
+	[TestMethod]
+	public void A_restore_that_cannot_write_every_file_does_not_claim_success()
+	{
+		WriteInstallFile("LibationUiBase.dll", "old-ui-base");
+		WriteInstallFile("LibationFileManager.dll", "old-file-manager");
+
+		var zipPath = CreateUpgradeZip(
+			("LibationUiBase.dll", "new-ui-base"),
+			("LibationFileManager.dll", "new-file-manager"));
+
+		InstallUpgradeManager.PrepareForUpgrade(_installDir, zipPath, new Version(9, 9, 9));
+
+		// Make one backup file unreadable so its restore fails while the other succeeds.
+		var unreadableBackup = Path.Combine(InstallUpgradeManager.GetBackupDirectory(_installDir), "LibationUiBase.dll");
+		using (var exclusive = new FileStream(unreadableBackup, FileMode.Open, FileAccess.Read, FileShare.None))
+		{
+			var recovery = InstallUpgradeManager.RecoverPendingUpgradeIfNeeded(_installDir);
+
+			Assert.IsNotNull(recovery);
+			Assert.AreEqual(RollbackConfidence.RestoreIncomplete, recovery!.Confidence);
+			Assert.IsFalse(recovery.WorthRestarting, "do not invite the user back into an install we could not finish");
+			StringAssert.Contains(recovery.Message, "could not put all of your previous install files back");
+			StringAssert.Contains(recovery.Message, "Could not be restored:");
+
+			// The file it could reach was still restored rather than abandoned.
+			Assert.AreEqual("old-file-manager", File.ReadAllText(Path.Combine(_installDir, "LibationFileManager.dll")));
+		}
+	}
+
 	[TestMethod]
 	public void A_displaced_file_is_swept_up_on_a_later_startup()
 	{

--- a/Source/_Tests/LibationFileManager.Tests/InstallUpgradeManagerTests.cs
+++ b/Source/_Tests/LibationFileManager.Tests/InstallUpgradeManagerTests.cs
@@ -23,6 +23,8 @@ public class InstallUpgradeManagerTests
 	[TestCleanup]
 	public void Cleanup()
 	{
+		StartupLog.ResetForTests();
+
 		try
 		{
 			if (Directory.Exists(_tempRoot))
@@ -83,6 +85,83 @@ public class InstallUpgradeManagerTests
 		Assert.IsNotNull(recoveryAlert);
 		Assert.AreEqual("In-app upgrade failed -- Libation was restored", recoveryAlert.Title);
 		StringAssert.Contains(recoveryAlert.Body, "LibationUiBase.dll");
+	}
+
+	// Issue #2001: the recovery logged through Serilog, and on an install broken badly enough to need
+	// recovering, Serilog itself would not load. The logging call threw from inside the very catch block
+	// that was meant to report the problem, which discarded the real exception and left the rollback undone.
+	// Logging now goes through one sink that swallows its own failures, so prove a hostile sink is harmless.
+	[TestMethod]
+	public void RecoverPendingUpgradeIfNeeded_rolls_back_even_when_every_log_call_throws()
+	{
+		StartupLog.ReplayTo(_ => throw new FileNotFoundException(
+			"Could not load file or assembly 'Serilog, Version=4.3.0.0, Culture=neutral, PublicKeyToken=24c2f752a8e58a10'.",
+			"Serilog, Version=4.3.0.0, Culture=neutral, PublicKeyToken=24c2f752a8e58a10"));
+
+		WriteInstallFile("LibationUiBase.dll", "old-ui-base");
+		WriteInstallFile("LibationFileManager.dll", "old-file-manager");
+
+		var zipPath = CreateUpgradeZip(
+			("LibationUiBase.dll", "new-ui-base"),
+			("LibationFileManager.dll", "new-file-manager"));
+
+		InstallUpgradeManager.PrepareForUpgrade(_installDir, zipPath, new Version(9, 9, 9));
+
+		// A partial overlay: LibationUiBase.dll was never replaced.
+		WriteInstallFile("LibationFileManager.dll", "new-file-manager");
+
+		var recovery = InstallUpgradeManager.RecoverPendingUpgradeIfNeeded(_installDir);
+
+		Assert.IsNotNull(recovery);
+		Assert.IsTrue(recovery!.RolledBack);
+		Assert.AreEqual("old-file-manager", File.ReadAllText(Path.Combine(_installDir, "LibationFileManager.dll")));
+		Assert.IsFalse(File.Exists(InstallUpgradeManager.GetPendingStatePath(_installDir)));
+	}
+
+	// Issue #2001: every backed-up file is an assembly, and by the time startup recovery runs this process
+	// has already loaded and mapped several of them. File.Copy(overwrite: true) over a mapped file segfaulted
+	// the process on Linux and is denied on Windows, so the rollback could never finish.
+	[TestMethod]
+	public void RecoverPendingUpgradeIfNeeded_restores_a_file_that_is_still_open()
+	{
+		WriteInstallFile("LibationUiBase.dll", "old-ui-base");
+		WriteInstallFile("LibationFileManager.dll", "old-file-manager");
+
+		var zipPath = CreateUpgradeZip(
+			("LibationUiBase.dll", "new-ui-base"),
+			("LibationFileManager.dll", "new-file-manager"));
+
+		InstallUpgradeManager.PrepareForUpgrade(_installDir, zipPath, new Version(9, 9, 9));
+
+		WriteInstallFile("LibationUiBase.dll", "new-ui-base");
+		// LibationFileManager.dll keeps its old contents, so verification fails and a rollback follows.
+
+		var openPath = Path.Combine(_installDir, "LibationUiBase.dll");
+		// The sharing mode .NET uses for a loaded assembly: readers and renames allowed, writers denied.
+		using (var held = new FileStream(openPath, FileMode.Open, FileAccess.Read, FileShare.Read | FileShare.Delete))
+		{
+			var recovery = InstallUpgradeManager.RecoverPendingUpgradeIfNeeded(_installDir);
+
+			Assert.IsNotNull(recovery);
+			Assert.IsTrue(recovery!.RolledBack);
+			Assert.AreEqual("old-ui-base", File.ReadAllText(openPath));
+
+			// The handle still reads the file it opened, which is what keeps a loaded assembly working.
+			using var reader = new StreamReader(held);
+			Assert.AreEqual("new-ui-base", reader.ReadToEnd());
+		}
+	}
+
+	[TestMethod]
+	public void A_displaced_file_is_swept_up_on_a_later_startup()
+	{
+		var displaced = Path.Combine(_installDir, "LibationUiBase.dll" + InstallUpgradeManager.DisplacedFileSuffix);
+		File.WriteAllText(displaced, "left behind by an earlier rollback");
+
+		// No pending upgrade, so this is the ordinary startup path.
+		Assert.IsNull(InstallUpgradeManager.RecoverPendingUpgradeIfNeeded(_installDir));
+
+		Assert.IsFalse(File.Exists(displaced));
 	}
 
 	[TestMethod]

--- a/Source/_Tests/LibationFileManager.Tests/PreLoggingCrashLogTests.cs
+++ b/Source/_Tests/LibationFileManager.Tests/PreLoggingCrashLogTests.cs
@@ -1,0 +1,113 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.IO;
+
+namespace LibationFileManager.Tests;
+
+/// <summary>
+/// Issue #2001: the crash dialog told reporters to attach LibationCrash.log, which is not where the record
+/// goes when a Log*.log already exists, so they went looking for a file that was not there. On one run the
+/// record was lost entirely, because a field getter threw and the caller's bare catch swallowed everything.
+/// </summary>
+[TestClass]
+[DoNotParallelize]
+public class PreLoggingCrashLogTests
+{
+	private string tempLibationFiles = null!;
+
+	[TestInitialize]
+	public void Initialize()
+	{
+		tempLibationFiles = Path.Combine(Path.GetTempPath(), $"libation-crash-log-tests-{Guid.NewGuid():N}");
+		Directory.CreateDirectory(tempLibationFiles);
+
+		// A fresh Configuration resolves LibationFiles from this variable, so the crash record lands here.
+		Environment.SetEnvironmentVariable(LibationFiles.LIBATION_FILES_DIR, tempLibationFiles);
+		Configuration.CreateMockInstance();
+	}
+
+	[TestCleanup]
+	public void Cleanup()
+	{
+		Configuration.RestoreSingletonInstance();
+		Environment.SetEnvironmentVariable(LibationFiles.LIBATION_FILES_DIR, null);
+
+		try { Directory.Delete(tempLibationFiles, recursive: true); } catch { }
+	}
+
+	[TestMethod]
+	public void With_no_log_file_yet_the_record_goes_to_LibationCrash_log()
+	{
+		var written = PreLoggingCrashLog.TryWrite(new InvalidOperationException("something went wrong"));
+
+		Assert.AreEqual(Path.Combine(tempLibationFiles, PreLoggingCrashLog.CrashFileName), written);
+		StringAssert.Contains(File.ReadAllText(written!), "something went wrong");
+	}
+
+	[TestMethod]
+	public void An_existing_log_file_gets_the_record_appended_and_is_the_path_reported()
+	{
+		var existingLog = Path.Combine(tempLibationFiles, "Log202608.log");
+		File.WriteAllText(existingLog, "an earlier line with no trailing newline");
+
+		var written = PreLoggingCrashLog.TryWrite(new InvalidOperationException("something went wrong"));
+
+		Assert.AreEqual(existingLog, written);
+
+		var contents = File.ReadAllText(existingLog);
+		StringAssert.Contains(contents, "an earlier line with no trailing newline");
+		StringAssert.Contains(contents, "Libation Crash");
+		Assert.IsFalse(
+			contents.Contains("newline" + DateTime.Now.Year),
+			"the record ran onto the end of the previous log line");
+	}
+
+	[TestMethod]
+	public void The_newest_log_file_is_chosen()
+	{
+		var older = Path.Combine(tempLibationFiles, "Log202607.log");
+		var newer = Path.Combine(tempLibationFiles, "Log202608.log");
+		File.WriteAllText(older, "older\n");
+		File.SetCreationTimeUtc(older, DateTime.UtcNow.AddDays(-30));
+		File.WriteAllText(newer, "newer\n");
+		File.SetCreationTimeUtc(newer, DateTime.UtcNow);
+
+		Assert.AreEqual(newer, PreLoggingCrashLog.TryWrite(new Exception("boom")));
+	}
+
+	[TestMethod]
+	public void Caller_supplied_fields_are_recorded()
+	{
+		var written = PreLoggingCrashLog.TryWrite(
+			new Exception("boom"),
+			[("ReleaseIdentifier", "WindowsAvalonia")]);
+
+		var contents = File.ReadAllText(written!);
+		StringAssert.Contains(contents, "ReleaseIdentifier");
+		StringAssert.Contains(contents, "WindowsAvalonia");
+	}
+
+	// The record has to survive a field that cannot be read. Books throws this early in startup, and
+	// InteropFactory.InteropFunctionsType ran a static constructor that itself needed Serilog.
+	[TestMethod]
+	public void A_field_that_cannot_be_read_does_not_cost_us_the_record()
+	{
+		var written = PreLoggingCrashLog.TryWrite(new InvalidOperationException("the failure that matters"));
+
+		Assert.IsNotNull(written);
+		var contents = File.ReadAllText(written!);
+		StringAssert.Contains(contents, "the failure that matters");
+		StringAssert.Contains(contents, "LibationFiles");
+	}
+
+	[TestMethod]
+	public void A_second_crash_appends_rather_than_replacing_the_first()
+	{
+		PreLoggingCrashLog.TryWrite(new Exception("first crash"));
+		var written = PreLoggingCrashLog.TryWrite(new Exception("second crash"));
+
+		var contents = File.ReadAllText(written!);
+		StringAssert.Contains(contents, "first crash");
+		StringAssert.Contains(contents, "second crash");
+	}
+}

--- a/Source/_Tests/LibationFileManager.Tests/PreLoggingCrashLogTests.cs
+++ b/Source/_Tests/LibationFileManager.Tests/PreLoggingCrashLogTests.cs
@@ -100,6 +100,19 @@ public class PreLoggingCrashLogTests
 		StringAssert.Contains(contents, "LibationFiles");
 	}
 
+	// The path goes straight into the crash dialog for someone to read and paste into a file browser, so it
+	// must not carry the Windows extended-length prefix. Returning the LongPath as-is put "\\?\" in front
+	// of it on Windows only, which Linux and macOS runs cannot notice.
+	[TestMethod]
+	public void The_reported_path_is_the_one_a_person_can_use()
+	{
+		var written = PreLoggingCrashLog.TryWrite(new Exception("boom"));
+
+		Assert.IsNotNull(written);
+		Assert.IsFalse(written!.StartsWith(@"\\?\"), $"reported path should not carry the extended-length prefix: {written}");
+		Assert.IsTrue(File.Exists(written), "the reported path should be usable as-is");
+	}
+
 	[TestMethod]
 	public void A_second_crash_appends_rather_than_replacing_the_first()
 	{

--- a/Source/_Tests/LibationFileManager.Tests/StartupAssemblyBootstrapTests.cs
+++ b/Source/_Tests/LibationFileManager.Tests/StartupAssemblyBootstrapTests.cs
@@ -1,0 +1,115 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.IO;
+
+namespace LibationFileManager.Tests;
+
+/// <summary>
+/// Issue #2001: a startup crash reported nothing more than "Libation encountered a fatal error", because
+/// the assembly that failed to load was Serilog and the classification only knew a handful of names.
+/// </summary>
+[TestClass]
+public class StartupAssemblyBootstrapTests
+{
+	// Serilog is in this test project's own output folder, so the file exists and its version can be read.
+	// Asking for an impossible version is the reporter's situation: an overlay upgrade that left the old
+	// file in place, where the loader reports the same "cannot find the file specified" as for a deletion.
+	private static FileNotFoundException StaleAssemblyFailure(string assembly = "Serilog", string version = "99.0.0.0")
+	{
+		var identity = $"{assembly}, Version={version}, Culture=neutral, PublicKeyToken=24c2f752a8e58a10";
+		return new FileNotFoundException(
+			$"Could not load file or assembly '{identity}'. The system cannot find the file specified.",
+			identity);
+	}
+
+	[TestMethod]
+	public void A_stale_install_file_is_recognised_and_both_versions_are_read()
+	{
+		Assert.IsTrue(StartupAssemblyBootstrap.TryGetInstallAssemblyFailure(StaleAssemblyFailure(), out var failure));
+
+		Assert.IsNotNull(failure);
+		Assert.AreEqual("Serilog", failure!.AssemblyName);
+		Assert.AreEqual(new Version("99.0.0.0"), failure.RequestedVersion);
+		Assert.IsNotNull(failure.InstalledVersion, "Serilog.dll is in this test's own folder, so its version should be readable");
+		Assert.IsTrue(failure.InstalledVersion < failure.RequestedVersion);
+		Assert.AreEqual("Serilog.dll", failure.FileName);
+	}
+
+	[TestMethod]
+	public void A_missing_install_file_is_recognised_with_no_installed_version()
+	{
+		Assert.IsTrue(StartupAssemblyBootstrap.TryGetInstallAssemblyFailure(
+			StaleAssemblyFailure("NoSuchLibationDependency", "1.2.3.4"),
+			out var failure));
+
+		Assert.IsNotNull(failure);
+		Assert.IsNull(failure!.InstalledVersion);
+		StringAssert.Contains(StartupAssemblyBootstrap.DescribeInstallAssemblyFailure(failure), "is missing from the install folder");
+	}
+
+	[TestMethod]
+	public void An_assembly_that_is_present_and_new_enough_is_left_to_someone_else()
+	{
+		// Serilog.dll is right there and satisfies this reference, so whatever went wrong is not a broken
+		// install folder and must not be reported as one.
+		Assert.IsFalse(StartupAssemblyBootstrap.TryGetInstallAssemblyFailure(
+			StaleAssemblyFailure("Serilog", "1.0.0.0"),
+			out var failure));
+
+		Assert.IsNull(failure);
+	}
+
+	// The loader is the only thing that raises a FileNotFoundException carrying an assembly identity.
+	// Libation's own "EF Core is missing" check carries a plain path, and must keep its own message.
+	[TestMethod]
+	public void A_plain_file_path_is_not_mistaken_for_an_assembly_reference()
+	{
+		var ex = new FileNotFoundException(
+			"Required file 'Microsoft.EntityFrameworkCore.Sqlite.dll' was not found in the Libation install folder.",
+			Path.Combine("C:", "Libation", "Microsoft.EntityFrameworkCore.Sqlite.dll"));
+
+		Assert.IsFalse(StartupAssemblyBootstrap.TryGetInstallAssemblyFailure(ex, out _));
+		Assert.AreEqual("Library load failed", StartupAssemblyBootstrap.GetStartupFailureMessage(ex)?.Title);
+	}
+
+	[TestMethod]
+	public void The_message_names_the_file_the_version_it_has_and_the_version_it_needs()
+	{
+		var message = StartupAssemblyBootstrap.GetStartupFailureMessage(StaleAssemblyFailure());
+
+		Assert.IsNotNull(message);
+		Assert.AreEqual("Libation could not load a required file", message!.Title);
+		StringAssert.Contains(message.Body, "Serilog.dll");
+		StringAssert.Contains(message.Body, "99.0.0.0");
+		StringAssert.Contains(message.Body, "troubleshoot#windows-incomplete-in-app-upgrade");
+	}
+
+	// Before this, a Serilog failure matched no predicate, so GetFatalStartupMessage never even looked for
+	// a backup to restore and fell through to the generic crash text.
+	[TestMethod]
+	public void A_stale_install_file_no_longer_falls_through_to_the_generic_crash_message()
+	{
+		var generic = new FatalStartupMessage("Libation Crash", "Libation encountered a fatal error and must close.");
+
+		var message = StartupAssemblyBootstrap.GetFatalStartupMessage(StaleAssemblyFailure(), generic);
+
+		Assert.AreNotEqual(generic.Title, message.Title);
+		Assert.AreNotEqual(generic.Body, message.Body);
+	}
+
+	[TestMethod]
+	public void An_assembly_failure_nested_in_an_AggregateException_is_still_found()
+	{
+		var ex = new AggregateException(new InvalidOperationException("unrelated"), StaleAssemblyFailure());
+
+		Assert.IsTrue(StartupAssemblyBootstrap.TryGetInstallAssemblyFailure(ex, out var failure));
+		Assert.AreEqual("Serilog", failure!.AssemblyName);
+	}
+
+	[TestMethod]
+	public void An_unrelated_failure_is_still_no_ones_problem()
+	{
+		Assert.IsFalse(StartupAssemblyBootstrap.TryGetInstallAssemblyFailure(new InvalidOperationException("nothing to do with files"), out _));
+		Assert.IsNull(StartupAssemblyBootstrap.GetStartupFailureMessage(new InvalidOperationException("nothing to do with files")));
+	}
+}

--- a/Source/_Tests/LibationFileManager.Tests/StartupLogTests.cs
+++ b/Source/_Tests/LibationFileManager.Tests/StartupLogTests.cs
@@ -1,0 +1,84 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+
+namespace LibationFileManager.Tests;
+
+/// <summary>
+/// Issue #2001: startup ran long before Serilog was configured, so its log calls wrote nowhere, and on a
+/// broken install they threw and ended startup instead.
+/// </summary>
+[TestClass]
+[DoNotParallelize]
+public class StartupLogTests
+{
+	[TestInitialize]
+	public void Initialize() => StartupLog.ResetForTests();
+
+	[TestCleanup]
+	public void Cleanup() => StartupLog.ResetForTests();
+
+	[TestMethod]
+	public void Entries_recorded_before_a_sink_exists_are_kept_in_order()
+	{
+		StartupLog.Information("first");
+		StartupLog.Warning("second");
+		StartupLog.Error(new InvalidOperationException("boom"), "third");
+
+		var buffered = StartupLog.BufferedEntries;
+
+		Assert.AreEqual(3, buffered.Count);
+		CollectionAssert.AreEqual(new[] { "first", "second", "third" }, buffered.Select(e => e.Message).ToArray());
+		CollectionAssert.AreEqual(
+			new[] { StartupLogLevel.Information, StartupLogLevel.Warning, StartupLogLevel.Error },
+			buffered.Select(e => e.Level).ToArray());
+		Assert.AreEqual("boom", buffered[2].Exception?.Message);
+	}
+
+	// The point of buffering: these messages used to be dropped even on a healthy install, because
+	// Serilog.Log.Logger is still Serilog's silent logger until logging is configured.
+	[TestMethod]
+	public void Everything_buffered_reaches_the_sink_once_logging_exists()
+	{
+		StartupLog.Information("before");
+
+		var delivered = new List<StartupLogEntry>();
+		StartupLog.ReplayTo(delivered.Add);
+
+		StartupLog.Information("after");
+
+		CollectionAssert.AreEqual(new[] { "before", "after" }, delivered.Select(e => e.Message).ToArray());
+		Assert.AreEqual(0, StartupLog.BufferedEntries.Count, "a replayed entry should not also stay buffered");
+	}
+
+	[TestMethod]
+	public void A_sink_that_throws_is_contained()
+	{
+		StartupLog.ReplayTo(_ => throw new FileNotFoundException(
+			"Could not load file or assembly 'Serilog, Version=4.3.0.0, Culture=neutral, PublicKeyToken=24c2f752a8e58a10'."));
+
+		// The caller is mid-recovery on a broken install. Logging must not be what ends it.
+		StartupLog.Error("this must not throw");
+		StartupLog.Warning(new Exception("nor this"), "still fine");
+	}
+
+	[TestMethod]
+	public void A_sink_that_throws_while_draining_the_buffer_is_contained_too()
+	{
+		StartupLog.Information("buffered before the bad sink arrived");
+
+		StartupLog.ReplayTo(_ => throw new InvalidOperationException("sink is broken"));
+	}
+
+	[TestMethod]
+	public void The_buffer_is_bounded_so_it_cannot_grow_without_a_sink()
+	{
+		for (var i = 0; i < 5_000; i++)
+			StartupLog.Information($"message {i}");
+
+		Assert.IsTrue(StartupLog.BufferedEntries.Count < 5_000, "the buffer should stop growing");
+		Assert.IsTrue(StartupLog.BufferedEntries.Count > 0);
+	}
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes the startup crash in #2001, and the reasons Libation could neither explain it nor repair itself.

## What the reporter hit

`Serilog.dll` in their install folder could not satisfy the `Serilog, Version=4.3.0.0` reference their build carries: either missing, or the 4.2.0 copy from before v13.7.10, where `Dinah.Core` 10.2.4.1 moved `Serilog.Settings.Configuration` to 10.0.1. Both states produce the identical loader message, because the loader rejects a file below the requested version and then reports that it cannot find one.

That is a broken install folder, not a logic bug. What follows is.

## The bugs

**Startup logged through Serilog on the one path where Serilog may not load.** Releases are ReadyToRun, so a Serilog reference resolves lazily when its line runs. `RecoverFromIncompleteUpgradeIfNeeded` logged from inside its own `catch`, and a handler cannot protect itself, so the real exception was replaced by a second load failure carrying a two-frame stack. Worse, `RecoverPendingUpgradeIfNeeded` logged *before* `RollbackAndReport`, so the rollback never ran and `pending.json` survived to crash the next launch too. Those calls were writing nowhere anyway: `Serilog.Log.Logger` is still Serilog's silent logger until `App.RunMigrations`.

New `StartupLog` is a Serilog-free, never-throwing buffer for that window, replayed into Serilog once logging exists. The pre-logging call sites move onto it, including the crash-message and crash-dialog paths that run precisely when the install is broken.

**Classification was by assembly name**, covering only `EntityFrameworkCore`, `Microsoft.Data.Sqlite` and `LibationUiBase`, so a Serilog failure reached neither `TryEmergencyRollback` nor an actionable message. It now matches on the assembly reference and compares the requested version against the file on disk, so the dialog can name the stale file and both versions.

**The rollback overwrote assemblies this process had already loaded.** `File.Copy(overwrite: true)` over a mapped file segfaults the process on Linux and is refused on Windows, so the restore could never complete. It now moves the loaded file aside first and sweeps the leavings on a later startup.

**The rollback never checked its own work.** It restored, announced "Libation restored your previous install files", and deleted the pending marker without reading back what it had written. It also could not distinguish an overlay that had not started, where restoring the backup returns the install to one version, from an overlay that got partway, where the backup covers the dozen names in `GetCriticalFileNames` out of the ~290 files in the folder and cannot. Both now get graded: each restored file is verified against its backup, and manifest files that *did* match the upgrade package are the signal that the overlay had begun.

**`Serilog.dll` was not in the upgrade manifest**, so an overlay could lose it and still verify clean. Added, with three more assemblies startup cannot survive without.

## Also

The crash dialog told reporters to attach `LibationCrash.log`, which is not where the record goes when a `Log*.log` exists, so they went looking for a file that was not there and attached nothing. The Serilog-free crash record moves to `PreLoggingCrashLog` in `LibationFileManager`, shared by both UIs, with every field guarded and the written path returned so the dialog names it. Classic previously wrote nothing at all here.

After a rollback, both entry points report it and quit rather than carrying on with the assemblies in memory no longer matching the files on disk. Libation then offers to start itself again, worded according to how well the rollback went.

The crash dialog was pinned to 450px tall, so the longer message pushed its own exception box and OK button out of the window. Its description is now capped and scrollable.

## Verification

The reported crash now names the file and both versions instead of saying nothing:

[The reporter](https://cursor.com/agents/bc-fa04c8cf-bab2-436a-a065-d8bfd2e93b83/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdialog-before-after.png)

Where a backup exists, which is the reporter's situation since `pending.json` implies `PrepareForUpgrade` ran, the rollback completes and repairs the install. How firmly it pushes a reinstall, and whether restarting is offered at all, follows what it found when it checked itself:

[Three rollback outcomes with correspondingly worded prompts](https://cursor.com/agents/bc-fa04c8cf-bab2-436a-a065-d8bfd2e93b83/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Frestart-prompt-proportional.png)

All three verified on a ReadyToRun self-contained publish, the layout official releases use. Answering Yes starts a detached process from the install folder carrying `LIBATION_RELAUNCHED_AFTER_ROLLBACK=1`, and that copy came up to the normal main window with the displaced files swept. The incomplete-restore case exits without relaunching. A startup message that previously went to the silent logger now appears as `[startup 13:05:51.432] In-app upgrade to 13.7.11.0 verified successfully at startup.`

1657 tests pass across the solution. The rollback test fails against the old copy behaviour with `IOException: The process cannot access the file ... because it is being used by another process`, the same refusal Windows gives for a loaded assembly.

**Not verified:** `LibationWinForms` compiles here but cannot run on Linux, so the Classic dialogs, its new crash record and its restart prompt need a human on Windows, and `MessageBoxLib.ShowAdminAlert` may need the same layout fix. The Windows file-locking behaviour behind the rollback change is inferred from its Linux equivalent rather than observed.


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fa04c8cf-bab2-436a-a065-d8bfd2e93b83?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fa04c8cf-bab2-436a-a065-d8bfd2e93b83&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

