### PR TITLE
Let one account scan more than one Audible marketplace

### DIFF
--- a/Source/ApplicationServices/LibraryCommands.cs
+++ b/Source/ApplicationServices/LibraryCommands.cs
@@ -328,11 +328,22 @@ public static class LibraryCommands
 		{
 			try
 			{
-				// get APIs in serial b/c of logins. do NOT move inside of parallel (Task.WhenAll)
-				var apiExtended = await ApiExtended.CreateAsync(account, allowInteractiveLogin);
+				// An account is scanned as a unit: all of its marketplaces or none of them. A partial scan would
+				// leave the marketplaces that did not run looking empty, and AbsentFromLastScan - which is keyed
+				// by account id, not by marketplace - would mark their titles absent.
+				var accountTasks = new List<Task<List<ImportItem>>>();
 
-				// add scanAccountAsync as a TASK: do not await
-				tasks.Add(scanAccountAsync(apiExtended, account, libraryOptions, archiver));
+				// ScanLocales leads with the account's own marketplace, so any login happens once, up front
+				foreach (var locale in account.ScanLocales)
+				{
+					// get APIs in serial b/c of logins. do NOT move inside of parallel (Task.WhenAll)
+					var apiExtended = await ApiExtended.CreateAsync(account, allowInteractiveLogin, storeLocale: locale);
+
+					// add scanAccountAsync as a TASK: do not await
+					accountTasks.Add(scanAccountAsync(apiExtended, account, locale, libraryOptions, archiver));
+				}
+
+				tasks.AddRange(accountTasks);
 			}
 			catch (Exception ex) when (!allowInteractiveLogin && AuthenticationExceptionHelper.IsAuthenticationFailure(ex))
 			{
@@ -352,23 +363,29 @@ public static class LibraryCommands
 		return new ScanResult(importItems, failedAccounts);
 	}
 
-	private static async Task<List<ImportItem>> scanAccountAsync(ApiExtended apiExtended, Account account, LibraryOptions libraryOptions, LogArchiver? archiver)
+	/// <param name="locale">
+	/// The marketplace being read. Usually the account's own; for an account holding titles under a second
+	/// storefront, each of those in turn. Books are tagged with it, which is how a download later finds its way
+	/// back to the right store.
+	/// </param>
+	private static async Task<List<ImportItem>> scanAccountAsync(ApiExtended apiExtended, Account account, Locale locale, LibraryOptions libraryOptions, LogArchiver? archiver)
 	{
 		ArgumentValidator.EnsureNotNull(account, nameof(account));
-		var locale = ArgumentValidator.EnsureNotNull(account.Locale, nameof(account.Locale));
+		ArgumentValidator.EnsureNotNull(locale, nameof(locale));
 
 		Log.Logger.Information("ImportLibraryAsync. {@DebugInfo}", new
 		{
-			Account = account.MaskedLogEntry ?? "[null]"
+			Account = account.MaskedLogEntry ?? "[null]",
+			LocaleName = locale.Name
 		});
 
-		logTime($"pre scanAccountAsync {account.AccountName}");
+		logTime($"pre scanAccountAsync {account.AccountName} {locale.Name}");
 
 		try
 		{
 			var dtoItems = await apiExtended.GetLibraryValidatedAsync(libraryOptions);
 
-			logTime($"post scanAccountAsync {account.AccountName} qty: {dtoItems.Count}");
+			logTime($"post scanAccountAsync {account.AccountName} {locale.Name} qty: {dtoItems.Count}");
 
 			await logDtoItemsAsync(dtoItems);
 
@@ -385,12 +402,13 @@ public static class LibraryCommands
 		{
 			if (archiver is not null)
 			{
-				var fileName = $"{DateTime.Now:u} {account.MaskedLogEntry}.json";
+				var fileName = $"{DateTime.Now:u} {account.MaskedLogEntry} {locale.Name}.json";
 				var items = await Task.Run(() => JArray.FromObject(dtoItems.Select(i => i.SourceJson)));
 
 				var scanFile = new JObject
 				{
 					{ "Account", account.MaskedLogEntry },
+					{ "Locale", locale.Name },
 					{ "ScannedDateTime", DateTime.Now.ToString("u") },
 				};
 

--- a/Source/AudibleUtilities/Account.cs
+++ b/Source/AudibleUtilities/Account.cs
@@ -5,7 +5,9 @@ using Dinah.Core.Security;
 using LibationFileManager;
 using Newtonsoft.Json;
 using System;
+using System.Collections.Generic;
 using System.Diagnostics;
+using System.Linq;
 
 namespace AudibleUtilities;
 
@@ -86,8 +88,112 @@ public class Account : IUpdatable, ILogMasked
 		}
 	}
 
+	/// <summary>
+	/// The marketplace this account is registered with: where it logs in, and the only place its tokens can be
+	/// refreshed. Every account has exactly one.
+	/// </summary>
 	[JsonIgnore]
 	public Locale? Locale => IdentityTokens?.Locale;
+
+	private readonly List<string> _additionalLocaleNames = new();
+
+	/// <summary>
+	/// <para>
+	/// Further marketplaces this same login holds a library in, beyond <see cref="Locale"/>. A title bought while
+	/// an Amazon address was temporarily set to another country stays in that country's library forever, and only
+	/// a scan of that marketplace will ever see it.
+	/// </para>
+	/// <para>
+	/// Only marketplace names live here - no credentials. Audible honors one device registration across every
+	/// marketplace, so these are read with the very tokens <see cref="Locale"/> registered.
+	/// </para>
+	/// <para>
+	/// Written as null rather than <c>[]</c> when empty, so that the settings file of an account with one
+	/// marketplace - which is nearly all of them - is exactly what it was before this property existed.
+	/// </para>
+	/// </summary>
+	[JsonProperty(PropertyName = "AdditionalLocaleNames", NullValueHandling = NullValueHandling.Ignore)]
+	private List<string>? _additionalLocaleNames_json
+	{
+		get => _additionalLocaleNames.Count == 0 ? null : _additionalLocaleNames;
+		// 'set' is only used by json deser
+		set
+		{
+			if (value is null)
+				return;
+
+			_additionalLocaleNames.Clear();
+			foreach (var name in value.Select(canonicalize).OfType<string>())
+				if (!_additionalLocaleNames.Contains(name) && name != Locale?.Name)
+					_additionalLocaleNames.Add(name);
+		}
+	}
+
+	/// <summary>The additional marketplaces, resolved. Names that no longer match a known locale are dropped.</summary>
+	[JsonIgnore]
+	public IReadOnlyList<Locale> AdditionalLocales
+		=> _additionalLocaleNames.Select(Localization.Get).Where(l => !string.IsNullOrEmpty(l.CountryCode)).ToList();
+
+	/// <summary>
+	/// Every marketplace a scan of this account should read: its own, then any extras. One account is scanned as
+	/// a unit, so that a title found under one marketplace is never counted absent because another was scanned.
+	/// </summary>
+	[JsonIgnore]
+	public IReadOnlyList<Locale> ScanLocales
+		=> Locale is null ? AdditionalLocales : new[] { Locale }.Concat(AdditionalLocales).ToList();
+
+	/// <summary>True if <paramref name="locale"/> is this account's own marketplace or one of its extras.</summary>
+	public bool HasMarketplace(string? localeName)
+		=> canonicalize(localeName) is string name
+		&& (name == Locale?.Name || _additionalLocaleNames.Contains(name));
+
+	/// <summary>Adds an extra marketplace. No-op if it is already this account's own, or already added.</summary>
+	public bool AddMarketplace(string? localeName)
+	{
+		if (canonicalize(localeName) is not string name || HasMarketplace(name))
+			return false;
+
+		_additionalLocaleNames.Add(name);
+		update();
+		return true;
+	}
+
+	public bool RemoveMarketplace(string? localeName)
+	{
+		if (canonicalize(localeName) is not string name || !_additionalLocaleNames.Remove(name))
+			return false;
+
+		update();
+		return true;
+	}
+
+	/// <summary>Replaces the extra marketplaces wholesale. Used by the accounts dialog, which edits a copy.</summary>
+	public void SetAdditionalMarketplaces(IEnumerable<string?> localeNames)
+	{
+		var replacement = (localeNames ?? [])
+			.Select(canonicalize)
+			.OfType<string>()
+			.Where(n => n != Locale?.Name)
+			.Distinct()
+			.ToList();
+
+		if (replacement.SequenceEqual(_additionalLocaleNames))
+			return;
+
+		_additionalLocaleNames.Clear();
+		_additionalLocaleNames.AddRange(replacement);
+		update();
+	}
+
+	/// <summary>
+	/// Store the locale's canonical name, so that a country code ('de') and an internal name ('germany') cannot
+	/// end up in the list as two separate marketplaces.
+	/// </summary>
+	private static string? canonicalize(string? localeName)
+	{
+		var locale = Localization.Get(localeName);
+		return string.IsNullOrEmpty(locale.CountryCode) ? null : locale.Name;
+	}
 
 	public Account(string accountId)
 	{

--- a/Source/AudibleUtilities/Account.cs
+++ b/Source/AudibleUtilities/Account.cs
@@ -129,10 +129,18 @@ public class Account : IUpdatable, ILogMasked
 		}
 	}
 
-	/// <summary>The additional marketplaces, resolved. Names that no longer match a known locale are dropped.</summary>
+	/// <summary>
+	/// The additional marketplaces, resolved. Names that no longer match a known locale are dropped, as is the
+	/// registered marketplace: json is applied in document order, so a file listing these before its
+	/// IdentityTokens would slip a duplicate past the check on the way in, and this marketplace would then be
+	/// scanned twice.
+	/// </summary>
 	[JsonIgnore]
 	public IReadOnlyList<Locale> AdditionalLocales
-		=> _additionalLocaleNames.Select(Localization.Get).Where(l => !string.IsNullOrEmpty(l.CountryCode)).ToList();
+		=> _additionalLocaleNames
+		.Select(Localization.Get)
+		.Where(l => !string.IsNullOrEmpty(l.CountryCode) && l.Name != Locale?.Name)
+		.ToList();
 
 	/// <summary>
 	/// Every marketplace a scan of this account should read: its own, then any extras. One account is scanned as
@@ -142,7 +150,7 @@ public class Account : IUpdatable, ILogMasked
 	public IReadOnlyList<Locale> ScanLocales
 		=> Locale is null ? AdditionalLocales : new[] { Locale }.Concat(AdditionalLocales).ToList();
 
-	/// <summary>True if <paramref name="locale"/> is this account's own marketplace or one of its extras.</summary>
+	/// <summary>True if <paramref name="localeName"/> is this account's own marketplace or one of its extras.</summary>
 	public bool HasMarketplace(string? localeName)
 		=> canonicalize(localeName) is string name
 		&& (name == Locale?.Name || _additionalLocaleNames.Contains(name));

--- a/Source/AudibleUtilities/AccountsSettings.cs
+++ b/Source/AudibleUtilities/AccountsSettings.cs
@@ -108,6 +108,12 @@ public class AccountsSettings : IUpdatable
 		account.Updated += update;
 	}
 
+	/// <summary>
+	/// The account that can speak to <paramref name="locale"/> for this login: the one registered with that
+	/// marketplace, or failing that the one carrying it as an extra marketplace. Callers hand this a book's
+	/// marketplace and get back the credentials that can license it, which is why extras have to resolve here
+	/// as well as the registered marketplace does.
+	/// </summary>
 	public Account? GetAccount(string accountId, string? locale)
 	{
 		if (locale is null)
@@ -116,9 +122,32 @@ public class AccountsSettings : IUpdatable
 		// AccountId is compared case-insensitively: Audible/library data has been observed to differ
 		// only by letter case (e.g. a stored id capitalized differently than settings), which caused
 		// spurious "No account found" failures that blocked every affected book. See issue #1931.
-		return Accounts.SingleOrDefault(a =>
+		var registered = Accounts.SingleOrDefault(a =>
 			a.AccountId.EqualsInsensitive(accountId)
 			&& a.Locale?.Name == locale);
+
+		if (registered is not null)
+			return registered;
+
+		return Accounts.FirstOrDefault(a =>
+			a.AccountId.EqualsInsensitive(accountId)
+			&& a.HasMarketplace(locale));
+	}
+
+	/// <summary>
+	/// The account already scanning <paramref name="localeName"/> for this login, if any. Adding a marketplace,
+	/// importing an audible-cli file, and probing all need to know whether a marketplace is spoken for - including
+	/// by a second row for the same login, which is how multiple marketplaces were handled before one account
+	/// could hold several.
+	/// </summary>
+	public Account? GetAccountClaimingMarketplace(string accountId, string? localeName, Account? excluding = null)
+	{
+		var name = Localization.Get(localeName).Name;
+
+		return Accounts.FirstOrDefault(a =>
+			!ReferenceEquals(a, excluding)
+			&& a.AccountId.EqualsInsensitive(accountId)
+			&& a.HasMarketplace(name));
 	}
 
 	public bool Delete(string accountId, string locale)
@@ -140,24 +169,17 @@ public class AccountsSettings : IUpdatable
 		return result;
 	}
 
+	/// <summary>
+	/// No two rows for one login may scan the same marketplace, or a scan would import it twice and a download
+	/// would have two accounts to choose from. Extra marketplaces count: claiming 'us' as an extra collides with
+	/// another row registered with 'us' just as surely as two 'us' registrations would.
+	/// </summary>
 	private void validate(Account account)
 	{
 		ArgumentValidator.EnsureNotNull(account, nameof(account));
 
-		var accountId = account.AccountId;
-		var locale = account?.IdentityTokens?.Locale?.Name;
-
-		var acct = GetAccount(accountId, locale);
-
-		// new: ok
-		if (acct is null)
-			return;
-
-		// same account instance: ok
-		if (acct == account)
-			return;
-
-		// same account id + locale, different instance: bad
-		throw new InvalidOperationException("Cannot add an account with the same account Id and Locale");
+		foreach (var locale in account.ScanLocales)
+			if (GetAccountClaimingMarketplace(account.AccountId, locale.Name, excluding: account) is not null)
+				throw new InvalidOperationException("Cannot add an account with the same account Id and Locale");
 	}
 }

--- a/Source/AudibleUtilities/ApiExtended.cs
+++ b/Source/AudibleUtilities/ApiExtended.cs
@@ -36,7 +36,11 @@ public class ApiExtended
 	public static Task<ApiExtended> CreateAsync(Account account)
 		=> CreateAsync(account, allowInteractiveLogin: true);
 
-	public static async Task<ApiExtended> CreateAsync(Account account, bool allowInteractiveLogin)
+	/// <param name="storeLocale">
+	/// The marketplace to read, when it is not the one the account is registered with. The account's own tokens
+	/// are used either way; only the store host changes. Null means the account's own marketplace.
+	/// </param>
+	public static async Task<ApiExtended> CreateAsync(Account account, bool allowInteractiveLogin, Locale? storeLocale = null)
 	{
 		ArgumentValidator.EnsureNotNull(account, nameof(account));
 		ArgumentValidator.EnsureNotNull(account.AccountId, nameof(account.AccountId));
@@ -46,13 +50,15 @@ public class ApiExtended
 		{
 			Serilog.Log.Logger.Information("{@DebugInfo}", new
 			{
-				AccountMaskedLogEntry = account.MaskedLogEntry
+				AccountMaskedLogEntry = account.MaskedLogEntry,
+				StoreLocaleName = (storeLocale ?? locale).Name
 			});
 
 			var api = await EzApiCreator.GetApiAsync(
 					locale,
 					AudibleApiStorage.AccountsSettingsFile,
-					account.GetIdentityTokensJsonPath());
+					account.GetIdentityTokensJsonPath(),
+					storeLocale);
 			return new ApiExtended(api);
 		}
 		catch (Exception ex)
@@ -103,6 +109,15 @@ public class ApiExtended
 					locale,
 					AudibleApiStorage.AccountsSettingsFile,
 					account.GetIdentityTokensJsonPath());
+
+				// login happens against the account's own marketplace, so the api it hands back reads that one.
+				// re-create once the tokens exist if some other marketplace is the one actually wanted.
+				if (storeLocale is not null && storeLocale.Name != locale.Name)
+					api = await EzApiCreator.GetApiAsync(
+						locale,
+						AudibleApiStorage.AccountsSettingsFile,
+						account.GetIdentityTokensJsonPath(),
+						storeLocale);
 
 				return new ApiExtended(api);
 			}

--- a/Source/AudibleUtilities/AudibleUtilities.csproj
+++ b/Source/AudibleUtilities/AudibleUtilities.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AudibleApi" Version="11.0.5.1" />
+    <PackageReference Include="AudibleApi" Version="12.0.0.1" />
     <PackageReference Include="Google.Protobuf" Version="3.34.1" />
   </ItemGroup>
 

--- a/Source/AudibleUtilities/AudibleUtilities.csproj
+++ b/Source/AudibleUtilities/AudibleUtilities.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AudibleApi" Version="11.0.4.1" />
+    <PackageReference Include="AudibleApi" Version="11.0.5.1" />
     <PackageReference Include="Google.Protobuf" Version="3.34.1" />
   </ItemGroup>
 

--- a/Source/AudibleUtilities/MarketplaceProbe.cs
+++ b/Source/AudibleUtilities/MarketplaceProbe.cs
@@ -1,0 +1,151 @@
+using AudibleApi;
+using Dinah.Core;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace AudibleUtilities;
+
+public enum MarketplaceProbeOutcome
+{
+	/// <summary>Already scanned: this account's own marketplace, or one it has already been given.</summary>
+	AlreadyScanned,
+	/// <summary>Scanned by a different account row for the same login - the pre-existing way to hold two marketplaces.</summary>
+	ScannedByAnotherAccount,
+	/// <summary>The marketplace answered, and holds titles.</summary>
+	TitlesFound,
+	/// <summary>The marketplace answered, and holds nothing.</summary>
+	Empty,
+	/// <summary>The marketplace could not be asked. Says nothing either way about what is there.</summary>
+	Failed
+}
+
+/// <param name="TitleCount">Titles the marketplace reports, or null when it was not asked or did not answer.</param>
+/// <param name="ClaimedBy">For <see cref="MarketplaceProbeOutcome.ScannedByAnotherAccount"/>, the account already scanning it.</param>
+public record MarketplaceProbeResult(
+	Locale Locale,
+	MarketplaceProbeOutcome Outcome,
+	int? TitleCount = null,
+	string? ClaimedBy = null,
+	string? Error = null)
+{
+	/// <summary>Whether adding this marketplace to the account is something the user can choose to do.</summary>
+	public bool CanAdd => Outcome is MarketplaceProbeOutcome.TitlesFound or MarketplaceProbeOutcome.Empty;
+}
+
+/// <summary>
+/// <para>
+/// Asks each Audible marketplace whether this login holds anything there.
+/// </para>
+/// <para>
+/// A title bought while an Amazon address was briefly set to another country stays in that country's library for
+/// good, and a scan of the account's own marketplace will never see it - no error, no warning, the titles are
+/// simply absent. One device registration is honored by every marketplace, so the only thing standing between
+/// those titles and a scan is knowing which marketplace to look in. That is what this answers.
+/// </para>
+/// <para>
+/// One request per marketplace, in sequence: enough to get a count, and no more traffic or concurrency than a
+/// user who clicked a button should generate. Nothing here runs on its own - the accounts dialog asks for it.
+/// </para>
+/// </summary>
+public static class MarketplaceProbe
+{
+	/// <summary>Space between requests. A deliberate trickle rather than a fan-out.</summary>
+	public static TimeSpan RequestSpacing { get; set; } = TimeSpan.FromMilliseconds(250);
+
+	/// <summary>
+	/// The marketplaces worth asking about for this account. Pre-Amazon locales and modern ones are separate
+	/// worlds with their own logins, so only the account's own kind is probed; asking about the rest would double
+	/// the traffic to learn nothing.
+	/// </summary>
+	public static IReadOnlyList<Locale> CandidateLocales(Account account)
+	{
+		var withUsername = account?.Locale?.WithUsername ?? false;
+
+		return Localization.Locales
+			.Where(l => l.WithUsername == withUsername)
+			.OrderBy(l => l.Name)
+			.ToList();
+	}
+
+	/// <summary>
+	/// Probe every candidate marketplace, yielding each result as it arrives so a dialog can fill in a row at a
+	/// time. Never throws for a single marketplace: one that cannot be reached is reported as such and the rest
+	/// carry on.
+	/// </summary>
+	public static async IAsyncEnumerable<MarketplaceProbeResult> ProbeAsync(
+		Account account,
+		AccountsSettings accountsSettings,
+		[System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken cancellationToken = default)
+	{
+		ArgumentValidator.EnsureNotNull(account, nameof(account));
+		ArgumentValidator.EnsureNotNull(accountsSettings, nameof(accountsSettings));
+
+		var first = true;
+
+		foreach (var locale in CandidateLocales(account))
+		{
+			cancellationToken.ThrowIfCancellationRequested();
+
+			if (account.HasMarketplace(locale.Name))
+			{
+				yield return new MarketplaceProbeResult(locale, MarketplaceProbeOutcome.AlreadyScanned);
+				continue;
+			}
+
+			if (accountsSettings.GetAccountClaimingMarketplace(account.AccountId, locale.Name, excluding: account) is { } other)
+			{
+				yield return new MarketplaceProbeResult(
+					locale,
+					MarketplaceProbeOutcome.ScannedByAnotherAccount,
+					ClaimedBy: AccountCredentialStatus.FormatAccountLabel(other));
+				continue;
+			}
+
+			if (!first)
+				await Task.Delay(RequestSpacing, cancellationToken);
+			first = false;
+
+			yield return await probeOneAsync(account, locale);
+		}
+	}
+
+	private static async Task<MarketplaceProbeResult> probeOneAsync(Account account, Locale locale)
+	{
+		try
+		{
+			// no interactive login: the whole premise is that this account's existing tokens already work here
+			var apiExtended = await ApiExtended.CreateAsync(account, allowInteractiveLogin: false, storeLocale: locale);
+
+			var count = await apiExtended.Api.GetItemsCountAsync(
+				new LibraryOptions { PurchasedAfter = new DateTime(1970, 1, 1) });
+
+			Serilog.Log.Logger.Information(
+				"Marketplace probe: {LocaleName} reported {TitleCount} titles. {@DebugInfo}",
+				locale.Name,
+				count,
+				new { Account = account.MaskedLogEntry });
+
+			// -1 means Audible answered without the count header. it answered, so the marketplace is reachable;
+			// treat it as reachable-but-unknown rather than claiming there is nothing there
+			return count switch
+			{
+				> 0 => new MarketplaceProbeResult(locale, MarketplaceProbeOutcome.TitlesFound, count),
+				0 => new MarketplaceProbeResult(locale, MarketplaceProbeOutcome.Empty, 0),
+				_ => new MarketplaceProbeResult(locale, MarketplaceProbeOutcome.Empty)
+			};
+		}
+		catch (Exception ex)
+		{
+			Serilog.Log.Logger.Information(
+				ex,
+				"Marketplace probe: {LocaleName} could not be checked. {@DebugInfo}",
+				locale.Name,
+				new { Account = account.MaskedLogEntry });
+
+			return new MarketplaceProbeResult(locale, MarketplaceProbeOutcome.Failed, Error: ex.Message);
+		}
+	}
+}

--- a/Source/AudibleUtilities/Mkb79Auth.cs
+++ b/Source/AudibleUtilities/Mkb79Auth.cs
@@ -237,6 +237,12 @@ public partial class Mkb79Auth
 		return account;
 	}
 
+	/// <summary>
+	/// The exported file names one marketplace - the one this account is registered with - because that is all
+	/// the format holds: a single <c>locale_code</c> alongside a single device registration. audible-cli switches
+	/// marketplaces on its own from those same tokens, so nothing is lost to it. Any additional marketplaces
+	/// Libation reads for this account are its own bookkeeping and have no slot here.
+	/// </summary>
 	public static Mkb79Auth FromAccount(Account account)
 		=> new()
 		{

--- a/Source/AudibleUtilities/Mkb79AuthImporter.cs
+++ b/Source/AudibleUtilities/Mkb79AuthImporter.cs
@@ -1,4 +1,4 @@
-using System.Linq;
+using System;
 using System.Threading.Tasks;
 
 namespace AudibleUtilities;
@@ -10,10 +10,37 @@ public enum Mkb79ImportOutcome
 	InvalidFile,
 }
 
-public sealed record Mkb79ImportResult(Mkb79ImportOutcome Outcome, Account? Account = null, string? Message = null);
+/// <param name="ClaimedBy">
+/// For <see cref="Mkb79ImportOutcome.DuplicateAccount"/>, the account already scanning that marketplace. It may
+/// be one registered with it, or one carrying it as an additional marketplace.
+/// </param>
+public sealed record Mkb79ImportResult(
+	Mkb79ImportOutcome Outcome,
+	Account? Account = null,
+	string? Message = null,
+	Account? ClaimedBy = null);
 
 public static class Mkb79AuthImporter
 {
+	/// <summary>
+	/// Why a duplicate import was refused, in the same words everywhere it is refused. Naming the account that
+	/// already reads the marketplace matters now that it need not be a row registered with it - it may be one
+	/// reading it as an additional marketplace, which is not obvious from the accounts grid.
+	/// </summary>
+	public static string DuplicateMessage(Mkb79ImportResult result)
+	{
+		var locale = result.Account?.Locale?.Name ?? "[unknown]";
+
+		if (result.ClaimedBy is { } claimedBy && claimedBy.Locale?.Name != locale)
+			return $"The '{locale}' marketplace is already scanned by the account "
+				+ $"{AccountCredentialStatus.FormatAccountLabel(claimedBy)}, as an additional marketplace. "
+				+ "Nothing was imported.";
+
+		return "An account with that account id and country already exists."
+			+ $"{Environment.NewLine}Account ID: {result.Account?.AccountId}"
+			+ $"{Environment.NewLine}Country: {locale}";
+	}
+
 	/// <summary>
 	/// Deserialize mkb79/audible-cli JSON, refresh tokens, and add the account if not already present.
 	/// </summary>
@@ -32,11 +59,12 @@ public static class Mkb79AuthImporter
 
 		using var persister = AudibleApiStorage.GetAccountsSettingsPersister();
 
-		if (persister.AccountsSettings.Accounts.Any(a =>
-				a.AccountId == account.AccountId && a.IdentityTokens?.Locale.Name == account.Locale?.Name))
-		{
-			return new Mkb79ImportResult(Mkb79ImportOutcome.DuplicateAccount, account);
-		}
+		// An mkb79 file names one marketplace, and a marketplace can only be scanned by one account. Ask about
+		// every claim on it, not just registrations: an existing account may already be reading this marketplace
+		// as an additional one, in which case importing would scan it twice.
+		var claimedBy = persister.AccountsSettings.GetAccountClaimingMarketplace(account.AccountId, account.Locale?.Name);
+		if (claimedBy is not null)
+			return new Mkb79ImportResult(Mkb79ImportOutcome.DuplicateAccount, account, ClaimedBy: claimedBy);
 
 		persister.AccountsSettings.Add(account);
 		return new Mkb79ImportResult(Mkb79ImportOutcome.Success, account);

--- a/Source/LibationAvalonia/Dialogs/AccountsDialog.axaml
+++ b/Source/LibationAvalonia/Dialogs/AccountsDialog.axaml
@@ -87,6 +87,23 @@
 					</DataGridTemplateColumn.CellTemplate>
 				</DataGridTemplateColumn>
 
+				<DataGridTemplateColumn Width="Auto" Header="Marketplaces">
+					<DataGridTemplateColumn.CellTemplate>
+						<DataTemplate>
+
+							<Button
+								Content="{Binding MarketplacesButtonText}"
+								VerticalAlignment="Stretch"
+								HorizontalAlignment="Stretch"
+								HorizontalContentAlignment="Center"
+								IsEnabled="{Binding CanCheckMarketplaces}"
+								ToolTip.Tip="{Binding MarketplacesButtonToolTip}"
+								Click="MarketplacesButton_Clicked" />
+
+						</DataTemplate>
+					</DataGridTemplateColumn.CellTemplate>
+				</DataGridTemplateColumn>
+
 				<DataGridTextColumn
 					Width="Auto"
 					Binding="{Binding AccountName, Mode=TwoWay}"

--- a/Source/LibationAvalonia/Dialogs/AccountsDialog.axaml.cs
+++ b/Source/LibationAvalonia/Dialogs/AccountsDialog.axaml.cs
@@ -3,6 +3,7 @@ using AudibleUtilities;
 using Avalonia.Collections;
 using Avalonia.Controls;
 using Avalonia.Platform.Storage;
+using LibationUiBase;
 using LibationUiBase.Forms;
 using ReactiveUI;
 using System;
@@ -45,6 +46,12 @@ public partial class AccountsDialog : DialogWindow
 		public string? AccountName { get; set; }
 		public bool IsDefault => string.IsNullOrEmpty(AccountId);
 
+		/// <summary>
+		/// Marketplaces beyond <see cref="SelectedLocale"/> that this account should also scan. Edited by the
+		/// marketplaces dialog and written on save, like every other field here.
+		/// </summary>
+		public List<string> AdditionalLocaleNames { get; } = new();
+
 		public bool CanExport
 		{
 			get => field;
@@ -56,6 +63,17 @@ public partial class AccountsDialog : DialogWindow
 				? "Export account authorization to audible-cli"
 				: "Authenticate this account (e.g. library scan) before exporting to audible-cli.";
 
+		/// <summary>
+		/// Checking other marketplaces uses this account's stored credentials, so it needs the same thing an
+		/// export does: an account that has logged in at least once.
+		/// </summary>
+		public bool CanCheckMarketplaces => CanExport;
+
+		public string MarketplacesButtonText => MarketplacesUi.ButtonText(AdditionalLocaleNames.Count + 1);
+
+		public string MarketplacesButtonToolTip
+			=> CanCheckMarketplaces ? MarketplacesUi.ButtonToolTip : MarketplacesUi.NotAuthenticatedToolTip;
+
 		public AccountDto() => RefreshCanExport();
 
 		public AccountDto(Account account)
@@ -64,13 +82,28 @@ public partial class AccountsDialog : DialogWindow
 			AccountId = account.AccountId;
 			SelectedLocale = Locales.Single(l => l.Name == account.Locale?.Name);
 			AccountName = account.AccountName;
+			AdditionalLocaleNames.AddRange(account.AdditionalLocales.Select(l => l.Name));
 			RefreshCanExportFromAccount(account);
+		}
+
+		public void SetAdditionalLocaleNames(IEnumerable<string> localeNames)
+		{
+			AdditionalLocaleNames.Clear();
+			AdditionalLocaleNames.AddRange(localeNames);
+			this.RaisePropertyChanged(nameof(MarketplacesButtonText));
 		}
 
 		private void RefreshCanExportFromAccount(Account account)
 		{
 			CanExport = account.IdentityTokens?.IsValid == true;
+			RaiseDerivedFromCanExport();
+		}
+
+		private void RaiseDerivedFromCanExport()
+		{
 			this.RaisePropertyChanged(nameof(ExportButtonToolTip));
+			this.RaisePropertyChanged(nameof(CanCheckMarketplaces));
+			this.RaisePropertyChanged(nameof(MarketplacesButtonToolTip));
 		}
 
 		private void RefreshCanExport()
@@ -78,7 +111,7 @@ public partial class AccountsDialog : DialogWindow
 			if (string.IsNullOrEmpty(AccountId) || SelectedLocale is null)
 			{
 				CanExport = false;
-				this.RaisePropertyChanged(nameof(ExportButtonToolTip));
+				RaiseDerivedFromCanExport();
 				return;
 			}
 
@@ -86,7 +119,7 @@ public partial class AccountsDialog : DialogWindow
 			var account = persister.AccountsSettings.Accounts.FirstOrDefault(a =>
 				a.AccountId == AccountId && a.Locale?.Name == SelectedLocale.Name);
 			CanExport = account?.IdentityTokens?.IsValid == true;
-			this.RaisePropertyChanged(nameof(ExportButtonToolTip));
+			RaiseDerivedFromCanExport();
 		}
 	}
 
@@ -174,9 +207,9 @@ public partial class AccountsDialog : DialogWindow
 				return;
 			}
 
-			if (importResult.Outcome is Mkb79ImportOutcome.DuplicateAccount && importResult.Account is { } dup)
+			if (importResult.Outcome is Mkb79ImportOutcome.DuplicateAccount && importResult.Account is not null)
 			{
-				await MessageBox.Show(this, $"An account with that account id and country already exists.\r\n\r\nAccount ID: {dup.AccountId}\r\nCountry: {dup.Locale?.Name}", "Cannot Add Duplicate Account");
+				await MessageBox.Show(this, Mkb79AuthImporter.DuplicateMessage(importResult), "Cannot Add Duplicate Account");
 				return;
 			}
 
@@ -197,6 +230,29 @@ public partial class AccountsDialog : DialogWindow
 	{
 		if (e.Source is Button expBtn && expBtn.DataContext is AccountDto acc)
 			Export(acc);
+	}
+
+	public async void MarketplacesButton_Clicked(object sender, Avalonia.Interactivity.RoutedEventArgs e)
+	{
+		if (e.Source is not Button btn || btn.DataContext is not AccountDto acc)
+			return;
+
+		// the probe speaks to Audible with this account's stored credentials, so it needs the saved account,
+		// not the grid's copy of it
+		using var persister = AudibleApiStorage.GetAccountsSettingsPersister();
+		var account = persister.AccountsSettings.Accounts.FirstOrDefault(a =>
+			a.AccountId == acc.AccountId && a.Locale?.Name == acc.SelectedLocale?.Name);
+
+		if (account is null || account.IdentityTokens?.IsValid != true)
+		{
+			await MessageBox.Show(this, MarketplacesUi.NotAuthenticatedToolTip, "Account Not Authenticated");
+			return;
+		}
+
+		var dialog = new MarketplacesDialog(account, persister.AccountsSettings, acc.AdditionalLocaleNames);
+
+		if (await dialog.ShowDialog<DialogResult>(this) == DialogResult.OK)
+			acc.SetAdditionalLocaleNames(dialog.SelectedAdditionalLocaleNames);
 	}
 
 	protected override async Task SaveAndCloseAsync()
@@ -246,6 +302,7 @@ public partial class AccountsDialog : DialogWindow
 		}
 
 		// upsert each. validation occurs through Account and AccountsSettings
+		var upserted = new List<(AccountDto Dto, Account Account)>();
 		foreach (var dto in Accounts.Where(a => a.AccountId is not null))
 		{
 			var acct = accountsSettings.Upsert(dto.AccountId!, dto.SelectedLocale?.Name);
@@ -254,7 +311,15 @@ public partial class AccountsDialog : DialogWindow
 				= string.IsNullOrWhiteSpace(dto.AccountName)
 				? $"{dto.AccountId} - {dto.SelectedLocale?.Name}"
 				: dto.AccountName.Trim();
+
+			// drop every marketplace before assigning any, so that moving one from one account to another in a
+			// single sitting cannot trip the "no two accounts scan one marketplace" rule halfway through
+			acct.SetAdditionalMarketplaces([]);
+			upserted.Add((dto, acct));
 		}
+
+		foreach (var (dto, acct) in upserted)
+			acct.SetAdditionalMarketplaces(dto.AdditionalLocaleNames);
 	}
 	private async Task<bool> inputIsValid()
 	{

--- a/Source/LibationAvalonia/Dialogs/MarketplacesDialog.axaml
+++ b/Source/LibationAvalonia/Dialogs/MarketplacesDialog.axaml
@@ -1,0 +1,81 @@
+<Window
+	xmlns="https://github.com/avaloniaui"
+	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+	xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+	mc:Ignorable="d"
+	d:DesignWidth="560" d:DesignHeight="520"
+	MinWidth="400" MinHeight="360"
+	Width="560" Height="520"
+	x:Class="LibationAvalonia.Dialogs.MarketplacesDialog"
+	xmlns:dialogs="clr-namespace:LibationAvalonia.Dialogs"
+	x:DataType="dialogs:MarketplacesDialog"
+	x:CompileBindings="True"
+	Title="Marketplaces"
+	WindowStartupLocation="CenterOwner">
+
+	<Grid
+		ColumnDefinitions="Auto,*,Auto"
+		RowDefinitions="Auto,Auto,*,Auto,Auto"
+		Margin="10">
+
+		<TextBlock
+			Grid.Row="0"
+			Grid.Column="0"
+			Grid.ColumnSpan="3"
+			TextWrapping="Wrap"
+			Text="{Binding Intro}" />
+
+		<TextBlock
+			Grid.Row="1"
+			Grid.Column="0"
+			Grid.ColumnSpan="3"
+			Margin="0,10,0,0"
+			FontWeight="Bold"
+			Text="{Binding AccountLabel}" />
+
+		<ListBox
+			Grid.Row="2"
+			Grid.Column="0"
+			Grid.ColumnSpan="3"
+			Margin="0,10"
+			Name="lbMarketplaces"
+			ItemsSource="{Binding Marketplaces}">
+			<ListBox.ItemTemplate>
+				<DataTemplate>
+					<CheckBox
+						IsChecked="{Binding IsChecked, Mode=TwoWay}"
+						IsEnabled="{Binding CanCheck}"
+						ToolTip.Tip="{Binding ToolTip}">
+						<TextBlock Text="{Binding Text}" />
+					</CheckBox>
+				</DataTemplate>
+			</ListBox.ItemTemplate>
+		</ListBox>
+
+		<TextBlock
+			Grid.Row="3"
+			Grid.Column="0"
+			Grid.ColumnSpan="3"
+			TextWrapping="Wrap"
+			Margin="0,0,0,10"
+			Name="StatusTextBlock" />
+
+		<Button
+			Grid.Row="4"
+			Grid.Column="0"
+			Padding="20,6"
+			Name="CheckButton"
+			Content="{Binding CheckButtonText}"
+			Click="CheckButton_Clicked" />
+
+		<Button
+			Grid.Row="4"
+			Grid.Column="2"
+			Classes="SaveButton"
+			HorizontalAlignment="Right"
+			Content="Save"
+			Name="SaveButton"
+			Command="{Binding SaveAndClose}" />
+	</Grid>
+</Window>

--- a/Source/LibationAvalonia/Dialogs/MarketplacesDialog.axaml.cs
+++ b/Source/LibationAvalonia/Dialogs/MarketplacesDialog.axaml.cs
@@ -1,0 +1,148 @@
+using AudibleApi;
+using AudibleUtilities;
+using Avalonia.Collections;
+using LibationUiBase;
+using ReactiveUI;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace LibationAvalonia.Dialogs;
+
+/// <summary>
+/// Which Audible marketplaces one account should read. Opened from the accounts grid, and only for an account
+/// that has already logged in - the check is made with that account's own credentials.
+/// </summary>
+public partial class MarketplacesDialog : DialogWindow
+{
+	public string Intro => MarketplacesUi.Intro;
+	public string CheckButtonText => MarketplacesUi.CheckButton;
+	public string AccountLabel { get; } = "";
+
+	public AvaloniaList<ListItem> Marketplaces { get; } = new();
+
+	/// <summary>The additional marketplaces the user checked. The registered one is never among them.</summary>
+	public IReadOnlyList<string> SelectedAdditionalLocaleNames
+		=> Marketplaces
+			.Where(m => m.IsChecked && m.CanCheck)
+			.Select(m => m.Locale.Name)
+			.ToList();
+
+	public class ListItem : ViewModels.ViewModelBase
+	{
+		public ListItem(Locale locale, string text, bool isChecked, bool canCheck, string? toolTip = null)
+		{
+			Locale = locale;
+			Text = text;
+			IsChecked = isChecked;
+			CanCheck = canCheck;
+			ToolTip = toolTip;
+		}
+
+		public Locale Locale { get; }
+		public string Text
+		{
+			get => field;
+			set => this.RaiseAndSetIfChanged(ref field, value);
+		}
+		public bool IsChecked
+		{
+			get => field;
+			set => this.RaiseAndSetIfChanged(ref field, value);
+		}
+		public bool CanCheck
+		{
+			get => field;
+			set => this.RaiseAndSetIfChanged(ref field, value);
+		}
+		public string? ToolTip { get; }
+		public override string ToString() => Text;
+	}
+
+	private readonly Account? account;
+	private readonly AccountsSettings? accountsSettings;
+
+	// parameterless ctor for the axaml designer
+	public MarketplacesDialog()
+	{
+		InitializeComponent();
+		DataContext = this;
+	}
+
+	/// <param name="selectedAdditionalLocaleNames">
+	/// What the accounts grid currently shows for this account, which may not yet be saved.
+	/// </param>
+	public MarketplacesDialog(Account account, AccountsSettings accountsSettings, IEnumerable<string> selectedAdditionalLocaleNames)
+	{
+		InitializeComponent();
+
+		this.account = account;
+		this.accountsSettings = accountsSettings;
+
+		AccountLabel = AccountCredentialStatus.FormatAccountLabel(account);
+
+		var selected = selectedAdditionalLocaleNames.ToHashSet();
+
+		// list every candidate up front, so the dialog is a full picture before anything is asked of Audible
+		foreach (var locale in MarketplaceProbe.CandidateLocales(account))
+		{
+			var isRegistered = locale.Name == account.Locale?.Name;
+
+			Marketplaces.Add(new ListItem(
+				locale,
+				isRegistered
+					? $"{locale.Name} - this account's own marketplace"
+					: locale.Name,
+				isChecked: isRegistered || selected.Contains(locale.Name),
+				canCheck: !isRegistered,
+				toolTip: isRegistered ? "Always scanned. This is where the account is registered." : null));
+		}
+
+		StatusTextBlock.Text = MarketplacesUi.ButtonToolTip;
+		ControlToFocusOnShow = CheckButton;
+		DataContext = this;
+	}
+
+	public async void CheckButton_Clicked(object? sender, Avalonia.Interactivity.RoutedEventArgs e)
+		=> await ProbeAsync();
+
+	public async Task ProbeAsync()
+	{
+		if (account is null || accountsSettings is null)
+			return;
+
+		CheckButton.IsEnabled = false;
+		StatusTextBlock.Text = MarketplacesUi.Checking;
+
+		var results = new List<MarketplaceProbeResult>();
+
+		try
+		{
+			await foreach (var result in MarketplaceProbe.ProbeAsync(account, accountsSettings))
+			{
+				results.Add(result);
+
+				if (Marketplaces.FirstOrDefault(m => m.Locale.Name == result.Locale.Name) is not { } item)
+					continue;
+
+				item.Text = MarketplacesUi.ResultText(result);
+
+				// a marketplace another account already scans must not be checkable here: two rows scanning one
+				// marketplace would import it twice
+				if (result.Outcome is MarketplaceProbeOutcome.ScannedByAnotherAccount or MarketplaceProbeOutcome.Failed)
+					item.CanCheck = false;
+
+				if (result.Outcome is MarketplaceProbeOutcome.TitlesFound)
+					item.IsChecked = true;
+			}
+
+			StatusTextBlock.Text = MarketplacesUi.Summary(results);
+		}
+		finally
+		{
+			CheckButton.IsEnabled = true;
+		}
+	}
+
+	public new void SaveAndClose() => base.SaveAndClose();
+}

--- a/Source/LibationAvalonia/Dialogs/ScanAccountsDialog.axaml.cs
+++ b/Source/LibationAvalonia/Dialogs/ScanAccountsDialog.axaml.cs
@@ -1,5 +1,6 @@
 using AudibleUtilities;
 using Avalonia.Collections;
+using LibationUiBase;
 using LibationUiBase.Forms;
 using System.Collections.Generic;
 using System.Linq;
@@ -17,7 +18,8 @@ public partial class ScanAccountsDialog : DialogWindow
 		{
 			Account = account;
 			IsChecked = account.LibraryScan;
-			Text = $"{account.AccountName} ({account.AccountId} - {account.Locale?.Name})";
+			// lists every marketplace: one checkbox here can scan more than one
+			Text = MarketplacesUi.ScanPickerText(account);
 		}
 		public Account Account { get; }
 		public string Text { get; }

--- a/Source/LibationCli/Options/ImportAccountOptions.cs
+++ b/Source/LibationCli/Options/ImportAccountOptions.cs
@@ -59,10 +59,8 @@ internal class ImportAccountOptions : OptionsBase
 				Console.Error.WriteLine(result.Message ?? "Invalid import file.");
 				Environment.ExitCode = (int)ExitCode.RunTimeError;
 				return;
-			case Mkb79ImportOutcome.DuplicateAccount when result.Account is { } dup:
-				Console.Error.WriteLine(
-					$"An account with that account id and country already exists.{Environment.NewLine}"
-					+ $"Account ID: {dup.AccountId}{Environment.NewLine}Country: {dup.Locale?.Name}");
+			case Mkb79ImportOutcome.DuplicateAccount when result.Account is not null:
+				Console.Error.WriteLine(Mkb79AuthImporter.DuplicateMessage(result));
 				Environment.ExitCode = (int)ExitCode.RunTimeError;
 				return;
 			case Mkb79ImportOutcome.Success when result.Account is { } account:

--- a/Source/LibationCli/Options/ListAccountsOptions.cs
+++ b/Source/LibationCli/Options/ListAccountsOptions.cs
@@ -1,15 +1,16 @@
 using AudibleUtilities;
 using CommandLine;
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 
 namespace LibationCli;
 
-[Verb("list-accounts", HelpText = "List configured Audible accounts: locale, whether the account is included in automatic GUI scans ('Scan library'), and whether stored credentials are valid.")]
+[Verb("list-accounts", HelpText = "List configured Audible accounts: locale, any further marketplaces the account also scans, whether the account is included in automatic GUI scans ('Scan library'), and whether stored credentials are valid.")]
 internal class ListAccountsOptions : OptionsBase
 {
-	[Option('b', "bare", HelpText = "Print tab-separated values without table borders (account id, name, locale, scan library, authenticated).")]
+	[Option('b', "bare", HelpText = "Print tab-separated values without table borders (account id, name, locale, scan library, authenticated, also-scans).")]
 	public bool Bare { get; set; }
 
 	protected override Task ProcessAsync()
@@ -29,28 +30,44 @@ internal class ListAccountsOptions : OptionsBase
 				a.AccountName ?? "",
 				a.Locale?.Name ?? "",
 				a.LibraryScan ? "yes" : "no",
-				a.IdentityTokens?.IsValid == true ? "yes" : "no"))
+				a.IdentityTokens?.IsValid == true ? "yes" : "no",
+				string.Join(", ", a.AdditionalLocales.Select(l => l.Name))))
 			.ToArray();
 
 		if (Bare)
 		{
+			// the extra field goes last and is always present, so a script reading the first five keeps working
 			foreach (var r in rows)
-				Console.WriteLine($"{r.AccountId}\t{r.AccountName}\t{r.Locale}\t{r.LibraryScan}\t{r.Authenticated}");
+				Console.WriteLine($"{r.AccountId}\t{r.AccountName}\t{r.Locale}\t{r.LibraryScan}\t{r.Authenticated}\t{r.AlsoScans}");
 		}
 		else
 		{
-			Console.Out.DrawTable(
-				rows,
-				new TextTableOptions(),
-				new ColumnDef<AccountListRow>("Account ID", r => r.AccountId),
-				new ColumnDef<AccountListRow>("Name", r => r.AccountName),
-				new ColumnDef<AccountListRow>("Locale", r => r.Locale),
-				new ColumnDef<AccountListRow>("Scan library", r => r.LibraryScan),
-				new ColumnDef<AccountListRow>("Authenticated", r => r.Authenticated));
+			// 'Locale' alone would misreport what a scan does for an account reading several marketplaces. The
+			// column is left out entirely when no account has any, which is the ordinary case.
+			var columns = new List<ColumnDef<AccountListRow>>
+			{
+				new("Account ID", r => r.AccountId),
+				new("Name", r => r.AccountName),
+				new("Locale", r => r.Locale)
+			};
+
+			if (rows.Any(r => r.AlsoScans.Length > 0))
+				columns.Add(new ColumnDef<AccountListRow>("Also scans", r => r.AlsoScans));
+
+			columns.Add(new ColumnDef<AccountListRow>("Scan library", r => r.LibraryScan));
+			columns.Add(new ColumnDef<AccountListRow>("Authenticated", r => r.Authenticated));
+
+			Console.Out.DrawTable(rows, new TextTableOptions(), columns.ToArray());
 		}
 
 		return Task.CompletedTask;
 	}
 
-	private sealed record AccountListRow(string AccountId, string AccountName, string Locale, string LibraryScan, string Authenticated);
+	private sealed record AccountListRow(
+		string AccountId,
+		string AccountName,
+		string Locale,
+		string LibraryScan,
+		string Authenticated,
+		string AlsoScans);
 }

--- a/Source/LibationFileManager/LibationFileManager.csproj
+++ b/Source/LibationFileManager/LibationFileManager.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AudibleApi" Version="11.0.4.1" />
+    <PackageReference Include="AudibleApi" Version="11.0.5.1" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="10.0.11" />
     <PackageReference Include="NameParserSharp" Version="1.5.0" />
     <PackageReference Include="Serilog.Exceptions" Version="8.4.0" />

--- a/Source/LibationFileManager/LibationFileManager.csproj
+++ b/Source/LibationFileManager/LibationFileManager.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AudibleApi" Version="11.0.5.1" />
+    <PackageReference Include="AudibleApi" Version="12.0.0.1" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="10.0.11" />
     <PackageReference Include="NameParserSharp" Version="1.5.0" />
     <PackageReference Include="Serilog.Exceptions" Version="8.4.0" />

--- a/Source/LibationUiBase/MarketplacesUi.cs
+++ b/Source/LibationUiBase/MarketplacesUi.cs
@@ -1,0 +1,107 @@
+using AudibleUtilities;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace LibationUiBase;
+
+/// <summary>
+/// Shared copy for the marketplaces feature, so Classic and Chardonnay say the same thing about the same
+/// state. The wording assumes the reader does not know a marketplace other than their own can hold titles -
+/// that is the whole reason they are here.
+/// </summary>
+public static class MarketplacesUi
+{
+	public const string DialogTitle = "Marketplaces";
+
+	public const string Intro
+		= "Audible keeps a separate library for each marketplace. A title bought while your Amazon address was "
+		+ "set to another country stays in that country's library, and Libation only sees the marketplaces "
+		+ "listed here.\r\n\r\nChecking one adds it to this account's library scans. No second login is needed - "
+		+ "your existing credentials work in every marketplace.";
+
+	public const string CheckButton = "Check other marketplaces";
+
+	public const string Checking = "Checking marketplaces...";
+
+	public const string NotAuthenticatedToolTip
+		= "Scan this account's library first, so Libation has credentials to check the other marketplaces with.";
+
+	public const string ButtonToolTip
+		= "See whether this account holds titles in other Audible marketplaces.";
+
+	public const string NoneFound
+		= "No other marketplace holds titles for this account.";
+
+	public const string NoneChecked
+		= "No marketplace could be checked. Scan this account's library to refresh its credentials, then try again.";
+
+	/// <summary>Label for the accounts grid button: the account's marketplaces, at a glance.</summary>
+	public static string ButtonText(int marketplaceCount)
+		=> marketplaceCount > 1 ? $"{DialogTitle} ({marketplaceCount})" : DialogTitle;
+
+	/// <summary>One probed marketplace, as a line in the list.</summary>
+	public static string ResultText(MarketplaceProbeResult result)
+		=> result.Outcome switch
+		{
+			MarketplaceProbeOutcome.AlreadyScanned
+				=> $"{result.Locale.Name} - already scanned by this account",
+			MarketplaceProbeOutcome.ScannedByAnotherAccount
+				=> $"{result.Locale.Name} - already scanned by {result.ClaimedBy}",
+			MarketplaceProbeOutcome.TitlesFound when result.TitleCount == 1
+				=> $"{result.Locale.Name} - 1 title",
+			MarketplaceProbeOutcome.TitlesFound
+				=> $"{result.Locale.Name} - {result.TitleCount} titles",
+			MarketplaceProbeOutcome.Empty when result.TitleCount == 0
+				=> $"{result.Locale.Name} - no titles",
+			MarketplaceProbeOutcome.Empty
+				=> $"{result.Locale.Name} - reachable, title count unknown",
+			_ => $"{result.Locale.Name} - could not be checked ({result.Error})"
+		};
+
+	/// <summary>
+	/// How an account's marketplaces read in a list of accounts. The scan picker in particular has to show
+	/// these: one checkbox there can scan several marketplaces, which would otherwise be invisible.
+	/// </summary>
+	public static string MarketplacesSuffix(Account account)
+	{
+		var extras = account.AdditionalLocales;
+		if (extras.Count == 0)
+			return account.Locale?.Name ?? "";
+
+		return string.Join(", ", new[] { account.Locale?.Name ?? "" }.Concat(extras.Select(l => l.Name)));
+	}
+
+	/// <summary>The row text used by both frontends' scan pickers.</summary>
+	public static string ScanPickerText(Account account)
+		=> $"{account.AccountName} ({account.AccountId} - {MarketplacesSuffix(account)})";
+
+	/// <summary>
+	/// What a probe turned up. A marketplace that could not be reached says nothing about what is in it, so
+	/// failures are never folded into "nothing found" - reporting an unasked marketplace as empty is the exact
+	/// silence this feature exists to break.
+	/// </summary>
+	public static string Summary(IEnumerable<MarketplaceProbeResult> results)
+	{
+		var all = results.ToList();
+
+		var found = all.Where(r => r.Outcome is MarketplaceProbeOutcome.TitlesFound).ToList();
+		var failed = all.Count(r => r.Outcome is MarketplaceProbeOutcome.Failed);
+		var answered = all.Count(r => r.Outcome is MarketplaceProbeOutcome.TitlesFound or MarketplaceProbeOutcome.Empty);
+
+		var unchecked_ = failed == 0
+			? ""
+			: $"\r\n\r\n{failed} marketplace{(failed == 1 ? "" : "s")} could not be checked, so what they hold is unknown.";
+
+		if (found.Count == 0)
+			return answered == 0
+				? NoneChecked
+				: NoneFound + unchecked_;
+
+		var list = string.Join(", ", found.Select(r => $"{r.Locale.Name} ({r.TitleCount})"));
+		var lead = found.Count == 1
+			? $"Found titles in another marketplace: {list}.\r\n\r\nCheck it to include it in library scans."
+			: $"Found titles in {found.Count} other marketplaces: {list}.\r\n\r\nCheck the ones to include in library scans.";
+
+		return lead + unchecked_;
+	}
+}

--- a/Source/LibationUiBase/WalkthroughMessages.cs
+++ b/Source/LibationUiBase/WalkthroughMessages.cs
@@ -75,7 +75,9 @@ public static class WalkthroughMessages
 		= new("Editing Quick Filters", "From here you can edit, delete, and change the order of Quick Filters");
 
 	public static WalkthroughMessage TourFinished { get; }
-		= new("Tour Finished", "You're now ready to begin using Libation.\r\n\r\nEnjoy!");
+		= new(
+			"Tour Finished",
+			"You're now ready to begin using Libation.\r\n\r\nOne thing worth knowing: Audible keeps a separate library for each marketplace. If you have ever changed your Amazon address to another country to buy a title, it lives in that country's library and a normal scan will not find it. Settings > Accounts > Marketplaces checks the other marketplaces for you.\r\n\r\nEnjoy!");
 
 	public static WalkthroughMessage ScanProceed(int accountCount)
 	{

--- a/Source/LibationWinForms/Dialogs/AccountsDialog.Designer.cs
+++ b/Source/LibationWinForms/Dialogs/AccountsDialog.Designer.cs
@@ -36,6 +36,7 @@ namespace LibationWinForms.Dialogs
             this.LibraryScan = new System.Windows.Forms.DataGridViewCheckBoxColumn();
             this.AccountId = new System.Windows.Forms.DataGridViewTextBoxColumn();
             this.Locale = new LocaleColumn();
+            this.Marketplaces = new MarketplacesColumn();
             this.AccountName = new System.Windows.Forms.DataGridViewTextBoxColumn();
             this.importBtn = new System.Windows.Forms.Button();
             ((System.ComponentModel.ISupportInitialize)(this.dataGridView1)).BeginInit();
@@ -79,6 +80,7 @@ namespace LibationWinForms.Dialogs
             this.LibraryScan,
             this.AccountId,
             this.Locale,
+            this.Marketplaces,
             this.AccountName});
             this.dataGridView1.Location = new System.Drawing.Point(14, 14);
             this.dataGridView1.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
@@ -121,6 +123,13 @@ namespace LibationWinForms.Dialogs
             this.Locale.HeaderText = "Locale";
             this.Locale.Name = "Locale";
             this.Locale.Width = 47;
+            // 
+            // Marketplaces
+            // 
+            this.Marketplaces.HeaderText = "Marketplaces";
+            this.Marketplaces.Name = "Marketplaces";
+            this.Marketplaces.Text = "Marketplaces";
+            this.Marketplaces.Width = 90;
             // 
             // AccountName
             // 
@@ -170,6 +179,7 @@ namespace LibationWinForms.Dialogs
 		private System.Windows.Forms.DataGridViewCheckBoxColumn LibraryScan;
 		private System.Windows.Forms.DataGridViewTextBoxColumn AccountId;
 		private LocaleColumn Locale;
+		private MarketplacesColumn Marketplaces;
 		private System.Windows.Forms.DataGridViewTextBoxColumn AccountName;
 	}
 }

--- a/Source/LibationWinForms/Dialogs/AccountsDialog.cs
+++ b/Source/LibationWinForms/Dialogs/AccountsDialog.cs
@@ -337,9 +337,9 @@ public partial class AccountsDialog : Form
 				return;
 			}
 
-			if (importResult.Outcome is Mkb79ImportOutcome.DuplicateAccount && importResult.Account is { } dup)
+			if (importResult.Outcome is Mkb79ImportOutcome.DuplicateAccount && importResult.Account is not null)
 			{
-				MessageBox.Show(this, $"An account with that account id and country already exists.\r\n\r\nAccount ID: {dup.AccountId}\r\nCountry: {dup.Locale?.Name}", "Cannot Add Duplicate Account");
+				MessageBox.Show(this, Mkb79AuthImporter.DuplicateMessage(importResult), "Cannot Add Duplicate Account");
 				return;
 			}
 

--- a/Source/LibationWinForms/Dialogs/AccountsDialog.cs
+++ b/Source/LibationWinForms/Dialogs/AccountsDialog.cs
@@ -1,5 +1,6 @@
 ﻿using AudibleApi;
 using AudibleUtilities;
+using LibationUiBase;
 using System;
 using System.Collections.Generic;
 using System.Drawing;
@@ -18,6 +19,7 @@ public partial class AccountsDialog : Form
 	private const string COL_AccountId = nameof(AccountId);
 	private const string COL_AccountName = nameof(AccountName);
 	private const string COL_Locale = nameof(Locale);
+	private const string COL_Marketplaces = nameof(Marketplaces);
 
 	public AccountsDialog()
 	{
@@ -56,13 +58,19 @@ public partial class AccountsDialog : Form
 
 	private void AddAccountToGrid(Account account)
 	{
+		var additional = account.AdditionalLocales.Select(l => l.Name).ToList();
+
 		var row = dataGridView1.Rows.Add(
 			"X",
 			"Export",
 			account.LibraryScan,
 			account.AccountId,
 			account.Locale?.Name ?? "",
+			MarketplacesUi.ButtonText(additional.Count + 1),
 			account.AccountName ?? "");
+
+		// the extra marketplaces are a list, not a cell value, so the row carries them alongside its cells
+		dataGridView1.Rows[row].Tag = additional;
 
 		dataGridView1[COL_Export, row].ToolTipText = "Export account authorization to audible-cli";
 		UpdateExportCellState(dataGridView1.Rows[row]);
@@ -73,6 +81,9 @@ public partial class AccountsDialog : Form
 		e.Row.Cells[COL_Delete].Value = "X";
 		e.Row.Cells[COL_LibraryScan].Value = true;
 		e.Row.Cells[COL_Export].ReadOnly = true;
+		e.Row.Cells[COL_Marketplaces].Value = MarketplacesUi.ButtonText(1);
+		e.Row.Cells[COL_Marketplaces].ReadOnly = true;
+		e.Row.Tag = new List<string>();
 	}
 
 	private void DataGridView1_CellValueChanged(object? sender, DataGridViewCellEventArgs e)
@@ -109,11 +120,21 @@ public partial class AccountsDialog : Form
 		if (row.IsNewRow || !dataGridView1.Columns.Contains(COL_Export))
 			return;
 
+		// checking other marketplaces speaks to Audible with this account's stored credentials, so it needs the
+		// same thing an export does: an account that has logged in at least once
 		var canExport = AccountRowCanExport(GetAccountId(row), GetLocale(row));
 		row.Cells[COL_Export].ReadOnly = !canExport;
 		row.Cells[COL_Export].ToolTipText = canExport
 			? "Export account authorization to audible-cli"
 			: "Authenticate this account (e.g. library scan) before exporting to audible-cli.";
+
+		if (!dataGridView1.Columns.Contains(COL_Marketplaces))
+			return;
+
+		row.Cells[COL_Marketplaces].ReadOnly = !canExport;
+		row.Cells[COL_Marketplaces].ToolTipText = canExport
+			? MarketplacesUi.ButtonToolTip
+			: MarketplacesUi.NotAuthenticatedToolTip;
 	}
 
 	private void DataGridView1_CellContentClick(object sender, DataGridViewCellEventArgs e)
@@ -137,6 +158,12 @@ public partial class AccountsDialog : Form
 						&& !row.Cells[COL_Export].ReadOnly
 						&& RowToAccountDto(row) is AccountDto accountDto)
 						Export(accountDto);
+					break;
+				case COL_Marketplaces:
+					// if final/edit row: do nothing
+					if (e.RowIndex < dgv.RowCount - 1
+						&& !row.Cells[COL_Marketplaces].ReadOnly)
+						EditMarketplaces(row);
 					break;
 					//case COL_MoveUp:
 					//	// if top: do nothing
@@ -162,7 +189,40 @@ public partial class AccountsDialog : Form
 		this.Close();
 	}
 
-	private record AccountDto(string AccountId, string? AccountName, string LocaleName, bool LibraryScan);
+	private record AccountDto(
+		string AccountId,
+		string? AccountName,
+		string LocaleName,
+		bool LibraryScan,
+		IReadOnlyList<string> AdditionalLocaleNames);
+
+	/// <summary>Opens the marketplaces dialog for one row and takes the result back into the row.</summary>
+	private void EditMarketplaces(DataGridViewRow row)
+	{
+		if (GetAccountId(row) is not string accountId || GetLocale(row) is not string localeName)
+			return;
+
+		// the probe speaks to Audible with this account's stored credentials, so it needs the saved account,
+		// not the grid's copy of it
+		using var persister = AudibleApiStorage.GetAccountsSettingsPersister();
+		var account = persister.AccountsSettings.Accounts.FirstOrDefault(a =>
+			a.AccountId == accountId && a.Locale?.Name == localeName);
+
+		if (account is null || account.IdentityTokens?.IsValid != true)
+		{
+			MessageBox.Show(this, MarketplacesUi.NotAuthenticatedToolTip, "Account Not Authenticated");
+			return;
+		}
+
+		using var dialog = new MarketplacesDialog(account, persister.AccountsSettings, GetAdditionalLocaleNames(row));
+
+		if (dialog.ShowDialog(this) != DialogResult.OK)
+			return;
+
+		var selected = dialog.SelectedAdditionalLocaleNames.ToList();
+		row.Tag = selected;
+		row.Cells[COL_Marketplaces].Value = MarketplacesUi.ButtonText(selected.Count + 1);
+	}
 
 	private void saveBtn_Click(object sender, EventArgs e)
 	{
@@ -224,6 +284,7 @@ public partial class AccountsDialog : Form
 		}
 
 		// upsert each. validation occurs through Account and AccountsSettings
+		var upserted = new List<(AccountDto Dto, Account Account)>();
 		foreach (var dto in dtos)
 		{
 			var acct = accountsSettings.Upsert(dto.AccountId, dto.LocaleName);
@@ -232,7 +293,15 @@ public partial class AccountsDialog : Form
 				= string.IsNullOrWhiteSpace(dto.AccountName)
 				? $"{dto.AccountId} - {dto.LocaleName}"
 				: dto.AccountName.Trim();
+
+			// drop every marketplace before assigning any, so that moving one from one account to another in a
+			// single sitting cannot trip the "no two accounts scan one marketplace" rule halfway through
+			acct.SetAdditionalMarketplaces([]);
+			upserted.Add((dto, acct));
 		}
+
+		foreach (var (dto, acct) in upserted)
+			acct.SetAdditionalMarketplaces(dto.AdditionalLocaleNames);
 	}
 
 	private IEnumerable<DataGridViewRow> getRows()
@@ -258,11 +327,14 @@ public partial class AccountsDialog : Form
 	private static string? GetAccountName(DataGridViewRow row)
 		=> row.Cells[COL_AccountName]?.Value as string;
 
+	private static IReadOnlyList<string> GetAdditionalLocaleNames(DataGridViewRow row)
+		=> row.Tag as List<string> ?? [];
+
 	private static AccountDto? RowToAccountDto(DataGridViewRow row)
 		=> GetAccountId(row) is string accountId
 		&& GetLocale(row) is string localeName
 		&& GetLibraryScan(row) is bool libraryScan
-		? new AccountDto(accountId, GetAccountName(row), localeName, libraryScan)
+		? new AccountDto(accountId, GetAccountName(row), localeName, libraryScan, GetAdditionalLocaleNames(row))
 		: null;
 
 	private string GetAudibleCliAppDataPath()
@@ -381,6 +453,14 @@ public partial class AccountsDialog : Form
 		}
 	}
 
+	public class MarketplacesColumn : DataGridViewButtonColumn
+	{
+		public MarketplacesColumn() : base()
+		{
+			this.CellTemplate = new MarketplacesColumnCell();
+		}
+	}
+
 	public class DeleteColumnCell : AccessibleDataGridViewButtonCell
 	{
 		public DeleteColumnCell() : base("Delete account from Libation")
@@ -397,9 +477,23 @@ public partial class AccountsDialog : Form
 		}
 	}
 
-	public class ExportColumnCell : AccessibleDataGridViewButtonCell
+	public class ExportColumnCell : DisableableButtonCell
 	{
-		public ExportColumnCell() : base("Export account to mkb79/audible-cli format")
+		public ExportColumnCell() : base("Export account to mkb79/audible-cli format") { }
+	}
+
+	public class MarketplacesColumnCell : DisableableButtonCell
+	{
+		public MarketplacesColumnCell() : base("Check which Audible marketplaces this account holds titles in") { }
+	}
+
+	/// <summary>
+	/// A button cell that looks disabled when it is. A read-only <see cref="DataGridViewButtonCell"/> still
+	/// paints as a live button, which invites a click that does nothing.
+	/// </summary>
+	public abstract class DisableableButtonCell : AccessibleDataGridViewButtonCell
+	{
+		protected DisableableButtonCell(string accessibilityName) : base(accessibilityName)
 		{
 			ToolTipText = AccessibilityName;
 		}

--- a/Source/LibationWinForms/Dialogs/MarketplacesDialog.Designer.cs
+++ b/Source/LibationWinForms/Dialogs/MarketplacesDialog.Designer.cs
@@ -1,0 +1,135 @@
+namespace LibationWinForms.Dialogs
+{
+	partial class MarketplacesDialog
+	{
+		private System.ComponentModel.IContainer components = null;
+
+		protected override void Dispose(bool disposing)
+		{
+			if (disposing && (components != null))
+			{
+				components.Dispose();
+			}
+			base.Dispose(disposing);
+		}
+
+		#region Windows Form Designer generated code
+
+		private void InitializeComponent()
+		{
+			this.introLbl = new System.Windows.Forms.Label();
+			this.accountLbl = new System.Windows.Forms.Label();
+			this.marketplacesClb = new System.Windows.Forms.CheckedListBox();
+			this.statusLbl = new System.Windows.Forms.Label();
+			this.checkBtn = new System.Windows.Forms.Button();
+			this.saveBtn = new System.Windows.Forms.Button();
+			this.cancelBtn = new System.Windows.Forms.Button();
+			this.SuspendLayout();
+			// 
+			// introLbl
+			// 
+			this.introLbl.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left)
+			| System.Windows.Forms.AnchorStyles.Right)));
+			this.introLbl.Location = new System.Drawing.Point(14, 14);
+			this.introLbl.Name = "introLbl";
+			this.introLbl.Size = new System.Drawing.Size(516, 76);
+			this.introLbl.TabIndex = 0;
+			// 
+			// accountLbl
+			// 
+			this.accountLbl.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left)
+			| System.Windows.Forms.AnchorStyles.Right)));
+			this.accountLbl.AutoEllipsis = true;
+			this.accountLbl.Font = new System.Drawing.Font("Segoe UI", 9F, System.Drawing.FontStyle.Bold);
+			this.accountLbl.Location = new System.Drawing.Point(14, 96);
+			this.accountLbl.Name = "accountLbl";
+			this.accountLbl.Size = new System.Drawing.Size(516, 19);
+			this.accountLbl.TabIndex = 1;
+			// 
+			// marketplacesClb
+			// 
+			this.marketplacesClb.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom)
+			| System.Windows.Forms.AnchorStyles.Left)
+			| System.Windows.Forms.AnchorStyles.Right)));
+			this.marketplacesClb.CheckOnClick = true;
+			this.marketplacesClb.FormattingEnabled = true;
+			this.marketplacesClb.Location = new System.Drawing.Point(14, 121);
+			this.marketplacesClb.Name = "marketplacesClb";
+			this.marketplacesClb.Size = new System.Drawing.Size(516, 202);
+			this.marketplacesClb.TabIndex = 2;
+			this.marketplacesClb.ItemCheck += new System.Windows.Forms.ItemCheckEventHandler(this.marketplacesClb_ItemCheck);
+			// 
+			// statusLbl
+			// 
+			this.statusLbl.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)
+			| System.Windows.Forms.AnchorStyles.Right)));
+			this.statusLbl.Location = new System.Drawing.Point(14, 331);
+			this.statusLbl.Name = "statusLbl";
+			this.statusLbl.Size = new System.Drawing.Size(516, 60);
+			this.statusLbl.TabIndex = 3;
+			// 
+			// checkBtn
+			// 
+			this.checkBtn.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
+			this.checkBtn.Location = new System.Drawing.Point(14, 399);
+			this.checkBtn.Name = "checkBtn";
+			this.checkBtn.Size = new System.Drawing.Size(190, 27);
+			this.checkBtn.TabIndex = 4;
+			this.checkBtn.UseVisualStyleBackColor = true;
+			this.checkBtn.Click += new System.EventHandler(this.checkBtn_Click);
+			// 
+			// saveBtn
+			// 
+			this.saveBtn.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
+			this.saveBtn.Location = new System.Drawing.Point(342, 399);
+			this.saveBtn.Name = "saveBtn";
+			this.saveBtn.Size = new System.Drawing.Size(88, 27);
+			this.saveBtn.TabIndex = 5;
+			this.saveBtn.Text = "Save";
+			this.saveBtn.UseVisualStyleBackColor = true;
+			this.saveBtn.Click += new System.EventHandler(this.saveBtn_Click);
+			// 
+			// cancelBtn
+			// 
+			this.cancelBtn.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
+			this.cancelBtn.DialogResult = System.Windows.Forms.DialogResult.Cancel;
+			this.cancelBtn.Location = new System.Drawing.Point(442, 399);
+			this.cancelBtn.Name = "cancelBtn";
+			this.cancelBtn.Size = new System.Drawing.Size(88, 27);
+			this.cancelBtn.TabIndex = 6;
+			this.cancelBtn.Text = "Cancel";
+			this.cancelBtn.UseVisualStyleBackColor = true;
+			this.cancelBtn.Click += new System.EventHandler(this.cancelBtn_Click);
+			// 
+			// MarketplacesDialog
+			// 
+			this.AcceptButton = this.saveBtn;
+			this.AutoScaleDimensions = new System.Drawing.SizeF(96F, 96F);
+			this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Dpi;
+			this.CancelButton = this.cancelBtn;
+			this.ClientSize = new System.Drawing.Size(544, 440);
+			this.Controls.Add(this.introLbl);
+			this.Controls.Add(this.accountLbl);
+			this.Controls.Add(this.marketplacesClb);
+			this.Controls.Add(this.statusLbl);
+			this.Controls.Add(this.checkBtn);
+			this.Controls.Add(this.saveBtn);
+			this.Controls.Add(this.cancelBtn);
+			this.MinimumSize = new System.Drawing.Size(460, 400);
+			this.Name = "MarketplacesDialog";
+			this.StartPosition = System.Windows.Forms.FormStartPosition.CenterParent;
+			this.Text = "Marketplaces";
+			this.ResumeLayout(false);
+		}
+
+		#endregion
+
+		private System.Windows.Forms.Label introLbl;
+		private System.Windows.Forms.Label accountLbl;
+		private System.Windows.Forms.CheckedListBox marketplacesClb;
+		private System.Windows.Forms.Label statusLbl;
+		private System.Windows.Forms.Button checkBtn;
+		private System.Windows.Forms.Button saveBtn;
+		private System.Windows.Forms.Button cancelBtn;
+	}
+}

--- a/Source/LibationWinForms/Dialogs/MarketplacesDialog.cs
+++ b/Source/LibationWinForms/Dialogs/MarketplacesDialog.cs
@@ -1,0 +1,127 @@
+using AudibleApi;
+using AudibleUtilities;
+using LibationUiBase;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Windows.Forms;
+
+namespace LibationWinForms.Dialogs;
+
+/// <summary>
+/// Which Audible marketplaces one account should read. Opened from the accounts grid, and only for an account
+/// that has already logged in - the check is made with that account's own credentials.
+/// </summary>
+public partial class MarketplacesDialog : Form
+{
+	private readonly Account account;
+	private readonly AccountsSettings accountsSettings;
+
+	/// <summary>Locale name for each row, by index, so a checked box maps back to a marketplace.</summary>
+	private readonly List<Locale> rowLocales = new();
+
+	/// <summary>The additional marketplaces the user checked. The registered one is never among them.</summary>
+	public IReadOnlyList<string> SelectedAdditionalLocaleNames { get; private set; } = [];
+
+	/// <param name="selectedAdditionalLocaleNames">
+	/// What the accounts grid currently shows for this account, which may not yet be saved.
+	/// </param>
+	public MarketplacesDialog(Account account, AccountsSettings accountsSettings, IEnumerable<string> selectedAdditionalLocaleNames)
+	{
+		this.account = account;
+		this.accountsSettings = accountsSettings;
+
+		InitializeComponent();
+		this.SetLibationIcon();
+
+		introLbl.Text = MarketplacesUi.Intro;
+		accountLbl.Text = AccountCredentialStatus.FormatAccountLabel(account);
+		checkBtn.Text = MarketplacesUi.CheckButton;
+		statusLbl.Text = MarketplacesUi.ButtonToolTip;
+
+		var selected = selectedAdditionalLocaleNames.ToHashSet();
+
+		// list every candidate up front, so the dialog is a full picture before anything is asked of Audible
+		foreach (var locale in MarketplaceProbe.CandidateLocales(account))
+		{
+			var isRegistered = locale.Name == account.Locale?.Name;
+
+			var text = isRegistered
+				? $"{locale.Name} - this account's own marketplace"
+				: locale.Name;
+
+			rowLocales.Add(locale);
+			marketplacesClb.Items.Add(text, isRegistered || selected.Contains(locale.Name));
+		}
+	}
+
+	/// <summary>The account's own marketplace is always scanned and must not be unchecked.</summary>
+	private void marketplacesClb_ItemCheck(object sender, ItemCheckEventArgs e)
+	{
+		if (rowLocales[e.Index].Name == account.Locale?.Name && e.NewValue == CheckState.Unchecked)
+			e.NewValue = CheckState.Checked;
+	}
+
+	private async void checkBtn_Click(object sender, EventArgs e)
+	{
+		checkBtn.Enabled = false;
+		statusLbl.Text = MarketplacesUi.Checking;
+
+		var results = new List<MarketplaceProbeResult>();
+		var unavailable = new HashSet<int>();
+
+		try
+		{
+			await foreach (var result in MarketplaceProbe.ProbeAsync(account, accountsSettings))
+			{
+				results.Add(result);
+
+				var index = rowLocales.FindIndex(l => l.Name == result.Locale.Name);
+				if (index < 0)
+					continue;
+
+				// a marketplace another account already scans must not be checkable here: two rows scanning one
+				// marketplace would import it twice. one that could not be reached is not offered either.
+				var offerable = result.Outcome is not
+					(MarketplaceProbeOutcome.ScannedByAnotherAccount or MarketplaceProbeOutcome.Failed);
+
+				if (!offerable)
+					unavailable.Add(index);
+
+				// replacing the item can reset its check mark, so the intended state is always re-applied
+				var wasChecked = marketplacesClb.GetItemChecked(index);
+				marketplacesClb.Items[index] = MarketplacesUi.ResultText(result);
+				marketplacesClb.SetItemChecked(
+					index,
+					offerable && (wasChecked || result.Outcome is MarketplaceProbeOutcome.TitlesFound));
+			}
+
+			statusLbl.Text = MarketplacesUi.Summary(results);
+			unavailableIndexes = unavailable;
+		}
+		finally
+		{
+			checkBtn.Enabled = true;
+		}
+	}
+
+	private HashSet<int> unavailableIndexes = new();
+
+	private void saveBtn_Click(object sender, EventArgs e)
+	{
+		SelectedAdditionalLocaleNames = marketplacesClb.CheckedIndices
+			.Cast<int>()
+			.Where(i => !unavailableIndexes.Contains(i) && rowLocales[i].Name != account.Locale?.Name)
+			.Select(i => rowLocales[i].Name)
+			.ToList();
+
+		DialogResult = DialogResult.OK;
+		Close();
+	}
+
+	private void cancelBtn_Click(object sender, EventArgs e)
+	{
+		DialogResult = DialogResult.Cancel;
+		Close();
+	}
+}

--- a/Source/LibationWinForms/Dialogs/ScanAccountsDialog.cs
+++ b/Source/LibationWinForms/Dialogs/ScanAccountsDialog.cs
@@ -31,7 +31,8 @@ public partial class ScanAccountsDialog : Form
 			var item = new listItem
 			{
 				Account = account,
-				Text = $"{account.AccountName} ({account.AccountId} - {account.Locale?.Name})"
+				// lists every marketplace: one checkbox here can scan more than one
+				Text = LibationUiBase.MarketplacesUi.ScanPickerText(account)
 			};
 			this.accountsClb.Items.Add(item, account.LibraryScan);
 		}

--- a/Source/_Tests/AudibleUtilities.Tests/AccountTests.cs
+++ b/Source/_Tests/AudibleUtilities.Tests/AccountTests.cs
@@ -546,6 +546,288 @@ public class delete : AccountsTestBase
 	}
 }
 
+/// <summary>
+/// One login can hold a library in more than one marketplace - a title bought while an Amazon address was
+/// briefly set to another country lives there permanently. The account keeps a single registration and simply
+/// records the extra marketplaces it should also read.
+/// </summary>
+[TestClass]
+public class additional_marketplaces : AccountsTestBase
+{
+	private static Account registeredIn(string localeName, string accountId = "user@example.com")
+		=> new(accountId) { IdentityTokens = new Identity(Localization.Get(localeName)) };
+
+	[TestMethod]
+	public void an_account_starts_with_only_its_own_marketplace()
+	{
+		var account = registeredIn("ca");
+
+		account.AdditionalLocales.Should().HaveCount(0);
+		account.ScanLocales.Select(l => l.Name).Should().BeEquivalentTo(["canada"]);
+		account.HasMarketplace("ca").Should().BeTrue();
+		account.HasMarketplace("us").Should().BeFalse();
+	}
+
+	[TestMethod]
+	public void a_scan_reads_the_registered_marketplace_first()
+	{
+		// the registered marketplace is where a login happens, so it has to be the one scanned first
+		var account = registeredIn("ca");
+		account.AddMarketplace("us");
+
+		CollectionAssert.AreEqual(
+			new[] { "canada", "us" },
+			account.ScanLocales.Select(l => l.Name).ToArray());
+	}
+
+	[TestMethod]
+	public void the_registered_marketplace_cannot_be_added_again()
+	{
+		var account = registeredIn("ca");
+
+		account.AddMarketplace("ca").Should().BeFalse();
+		account.ScanLocales.Count.Should().Be(1);
+	}
+
+	[TestMethod]
+	public void a_marketplace_cannot_be_added_twice()
+	{
+		var account = registeredIn("ca");
+
+		account.AddMarketplace("us").Should().BeTrue();
+		account.AddMarketplace("us").Should().BeFalse();
+		account.AdditionalLocales.Count.Should().Be(1);
+	}
+
+	[TestMethod]
+	public void a_country_code_and_a_locale_name_are_the_same_marketplace()
+	{
+		// 'de' and 'germany' name one marketplace; storing both would scan it twice
+		var account = registeredIn("us");
+
+		account.AddMarketplace("de").Should().BeTrue();
+		account.AddMarketplace("germany").Should().BeFalse();
+		account.AdditionalLocales.Single().Name.Should().Be("germany");
+	}
+
+	[TestMethod]
+	public void an_unknown_marketplace_is_refused()
+	{
+		var account = registeredIn("us");
+
+		account.AddMarketplace("atlantis").Should().BeFalse();
+		account.AddMarketplace("").Should().BeFalse();
+		account.AddMarketplace(null).Should().BeFalse();
+		account.AdditionalLocales.Should().HaveCount(0);
+	}
+
+	[TestMethod]
+	public void removing_a_marketplace_leaves_the_registered_one_alone()
+	{
+		var account = registeredIn("ca");
+		account.AddMarketplace("us");
+
+		account.RemoveMarketplace("us").Should().BeTrue();
+		account.RemoveMarketplace("ca").Should().BeFalse();
+		account.ScanLocales.Select(l => l.Name).Should().BeEquivalentTo(["canada"]);
+	}
+
+	[TestMethod]
+	public void adding_a_marketplace_marks_the_settings_dirty()
+	{
+		var account = registeredIn("ca");
+		var updates = 0;
+		account.Updated += (_, _) => updates++;
+
+		account.AddMarketplace("us");
+		updates.Should().Be(1);
+
+		// no change, no save
+		account.AddMarketplace("us");
+		updates.Should().Be(1);
+	}
+
+	[TestMethod]
+	public void a_download_finds_the_account_by_the_marketplace_its_book_came_from()
+	{
+		// this is the lookup FileLiberator uses: (account id, book's marketplace) -> credentials
+		var settings = new AccountsSettings();
+		var account = registeredIn("ca");
+		settings.Add(account);
+		account.AddMarketplace("us");
+
+		settings.GetAccount("user@example.com", "us").Should().BeSameAs(account);
+		settings.GetAccount("user@example.com", "ca").Should().BeSameAs(account);
+		settings.GetAccount("user@example.com", "uk").Should().BeNull();
+	}
+
+	[TestMethod]
+	public void the_registered_account_wins_over_one_holding_the_marketplace_as_an_extra()
+	{
+		var settings = new AccountsSettings();
+		var mine = registeredIn("us", "mine@example.com");
+		var theirs = registeredIn("ca", "theirs@example.com");
+		settings.Add(mine);
+		settings.Add(theirs);
+		theirs.AddMarketplace("uk");
+
+		settings.GetAccount("mine@example.com", "us").Should().BeSameAs(mine);
+		settings.GetAccount("theirs@example.com", "uk").Should().BeSameAs(theirs);
+	}
+
+	[TestMethod]
+	public void two_rows_for_one_login_cannot_scan_the_same_marketplace()
+	{
+		// the older way to hold two marketplaces was two rows for one login. adding a marketplace that another
+		// row already scans would import it twice and leave a download two accounts to choose from.
+		var settings = new AccountsSettings();
+		var ca = registeredIn("ca");
+		var us = registeredIn("us");
+		settings.Add(ca);
+		settings.Add(us);
+
+		Assert.ThrowsExactly<InvalidOperationException>(() => ca.AddMarketplace("us"));
+	}
+
+	[TestMethod]
+	public void a_different_login_may_scan_the_same_marketplace()
+	{
+		var settings = new AccountsSettings();
+		var mine = registeredIn("ca", "mine@example.com");
+		var theirs = registeredIn("uk", "theirs@example.com");
+		settings.Add(mine);
+		settings.Add(theirs);
+
+		mine.AddMarketplace("us");
+		theirs.AddMarketplace("us");
+
+		mine.HasMarketplace("us").Should().BeTrue();
+		theirs.HasMarketplace("us").Should().BeTrue();
+	}
+
+	[TestMethod]
+	public void a_row_registered_with_a_marketplace_blocks_another_row_from_adding_it()
+	{
+		var settings = new AccountsSettings();
+		var ca = registeredIn("ca");
+		settings.Add(ca);
+		ca.AddMarketplace("us");
+
+		// the extra marketplace is a claim as real as a registration
+		Assert.ThrowsExactly<InvalidOperationException>(() => settings.Add(registeredIn("us")));
+	}
+
+	[TestMethod]
+	public void the_account_already_scanning_a_marketplace_can_be_named()
+	{
+		var settings = new AccountsSettings();
+		var ca = registeredIn("ca");
+		ca.AccountName = "Canada";
+		settings.Add(ca);
+
+		settings.GetAccountClaimingMarketplace("user@example.com", "ca").Should().BeSameAs(ca);
+		settings.GetAccountClaimingMarketplace("user@example.com", "ca", excluding: ca).Should().BeNull();
+		settings.GetAccountClaimingMarketplace("user@example.com", "us").Should().BeNull();
+	}
+}
+
+[TestClass]
+public class additional_marketplaces_persistence : AccountsTestBase
+{
+	/// <summary>An account file exactly as it was written before additional marketplaces existed.</summary>
+	private static string OneMarketplaceFile()
+	{
+		var settings = new AccountsSettings();
+		settings.Add(new Account("user@example.com")
+		{
+			AccountName = "Main",
+			IdentityTokens = new Identity(Localization.Get("ca"))
+		});
+		return settings.ToJson();
+	}
+
+	[TestMethod]
+	public void a_file_written_before_this_feature_loads_as_a_single_marketplace_account()
+	{
+		var json = OneMarketplaceFile();
+		JObject.Parse(json)["Accounts"]![0]!["AdditionalLocaleNames"].Should().BeNull();
+
+		var loaded = AccountsSettings.FromJson(json);
+		loaded.BeNotNull();
+
+		var account = loaded.Accounts.Single();
+		account.AdditionalLocales.Should().HaveCount(0);
+		account.ScanLocales.Select(l => l.Name).Should().BeEquivalentTo(["canada"]);
+
+		// and saving it back does not introduce the property
+		JObject.Parse(loaded.ToJson())["Accounts"]![0]!["AdditionalLocaleNames"].Should().BeNull();
+	}
+
+	[TestMethod]
+	public void additional_marketplaces_survive_a_round_trip()
+	{
+		var settings = new AccountsSettings();
+		var account = new Account("user@example.com") { IdentityTokens = new Identity(Localization.Get("ca")) };
+		settings.Add(account);
+		account.AddMarketplace("us");
+		account.AddMarketplace("uk");
+
+		var reloaded = AccountsSettings.FromJson(settings.ToJson());
+		reloaded.BeNotNull();
+
+		CollectionAssert.AreEqual(
+			new[] { "canada", "us", "uk" },
+			reloaded.Accounts.Single().ScanLocales.Select(l => l.Name).ToArray());
+	}
+
+	[TestMethod]
+	public void the_registered_marketplace_is_never_duplicated_into_the_extras_by_a_hand_edited_file()
+	{
+		var jo = JObject.Parse(OneMarketplaceFile());
+		jo["Accounts"]![0]!["AdditionalLocaleNames"]
+			= new JArray("ca", "canada", "us", "us", "atlantis");
+
+		var account = AccountsSettings.FromJson(jo.ToString())!.Accounts.Single();
+
+		account.ScanLocales.Select(l => l.Name).Should().BeEquivalentTo(["canada", "us"]);
+	}
+
+	/// <summary>
+	/// Encrypted tokens are bound to the marketplace they were registered with: the AES-GCM associated data is
+	/// built from Identity.LocaleName. Extra marketplaces must therefore stay out of the identity, or every
+	/// stored token would need re-encrypting.
+	/// </summary>
+	[TestMethod]
+	public void adding_a_marketplace_leaves_the_stored_identity_untouched()
+	{
+		var settings = new AccountsSettings();
+		var account = new Account("user@example.com") { IdentityTokens = new Identity(Localization.Get("ca")) };
+		settings.Add(account);
+
+		var identityBefore = JObject.Parse(settings.ToJson())["Accounts"]![0]!["IdentityTokens"]!.ToString();
+
+		account.AddMarketplace("us");
+
+		JObject.Parse(settings.ToJson())["Accounts"]![0]!["IdentityTokens"]!.ToString()
+			.Should().Be(identityBefore);
+		account.Locale!.Name.Should().Be("canada");
+	}
+
+	/// <summary>
+	/// The identity is located in the file by account id and the identity's own LocaleName. A scan of an extra
+	/// marketplace loads the very same tokens, so the path must not follow the marketplace being read.
+	/// </summary>
+	[TestMethod]
+	public void the_identity_json_path_follows_the_registered_marketplace()
+	{
+		var account = new Account("user@example.com") { IdentityTokens = new Identity(Localization.Get("ca")) };
+		account.AddMarketplace("us");
+
+		account.GetIdentityTokensJsonPath()
+			.Should().Be(AudibleApiStorage.GetIdentityTokensJsonPath("user@example.com", "canada"));
+	}
+}
+
 // account.Id + Locale.Name -- must be unique
 [TestClass]
 public class validate : AccountsTestBase
@@ -799,6 +1081,28 @@ public class SerializedShape : AccountsTestBase
 		CollectionAssert.AreEquivalent(
 			new[] { "AccountId", "AccountName", "LibraryScan", "DecryptKey", "IdentityTokens" },
 			SerializeOneAccount().Properties().Select(p => p.Name).ToArray());
+	}
+
+	[TestMethod]
+	public void additional_marketplaces_are_written_only_when_there_are_some()
+	{
+		// An account with one marketplace - nearly every account - must serialize exactly as it did before
+		// additional marketplaces existed, so that nothing about those files changes.
+		var settings = new AccountsSettings();
+		var account = new Account("user@example.com")
+		{
+			AccountName = "Main",
+			IdentityTokens = new Identity(Localization.Get("ca"))
+		};
+		settings.Add(account);
+
+		((JObject)JObject.Parse(settings.ToJson())["Accounts"]![0]!)
+			.ContainsKey("AdditionalLocaleNames").Should().BeFalse();
+
+		account.AddMarketplace("us");
+
+		JObject.Parse(settings.ToJson())["Accounts"]![0]!["AdditionalLocaleNames"]!
+			.Values<string>().Should().BeEquivalentTo(["us"]);
 	}
 
 	[TestMethod]

--- a/Source/_Tests/AudibleUtilities.Tests/AccountTests.cs
+++ b/Source/_Tests/AudibleUtilities.Tests/AccountTests.cs
@@ -793,6 +793,33 @@ public class additional_marketplaces_persistence : AccountsTestBase
 	}
 
 	/// <summary>
+	/// Newtonsoft applies values in the order the document lists them, so a file naming the marketplaces before
+	/// its IdentityTokens has no registered marketplace to compare against yet. The duplicate has to be caught
+	/// on the way out as well, or this account would scan 'canada' twice.
+	/// </summary>
+	[TestMethod]
+	public void the_registered_marketplace_is_dropped_even_when_the_file_lists_it_first()
+	{
+		var account = (JObject)JObject.Parse(OneMarketplaceFile())["Accounts"]![0]!;
+		var identity = account["IdentityTokens"]!;
+		account.Remove("IdentityTokens");
+
+		var reordered = new JObject
+		{
+			["AccountId"] = account["AccountId"],
+			["AdditionalLocaleNames"] = new JArray("canada", "us"),
+			["IdentityTokens"] = identity
+		};
+
+		var loaded = AccountsSettings
+			.FromJson(new JObject { ["Accounts"] = new JArray(reordered) }.ToString())!
+			.Accounts.Single();
+
+		loaded.ScanLocales.Select(l => l.Name).Should().BeEquivalentTo(["canada", "us"]);
+		loaded.AdditionalLocales.Select(l => l.Name).Should().BeEquivalentTo(["us"]);
+	}
+
+	/// <summary>
 	/// Encrypted tokens are bound to the marketplace they were registered with: the AES-GCM associated data is
 	/// built from Identity.LocaleName. Extra marketplaces must therefore stay out of the identity, or every
 	/// stored token would need re-encrypting.

--- a/Source/_Tests/AudibleUtilities.Tests/Mkb79AuthExportTests.cs
+++ b/Source/_Tests/AudibleUtilities.Tests/Mkb79AuthExportTests.cs
@@ -1,4 +1,6 @@
 using AssertionHelper;
+using AudibleApi;
+using AudibleApi.Authorization;
 using AudibleApi.Cryptography;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Newtonsoft.Json.Linq;
@@ -64,5 +66,29 @@ public class Mkb79AuthExportTests
 		var auth = Mkb79Auth.FromJson(MinimalMkb79Json(j => j["device_private_key"] = "AAAA"));
 		auth.BeNotNull();
 		auth.ToJson().Should().Be(Serialize.ToJson(auth));
+	}
+
+	/// <summary>
+	/// The file carries one marketplace because that is all the format has room for: one locale_code beside one
+	/// device registration. Exporting an account that reads several must still name the one it is registered
+	/// with, so the file stays valid for audible-cli - which switches marketplaces from those same tokens anyway.
+	/// </summary>
+	[TestMethod]
+	public void export_names_the_registered_marketplace_and_leaves_the_additional_ones_out()
+	{
+		var account = new Account("user@example.com")
+		{
+			IdentityTokens = new Identity(Localization.Get("ca"))
+		};
+		account.AddMarketplace("us");
+
+		var jo = JObject.Parse(Mkb79Auth.FromAccount(account).ToJson());
+
+		jo["locale_code"]!.Value<string>().Should().Be("ca");
+		jo["with_username"]!.Value<bool>().Should().BeFalse();
+
+		// nothing in the format records the extra marketplace, so a re-import will not restore it
+		jo.ContainsKey("AdditionalLocaleNames").Should().BeFalse();
+		jo.Properties().Select(p => p.Name).Contains("additional_locale_codes").Should().BeFalse();
 	}
 }

--- a/Source/_Tests/LibationUiBase.Tests/MarketplacesUiTests.cs
+++ b/Source/_Tests/LibationUiBase.Tests/MarketplacesUiTests.cs
@@ -1,0 +1,123 @@
+using AudibleApi;
+using AudibleApi.Authorization;
+using AudibleUtilities;
+using LibationUiBase;
+
+namespace LibationUiBase.Tests;
+
+/// <summary>
+/// The marketplaces summary reports on marketplaces that answered. A marketplace that could not be reached
+/// says nothing about what is in it, and calling it empty would recreate the very silence the feature exists
+/// to break - titles present, and no sign of them anywhere in the app.
+/// </summary>
+[TestClass]
+public class MarketplacesUiTests
+{
+	private static Locale locale(string name) => Localization.Get(name);
+
+	private static MarketplaceProbeResult found(string name, int count)
+		=> new(locale(name), MarketplaceProbeOutcome.TitlesFound, count);
+
+	private static MarketplaceProbeResult empty(string name)
+		=> new(locale(name), MarketplaceProbeOutcome.Empty, 0);
+
+	private static MarketplaceProbeResult failed(string name)
+		=> new(locale(name), MarketplaceProbeOutcome.Failed, Error: "Request could not be authenticated");
+
+	[TestMethod]
+	public void nothing_checked_does_not_claim_there_is_nothing_to_find()
+	{
+		var summary = MarketplacesUi.Summary([failed("canada"), failed("uk")]);
+
+		Assert.AreEqual(MarketplacesUi.NoneChecked, summary);
+		Assert.IsFalse(summary.Contains("No other marketplace holds titles"));
+	}
+
+	[TestMethod]
+	public void every_marketplace_answering_empty_is_a_real_answer()
+		=> Assert.AreEqual(MarketplacesUi.NoneFound, MarketplacesUi.Summary([empty("canada"), empty("uk")]));
+
+	[TestMethod]
+	public void a_marketplace_that_could_not_be_checked_is_called_out_alongside_the_ones_that_could()
+	{
+		var summary = MarketplacesUi.Summary([empty("canada"), failed("uk")]);
+
+		StringAssert.Contains(summary, MarketplacesUi.NoneFound);
+		StringAssert.Contains(summary, "1 marketplace could not be checked");
+	}
+
+	[TestMethod]
+	public void found_titles_are_named_with_their_counts()
+	{
+		var summary = MarketplacesUi.Summary([found("us", 50), empty("uk")]);
+
+		StringAssert.Contains(summary, "us (50)");
+		StringAssert.Contains(summary, "another marketplace");
+	}
+
+	[TestMethod]
+	public void several_finds_are_counted()
+	{
+		var summary = MarketplacesUi.Summary([found("us", 50), found("uk", 3)]);
+
+		StringAssert.Contains(summary, "2 other marketplaces");
+		StringAssert.Contains(summary, "us (50)");
+		StringAssert.Contains(summary, "uk (3)");
+	}
+
+	[TestMethod]
+	public void a_find_still_reports_what_could_not_be_checked()
+	{
+		var summary = MarketplacesUi.Summary([found("us", 50), failed("uk"), failed("japan")]);
+
+		StringAssert.Contains(summary, "us (50)");
+		StringAssert.Contains(summary, "2 marketplaces could not be checked");
+	}
+
+	[TestMethod]
+	public void one_title_is_not_reported_as_titles()
+		=> StringAssert.Contains(
+			MarketplacesUi.ResultText(found("us", 1)),
+			"1 title");
+
+	[TestMethod]
+	public void a_reachable_marketplace_with_no_count_is_not_called_empty()
+		=> StringAssert.Contains(
+			MarketplacesUi.ResultText(new MarketplaceProbeResult(locale("us"), MarketplaceProbeOutcome.Empty)),
+			"title count unknown");
+
+	[TestMethod]
+	public void the_scan_picker_names_every_marketplace_an_account_reads()
+	{
+		var account = new Account("user@example.com")
+		{
+			AccountName = "Mine",
+			IdentityTokens = new Identity(Localization.Get("ca"))
+		};
+		account.AddMarketplace("us");
+
+		var text = MarketplacesUi.ScanPickerText(account);
+
+		StringAssert.Contains(text, "canada");
+		StringAssert.Contains(text, "us");
+	}
+
+	[TestMethod]
+	public void the_scan_picker_reads_as_it_always_did_for_a_single_marketplace_account()
+	{
+		var account = new Account("user@example.com")
+		{
+			AccountName = "Mine",
+			IdentityTokens = new Identity(Localization.Get("ca"))
+		};
+
+		Assert.AreEqual("Mine (user@example.com - canada)", MarketplacesUi.ScanPickerText(account));
+	}
+
+	[TestMethod]
+	public void the_accounts_grid_button_counts_marketplaces_only_when_there_is_more_than_one()
+	{
+		Assert.AreEqual("Marketplaces", MarketplacesUi.ButtonText(1));
+		Assert.AreEqual("Marketplaces (3)", MarketplacesUi.ButtonText(3));
+	}
+}

--- a/docs/advanced/command-line-interface.md
+++ b/docs/advanced/command-line-interface.md
@@ -126,7 +126,9 @@ libationcli list-accounts
 libationcli list-accounts --bare
 ```
 
-`--bare` (`-b`) prints tab-separated values with no table: account id, name, locale, scan library (`yes` / `no`), authenticated (`yes` / `no`), for scripts and `cut` / `awk`.
+`--bare` (`-b`) prints tab-separated values with no table: account id, name, locale, scan library (`yes` / `no`), authenticated (`yes` / `no`), also-scans, for scripts and `cut` / `awk`.
+
+An account can read more than one marketplace - see [Titles bought from another country](/docs/getting-started#titles-bought-from-another-country). When any account does, the table grows an **Also scans** column listing its further marketplaces, since the single **Locale** column would otherwise misreport what a scan covers. The column is omitted when no account has any. `--bare` always emits the field, last, so a script reading the first five keeps working. Marketplaces are added from the GUI: there is no CLI verb for it.
 
 **Scan library** (`yes` / `no`) is the same checkbox as "Include in library scan?" in Accounts: it controls whether the main Libation app includes that account in automatic scans (startup / periodic scan behavior). It does **not** restrict `libationcli scan` with no arguments, which still imports from every configured account unless you pass specific account nicknames or ids.
 

--- a/docs/advanced/troubleshoot.md
+++ b/docs/advanced/troubleshoot.md
@@ -61,9 +61,14 @@ Work down this list. The first two account for most reports, and neither leaves 
 3. **Check what you are importing.** In **Settings > Import**, "Import episodes" and "Import Audible Plus
    books" each exclude titles from every scan. Both are recorded near the top of the log:
    `"ImportEpisodes":true,"ImportPlusTitles":true`.
-4. **Scan again.** Audible occasionally leaves titles out of a scan. Libation re-requests what it notices
+4. **Check the other marketplaces.** Audible keeps a separate library per marketplace. A title bought while
+   your Amazon address was set to another country stays in that country's library, and a scan of your usual
+   marketplace will never see it. **Settings > Accounts > Marketplaces > Check other marketplaces** asks each
+   one what it holds, using the credentials you already have. See
+   [Titles bought from another country](/docs/getting-started#titles-bought-from-another-country).
+5. **Scan again.** Audible occasionally leaves titles out of a scan. Libation re-requests what it notices
    missing, but a title absent from the library listing itself cannot be recovered until Audible sends it.
-5. **Read the scan summary in the log.** Every scan ends with a tally, and anything Libation dropped is named
+6. **Read the scan summary in the log.** Every scan ends with a tally, and anything Libation dropped is named
    just above it:
 
 ```
@@ -73,6 +78,7 @@ Library scan tally. {"LibraryItems":434,"EpisodesFetched":1724,"OrphanedEpisodes
 ```
 
 `PlusTitlesExcluded` or `EpisodeItemsExcluded` above zero means a setting from step 3 is dropping titles.
+Each marketplace an account reads is scanned and tallied separately.
 An `Audible did not return ... catalog products` warning means Audible sent an incomplete response even after
 Libation asked again. `podcast episodes were not imported because their series parent was missing` names each
 episode that was dropped.

--- a/docs/frequently-asked-questions.md
+++ b/docs/frequently-asked-questions.md
@@ -85,6 +85,16 @@ Like many countries, amazon gives South Africa it's own amazon site. [Unlike man
 
 (Not exactly a *frequently* asked question but it's come up more than once)
 
+## Some Of My Books Are Missing From The Scan
+
+If you have ever changed your Amazon address to another country to buy a title that was not sold in your own, that title is in **that country's** Audible library and has stayed there ever since. Audible keeps a separate library per marketplace, so a scan of your usual one will never see it - there is no error and no warning, the titles are simply not there.
+
+Open **Settings -> Accounts**, click **Marketplaces** on the account's row, and click **Check other marketplaces**. Libation asks every marketplace how many titles it holds using the credentials you already have - no second login - and you tick the ones to include. After that, one scan of that account covers all of them.
+
+The button is only available once the account has signed in, so run a scan first if it looks greyed out. See [Getting Started - Titles bought from another country](/docs/getting-started#titles-bought-from-another-country).
+
+If the titles are missing for some other reason, check whether they are marked [absent from your last scan](/docs/advanced/troubleshoot) instead.
+
 ## My Audible Account Is From Before Amazon - How Do I Add It?
 
 Choose a **pre-amazon** locale (US, UK, or Germany) in the region dropdown, and enter your old Audible **username** in the Audible email/login field - not an email address. Details: [Getting Started - Create Accounts](/docs/getting-started#create-accounts).

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -49,6 +49,14 @@ Create your account(s):
 Most people use a normal region and their Audible **email**. If your account predates Amazon and still signs in with a **username**, choose a **pre-amazon** locale and put that username in the Audible email/login field.
 :::
 
+### Titles bought from another country
+
+Audible keeps a **separate library for each marketplace**. If you have ever changed your Amazon address to another country to buy a title that was not sold in your own - a common way to get around region-locked titles - that title stayed in that country's library. Scanning your usual marketplace will never find it, and nothing in Libation will suggest it is missing.
+
+The **Marketplaces** button on each account row checks the other marketplaces for you. Your existing credentials work in all of them, so there is no second login: Libation asks each one how many titles it holds, and you tick the ones to include. From then on a scan of that account covers every marketplace you ticked, all in one go.
+
+The button becomes available once the account has signed in, so scan your library once first.
+
 ## Import Your Library
 
 Be default, Libation will periodically scan the accounts you added above with a checkbox next to them. Nothing for you to do. You can also scan manually.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes #1983.

A title bought while an Amazon address was briefly set to another country stays in that country's Audible library for good. A scan of the account's own marketplace never sees it - no error, no warning, the titles are simply absent. The reporter had 50 such titles in `us` under an account they use as `ca`, and only found them by querying the API themselves.

The workaround was to add the same login a second time under the other marketplace, which requires knowing it is there and logging in again. This makes it discoverable instead.

[marketplaces_demo.mp4](https://cursor.com/agents/bc-ea951c43-e78b-4856-8f04-cd08e52b6d3e/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fmarketplaces_demo.mp4)

## What it does

Each account row gets a **Marketplaces** button. It opens a dialog that asks every marketplace how many titles this login holds there, and lets the user tick the ones to scan. From then on, one scan of that account covers all of them.

Audible honors one device registration across every marketplace, so there is no second login and no second set of tokens - only the store host changes.

## What it costs when you do not use it

Nothing measurable. The probe is one request per marketplace, in sequence, and runs only when the button is clicked - never on a scan, a login, or a schedule. An account with one marketplace scans exactly as it did, and its settings file is byte-for-byte what it was: the new property is omitted entirely when empty.

For scale, an ordinary scan pages the library 50 items at a time over 10 concurrent connections. A one-off trickle of eleven single-item GETs is not in the same league.

## Stored credentials: nothing moves

This was the constraint the design was built around, so it is worth being explicit.

- Encrypted tokens are bound to their marketplace by AES-GCM associated data built from `Identity.LocaleName`, and the identity is located in the settings file by that same name. The extra marketplaces are **locale names alone**, held on `Account` and never on `Identity`, so both keep resolving to the registration that already exists. **No re-encryption, no migration, no re-login.**
- **Upgrading:** an old file has no such property, so it loads as a single-marketplace account. No file is rewritten.
- **Downgrading:** an older Libation ignores the property on load but does not emit it on save, so a downgrade-and-save **silently drops the extra marketplaces**. Those books stay in the library but cannot find an account to download from until the marketplace is re-added. Omitting the property when empty confines this to people who actually used the feature. Worth a release-note line.
- **Existing duplicate rows** (the current recommended workaround) keep working untouched. The probe recognizes a marketplace another row already holds and reports it as configured rather than offering it. Consolidating two rows is deliberately not attempted - it would mean choosing which registration to discard.

## mkb79 / audible-cli import and export

The format has one `locale_code` beside one device registration, and audible-cli keeps one file per marketplace. So:

- **Export is unchanged.** It still names the marketplace the account is registered with. The file stays valid for audible-cli, which switches marketplaces from those same tokens anyway. Extra marketplaces are Libation-side bookkeeping with no slot in the format, so an export-then-reimport loses that list and nothing else - a test says so.
- **Import** now checks *every* claim on the marketplace rather than just registrations, so a file whose marketplace an existing account already reads as an extra is caught instead of silently creating a conflicting row. The refusal names the account responsible.

## UI, docs, and the tour

- **Accounts dialog** (both frontends): a Marketplaces column, enabled on the same condition as Export - an account that has logged in at least once, since the check uses its credentials. The button shows a count when there is more than one.
- **Scan picker** (both frontends): now lists an account's marketplaces, because one checkbox there can scan several.
- **`list-accounts`**: gains an **Also scans** column, since printing one locale for an account reading three misreports what a scan does. It appears only when some account has extras; `--bare` always emits the field last, so a script reading the first five keeps working. No CLI probe verb.
- **The tour** mentions marketplaces at the end rather than at the accounts step - that step runs before any login, so the button is necessarily disabled while the user is looking at it.
- **Docs**: a new getting-started section, an FAQ entry filed under the symptom ("some of my books are missing"), plus troubleshooting and CLI updates.

Unchanged on purpose: the database schema, `Book.Locale`, `LibraryBook.Account`, download resolution, naming templates, and search. A book already records which marketplace it came from, which is what lets a download find its way back to the right store, and what answers "why do I suddenly have these books".

## Verification

- `dotnet test` from `Source/`: **1664 tests, 0 failures** (23 skipped, the usual opt-in OS-secret-store ones). New coverage for the settings round trip, old-file/new-file compatibility, the cross-row uniqueness rule, the identity and its encryption staying put, the mkb79 round trip, and the probe summary wording.
- **Exercised in the running app on Linux** (the video): the button gating, the dialog, adding and removing a marketplace, the count updating, the settings file afterwards, the scan picker text, and `list-accounts`. The probe reached all eleven marketplace hosts for real.
- One bug this caught: after every marketplace failed to answer, the summary said "No other marketplace holds titles for this account" - asserting a negative that had never been established, which is precisely the silence this feature exists to break. Unreachable marketplaces are now reported as unchecked, with a test.
- **WinForms is compile-checked only.** It builds here via `EnableWindowsTargeting` but cannot run on Linux, so the new dialog's layout still needs a look on Windows.
- The accounts screenshots in `docs/getting-started.md` predate the new column and need retaking on Windows.

## Not verified, and worth a real account before release

Library reads across marketplaces are proven. Two things are not, and neither can be from here:

1. **Licensing and downloading** a title from a non-registered marketplace. The CDS host now follows the store locale, which is the intent, but only a real region-locked title can confirm it end to end.
2. **Token refresh longevity** under this usage.

The reporter on #1983 offered their verification script and has an account with exactly this split.

## Depends on

[AudibleApi #82](https://github.com/rmcrackan/AudibleApi/pull/82), which adds the store-locale override. This branch references `AudibleApi 11.0.5.1`, so that has to publish first.


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ea951c43-e78b-4856-8f04-cd08e52b6d3e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ea951c43-e78b-4856-8f04-cd08e52b6d3e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

