### PR TITLE
Bump version to 14.0.0

### DIFF
--- a/Source/AppScaffolding/AppScaffolding.csproj
+++ b/Source/AppScaffolding/AppScaffolding.csproj
@@ -2,7 +2,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
-    <Version>13.7.11</Version>
+    <Version>14.0.0</Version>
     <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Bump `<Version>` in `Source/AppScaffolding/AppScaffolding.csproj` from 13.7.11 to 14.0.0 for the next release.

`AppScaffolding.csproj` is the only place the version is declared - a grep for `13.7.11` across the tree turns up nothing else that needs moving.

After merge: annotated tag `v14.0.0` will be pushed to trigger `release.yml` (draft GitHub release). I will wait for an explicit "merged" before tagging. I will not merge this PR.

## Verification

Version-string change only, and no testing was requested for this release, so none was run. The bump matches the single-file shape of the previous release commits (`Bump version to 13.7.11`, `13.7.10`, `13.7.9`).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-497d91e4-f6a4-43c1-a4d2-fe3a647a073d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-497d91e4-f6a4-43c1-a4d2-fe3a647a073d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

