### PR TITLE
Update Deendencies and fix warnings

### DIFF
--- a/Source/AudibleUtilities/AudibleUtilities.csproj
+++ b/Source/AudibleUtilities/AudibleUtilities.csproj
@@ -7,8 +7,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AudibleApi" Version="14.0.0" />
-    <PackageReference Include="Google.Protobuf" Version="3.34.1" />
+    <PackageReference Include="Google.Protobuf" Version="3.36.1">
+		<PrivateAssets>all</PrivateAssets>
+		<PublicAssets>runtime</PublicAssets>
+	</PackageReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/Source/DataLayer/DataLayer.csproj
+++ b/Source/DataLayer/DataLayer.csproj
@@ -13,7 +13,7 @@
   <ItemGroup>
     <PackageReference Include="Dinah.Core" Version="11.0.0.1" />
     <PackageReference Include="Dinah.EntityFrameworkCore" Version="11.0.0.1" />
-	<PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.0.1" />
+	<PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.0.3" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.0.11" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.11">
       <PrivateAssets>all</PrivateAssets>

--- a/Source/FileManager/FileManager.csproj
+++ b/Source/FileManager/FileManager.csproj
@@ -7,7 +7,7 @@
 
   <ItemGroup>
     <PackageReference Include="Dinah.Core" Version="11.0.0.1" />
-    <PackageReference Include="Polly" Version="8.6.6" />
+    <PackageReference Include="Polly" Version="8.7.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Source/HangoverAvalonia/HangoverAvalonia.csproj
+++ b/Source/HangoverAvalonia/HangoverAvalonia.csproj
@@ -70,11 +70,10 @@
 		<TrimmableAssembly Include="Avalonia.Themes.Default" />
 	</ItemGroup>
 	<ItemGroup>
-		<PackageReference Include="Avalonia.Desktop" Version="12.0.2" />
-		<!--Condition below is needed to remove Avalonia.Diagnostics package from build output in Release configuration.-->
-		<PackageReference Condition="'$(Configuration)' == 'Debug'" Include="Avalonia.Diagnostics" Version="11.3.14" />
-		<PackageReference Include="ReactiveUI.Avalonia" Version="12.0.2" />
-		<PackageReference Include="Avalonia.Themes.Fluent" Version="12.0.2" />
+		<PackageReference Include="Avalonia.Desktop" Version="12.1.2" />
+		<PackageReference Condition="'$(Configuration)' == 'Debug'" Include="AvaloniaUI.DiagnosticsSupport" Version="2.2.3" />
+		<PackageReference Include="ReactiveUI.Avalonia" Version="12.1.1" />
+		<PackageReference Include="Avalonia.Themes.Fluent" Version="12.1.2" />
 	</ItemGroup>
 	<ItemGroup>
 		<ProjectReference Include="..\HangoverBase\HangoverBase.csproj" />

--- a/Source/LibationAvalonia/Controls/DataGridMyRatingColumn.cs
+++ b/Source/LibationAvalonia/Controls/DataGridMyRatingColumn.cs
@@ -1,56 +1,54 @@
 ﻿using Avalonia.Controls;
+using Avalonia.Controls.Templates;
 using Avalonia.Data;
 using Avalonia.Interactivity;
 using DataLayer;
 
 namespace LibationAvalonia.Controls;
 
-public class DataGridMyRatingColumn : DataGridBoundColumn
+public class DataGridMyRatingColumn : DataGridTemplateColumn
 {
 	[AssignBinding] public BindingBase? BackgroundBinding { get; set; }
 	[AssignBinding] public BindingBase? OpacityBinding { get; set; }
+	[AssignBinding] public BindingBase? RatingBinding { get; set; }
 	private static Rating DefaultRating => new Rating(0, 0, 0);
 	public DataGridMyRatingColumn()
 	{
-		BindingTarget = MyRatingCellEditor.RatingProperty;
+		this.IsReadOnly = false;
+		//Must set the CellEditingTemplate to enable cell editing in a DataGridTemplateColumn.
+		CellEditingTemplate = new FuncDataTemplate(typeof(Rating), (value, _) =>
+		{
+			var myRatingElement = CreateControl();
+			myRatingElement.Name = "CellMyRatingEditor";
+			myRatingElement.IsEditingMode = true;
+			return myRatingElement;
+		});
 	}
 
 	protected override Control GenerateElement(DataGridCell cell, object dataItem)
 	{
-		var myRatingElement = new MyRatingCellEditor
-		{
-			Name = "CellMyRatingDisplay",
-			IsEditingMode = false
-		};
+		var myRatingElement = CreateControl();
+		myRatingElement.Name = "CellMyRatingDisplay";
+		myRatingElement.IsEditingMode = false;
 
 		cell.Tag = this;
 
 		if (!IsReadOnly)
 			ToolTip.SetTip(myRatingElement, "Click to change ratings");
 
-		if (Binding != null)
-			myRatingElement.Bind(BindingTarget, Binding);
-		if (BackgroundBinding != null)
-			myRatingElement.Bind(MyRatingCellEditor.BackgroundProperty, BackgroundBinding);
-		if (OpacityBinding != null)
-			myRatingElement.Bind(MyRatingCellEditor.OpacityProperty, OpacityBinding);
-
 		return myRatingElement;
 	}
 
-	protected override Control GenerateEditingElementDirect(DataGridCell cell, object dataItem)
+	private MyRatingCellEditor CreateControl()
 	{
-		var myRatingElement = new MyRatingCellEditor
-		{
-			Name = "CellMyRatingEditor",
-			IsEditingMode = true
-		};
+		var myRatingElement = new MyRatingCellEditor();
 
+		if (RatingBinding != null)
+			myRatingElement.Bind(MyRatingCellEditor.RatingProperty, RatingBinding);
 		if (BackgroundBinding != null)
 			myRatingElement.Bind(MyRatingCellEditor.BackgroundProperty, BackgroundBinding);
 		if (OpacityBinding != null)
 			myRatingElement.Bind(MyRatingCellEditor.OpacityProperty, OpacityBinding);
-
 		return myRatingElement;
 	}
 

--- a/Source/LibationAvalonia/Controls/MyRatingCellEditor.axaml.cs
+++ b/Source/LibationAvalonia/Controls/MyRatingCellEditor.axaml.cs
@@ -23,11 +23,17 @@ public partial class MyRatingCellEditor : UserControl
 	{
 		InitializeComponent();
 
-		var subscriber = this.ObservableForProperty(p => p.Rating).Subscribe(o => DisplayStarRating(o.Value ?? new Rating(0, 0, 0)));
-		Unloaded += (_, _) => subscriber.Dispose();
-
 		if (Design.IsDesignMode)
 			Rating = new Rating(5, 4, 3);
+	}
+
+	protected override void OnPropertyChanged(AvaloniaPropertyChangedEventArgs change)
+	{
+		base.OnPropertyChanged(change);
+		if (change.Property == RatingProperty)
+		{
+			DisplayStarRating(change.GetNewValue<Rating>() ?? new Rating(0f, 0f, 0f));
+		}
 	}
 
 	private void DisplayStarRating(Rating rating)

--- a/Source/LibationAvalonia/Dialogs/ImageDisplayDialog.axaml.cs
+++ b/Source/LibationAvalonia/Dialogs/ImageDisplayDialog.axaml.cs
@@ -50,7 +50,7 @@ public partial class ImageDisplayDialog : DialogWindow, INotifyPropertyChanged
 
 		try
 		{
-			_bitmapHolder.CoverImage?.Save(selectedFile);
+			_bitmapHolder.CoverImage?.Save(selectedFile, JpegBitmapEncoderOptions.Default);
 		}
 		catch (Exception ex)
 		{

--- a/Source/LibationAvalonia/Dialogs/LocateAudiobooksDialog.axaml.cs
+++ b/Source/LibationAvalonia/Dialogs/LocateAudiobooksDialog.axaml.cs
@@ -10,7 +10,6 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Reactive.Linq;
 using System.Threading;
 
 namespace LibationAvalonia.Dialogs;

--- a/Source/LibationAvalonia/LibationAvalonia.csproj
+++ b/Source/LibationAvalonia/LibationAvalonia.csproj
@@ -72,13 +72,13 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Avalonia.Controls.ColorPicker" Version="12.0.2" />
-		<PackageReference Include="Avalonia.Controls.WebView" Version="12.0.0" />
-		<PackageReference Include="Avalonia.Diagnostics" Version="11.3.14" Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'" />
-		<PackageReference Include="Avalonia.Controls.DataGrid" Version="12.0.0" />
-		<PackageReference Include="Avalonia.Desktop" Version="12.0.2" />
-		<PackageReference Include="ReactiveUI.Avalonia" Version="12.0.2" />
-		<PackageReference Include="Avalonia.Themes.Fluent" Version="12.0.2" />
+		<PackageReference Include="Avalonia.Controls.ColorPicker" Version="12.1.2" />
+		<PackageReference Include="Avalonia.Controls.WebView" Version="12.1.0" />
+		<PackageReference Include="AvaloniaUI.DiagnosticsSupport" Version="2.2.3" Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'" />
+		<PackageReference Include="Avalonia.Controls.DataGrid" Version="12.1.2" />
+		<PackageReference Include="Avalonia.Desktop" Version="12.1.2" />
+		<PackageReference Include="ReactiveUI.Avalonia" Version="12.1.1" />
+		<PackageReference Include="Avalonia.Themes.Fluent" Version="12.1.2" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/Source/LibationAvalonia/ViewModels/MainVM.Settings.cs
+++ b/Source/LibationAvalonia/ViewModels/MainVM.Settings.cs
@@ -3,8 +3,8 @@ using LibationFileManager;
 using LibationUiBase.Forms;
 using ReactiveUI;
 using System;
-using System.Reactive;
 using System.Threading.Tasks;
+using System.Windows.Input;
 
 namespace LibationAvalonia.ViewModels;
 
@@ -12,7 +12,7 @@ partial class MainVM
 {
 	public string FindBetterQualityBooksTip => Configuration.GetHelpText("FindBetterQualityBooks");
 	public bool MenuBarVisible { get => field; set => this.RaiseAndSetIfChanged(ref field, value); } = !Configuration.IsMacOs;
-	public ReactiveCommand<Unit, Unit> LaunchHangover { get; private set; } = null!;
+	public ICommand LaunchHangover { get; private set; } = null!;
 
 	private void Configure_Settings()
 	{
@@ -20,7 +20,7 @@ partial class MainVM
 
 		if (App.Current is Avalonia.Application app &&
 			NativeMenu.GetMenu(app)?.Items[0] is NativeMenuItem aboutMenu)
-			aboutMenu.Command = ReactiveCommand.Create(ShowAboutAsync);
+			aboutMenu.Command = ReactiveCommand.CreateFromTask(ShowAboutAsync);
 	}
 
 	public Task ShowAboutAsync() => new LibationAvalonia.Dialogs.AboutDialog().ShowDialog(MainWindow);

--- a/Source/LibationAvalonia/Views/ProductsDisplay.axaml
+++ b/Source/LibationAvalonia/Views/ProductsDisplay.axaml
@@ -242,7 +242,7 @@
 					SortMemberPath="ProductRating" CanUserSort="True"
 					OpacityBinding="{Binding Liberate.Opacity}"
 					ClipboardContentBinding="{Binding ProductRating}"
-					Binding="{Binding ProductRating}">
+					RatingBinding="{Binding ProductRating}">
 					<controls:DataGridMyRatingColumn.Width>
 						<Binding x:DataType="vm:ProductsDisplayViewModel" Path="ProductRatingWidth" Mode="TwoWay" />
 					</controls:DataGridMyRatingColumn.Width>
@@ -269,7 +269,7 @@
 					SortMemberPath="MyRating" CanUserSort="True"
 					OpacityBinding="{Binding Liberate.Opacity}"
 					ClipboardContentBinding="{Binding MyRating}"					
-					Binding="{Binding MyRating, Mode=TwoWay}">
+					RatingBinding="{Binding MyRating, Mode=TwoWay}">
 					<controls:DataGridMyRatingColumn.Width>
 						<Binding x:DataType="vm:ProductsDisplayViewModel" Path="MyRatingWidth" Mode="TwoWay" />
 					</controls:DataGridMyRatingColumn.Width>

--- a/Source/LibationFileManager/Configuration.KnownDirectories.cs
+++ b/Source/LibationFileManager/Configuration.KnownDirectories.cs
@@ -57,7 +57,7 @@ public partial class Configuration
 		(KnownDirectories.MyDocs, () => MyDocs),
 			// this is important to not let very early calls try to accidentally load LibationFiles too early.
 			// also, keep this at bottom of this list
-			(KnownDirectories.LibationFiles, () => Instance.LibationFiles.Location)
+			(KnownDirectories.LibationFiles, () => Instance!.LibationFiles.Location)
 	};
 	public static string? GetKnownDirectoryPath(KnownDirectories directory)
 	{

--- a/Source/LibationFileManager/LibationFileManager.csproj
+++ b/Source/LibationFileManager/LibationFileManager.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AudibleApi" Version="14.0.0" />
+    <PackageReference Include="AudibleApi" Version="14.1.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="10.0.11" />
     <PackageReference Include="NameParserSharp" Version="1.5.0" />
     <PackageReference Include="Serilog.Exceptions" Version="8.4.0" />

--- a/Source/LibationUiBase/DeviceRegistrationSettingsUi.cs
+++ b/Source/LibationUiBase/DeviceRegistrationSettingsUi.cs
@@ -7,11 +7,7 @@ namespace LibationUiBase;
 public static class DeviceRegistrationSettingsUi
 {
 	public static EnumDisplay<DeviceRegistrationKind>[] Options { get; } =
-	[
-		new(DeviceRegistrationKind.CurrentAndroid, "Android emulator (default)"),
-		new(DeviceRegistrationKind.RetailAndroid, "Android Pixel (experimental)"),
-		new(DeviceRegistrationKind.Mkb79IPhone, "iPhone / audible-cli (experimental; no Widevine)"),
-	];
+		DeviceRegistrationProfile.AllProfiles.Select(p => new EnumDisplay<DeviceRegistrationKind>(p.Kind, p.Description)).ToArray();
 
 	public static string SettingLabel { get; } = "Device registration (experimental)";
 

--- a/Source/LibationUiBase/LibationUiBase.csproj
+++ b/Source/LibationUiBase/LibationUiBase.csproj
@@ -12,7 +12,7 @@
   <ItemGroup>
 	<!-- Rasterizes the Liberate column's icons. Kept on the same major version as the one
 	     Avalonia.Skia resolves, so the Avalonia app doesn't get a mismatched native Skia. -->
-	<PackageReference Include="SkiaSharp" Version="3.119.4" />
+	<PackageReference Include="SkiaSharp" Version="4.151.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Source/LibationUiBase/LibationUiBase.csproj
+++ b/Source/LibationUiBase/LibationUiBase.csproj
@@ -12,7 +12,7 @@
   <ItemGroup>
 	<!-- Rasterizes the Liberate column's icons. Kept on the same major version as the one
 	     Avalonia.Skia resolves, so the Avalonia app doesn't get a mismatched native Skia. -->
-	<PackageReference Include="SkiaSharp" Version="4.151.2" />
+	<PackageReference Include="SkiaSharp" Version="3.119.4" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Source/LibationUiBase/StatusIcons/StatusImageGenerator.cs
+++ b/Source/LibationUiBase/StatusIcons/StatusImageGenerator.cs
@@ -105,8 +105,10 @@ public static class StatusImageGenerator
 		};
 
 		//The lamp goes under the body, so it shows through the bezel cut out of it.
-		var lamp = new SKPath();
-		lamp.AddRect(SKRect.Create(LiberateIconGeometry.LampLeft, lampTop, LiberateIconGeometry.LampWidth, LiberateIconGeometry.LampHeight));
+		using var lampBuilder = new SKPathBuilder();
+		lampBuilder.AddRect(SKRect.Create(LiberateIconGeometry.LampLeft, lampTop, LiberateIconGeometry.LampWidth, LiberateIconGeometry.LampHeight));
+		var lamp = lampBuilder.Detach();
+		
 
 		//Sitting flush with the top edge keeps the badge out of the stoplight's height, so a Plus
 		//title's stoplight is drawn at exactly the same size as a purchased one's.
@@ -158,8 +160,9 @@ public static class StatusImageGenerator
 		//Drawn last so the badge sits on top of everything it overlaps.
 		if (descriptor.IsPlus)
 		{
-			var badge = new SKPath();
-			badge.AddCircle(badgeCenterX, badgeCenterY, badgeRadius);
+			using var badgeBuilder = new SKPathBuilder();
+			badgeBuilder.AddCircle(badgeCenterX, badgeCenterY, badgeRadius);
+			var badge = badgeBuilder.Detach();
 
 			layers.Add((badge, palette.PlusBadge));
 			layers.Add((PlusGlyph(badgeCenterX, badgeCenterY), palette.PlusBadgeGlyph));
@@ -171,9 +174,9 @@ public static class StatusImageGenerator
 	/// <summary>The hole cut around the Audible Plus badge, separating it from whatever it overlaps.</summary>
 	private static SKPath BadgeRim(float centerX, float centerY, float badgeRadius)
 	{
-		var rim = new SKPath();
-		rim.AddCircle(centerX, centerY, badgeRadius + LiberateIconGeometry.PlusBadgeRimWidth);
-		return rim;
+		using var rimBuilder = new SKPathBuilder();
+		rimBuilder.AddCircle(centerX, centerY, badgeRadius + LiberateIconGeometry.PlusBadgeRimWidth);
+		return rimBuilder.Detach();
 	}
 
 	/// <summary>
@@ -186,10 +189,10 @@ public static class StatusImageGenerator
 		var thickness = extent * LiberateIconGeometry.PlusBadgeGlyphThickness;
 		var corner = thickness * 0.15f;
 
-		var plus = new SKPath { FillType = SKPathFillType.Winding };
-		plus.AddRoundRect(SKRect.Create(centerX - extent / 2, centerY - thickness / 2, extent, thickness), corner, corner);
-		plus.AddRoundRect(SKRect.Create(centerX - thickness / 2, centerY - extent / 2, thickness, extent), corner, corner);
-		return plus;
+		using var plusBuilder = new SKPathBuilder { FillType = SKPathFillType.Winding };
+		plusBuilder.AddRoundRect(SKRect.Create(centerX - extent / 2, centerY - thickness / 2, extent, thickness), corner, corner);
+		plusBuilder.AddRoundRect(SKRect.Create(centerX - thickness / 2, centerY - extent / 2, thickness, extent), corner, corner);
+		return plusBuilder.Detach();
 	}
 
 	private static SKPath ParsePath(string svgPathData)

--- a/Source/LibationUiBase/StatusIcons/StatusImageGenerator.cs
+++ b/Source/LibationUiBase/StatusIcons/StatusImageGenerator.cs
@@ -105,10 +105,9 @@ public static class StatusImageGenerator
 		};
 
 		//The lamp goes under the body, so it shows through the bezel cut out of it.
-		using var lampBuilder = new SKPathBuilder();
-		lampBuilder.AddRect(SKRect.Create(LiberateIconGeometry.LampLeft, lampTop, LiberateIconGeometry.LampWidth, LiberateIconGeometry.LampHeight));
-		var lamp = lampBuilder.Detach();
-		
+		var lamp = new SKPath();
+		lamp.AddRect(SKRect.Create(LiberateIconGeometry.LampLeft, lampTop, LiberateIconGeometry.LampWidth, LiberateIconGeometry.LampHeight));
+
 
 		//Sitting flush with the top edge keeps the badge out of the stoplight's height, so a Plus
 		//title's stoplight is drawn at exactly the same size as a purchased one's.
@@ -160,9 +159,8 @@ public static class StatusImageGenerator
 		//Drawn last so the badge sits on top of everything it overlaps.
 		if (descriptor.IsPlus)
 		{
-			using var badgeBuilder = new SKPathBuilder();
-			badgeBuilder.AddCircle(badgeCenterX, badgeCenterY, badgeRadius);
-			var badge = badgeBuilder.Detach();
+			var badge = new SKPath();
+			badge.AddCircle(badgeCenterX, badgeCenterY, badgeRadius);
 
 			layers.Add((badge, palette.PlusBadge));
 			layers.Add((PlusGlyph(badgeCenterX, badgeCenterY), palette.PlusBadgeGlyph));
@@ -174,9 +172,9 @@ public static class StatusImageGenerator
 	/// <summary>The hole cut around the Audible Plus badge, separating it from whatever it overlaps.</summary>
 	private static SKPath BadgeRim(float centerX, float centerY, float badgeRadius)
 	{
-		using var rimBuilder = new SKPathBuilder();
-		rimBuilder.AddCircle(centerX, centerY, badgeRadius + LiberateIconGeometry.PlusBadgeRimWidth);
-		return rimBuilder.Detach();
+		var rim = new SKPath();
+		rim.AddCircle(centerX, centerY, badgeRadius + LiberateIconGeometry.PlusBadgeRimWidth);
+		return rim;
 	}
 
 	/// <summary>
@@ -189,10 +187,10 @@ public static class StatusImageGenerator
 		var thickness = extent * LiberateIconGeometry.PlusBadgeGlyphThickness;
 		var corner = thickness * 0.15f;
 
-		using var plusBuilder = new SKPathBuilder { FillType = SKPathFillType.Winding };
-		plusBuilder.AddRoundRect(SKRect.Create(centerX - extent / 2, centerY - thickness / 2, extent, thickness), corner, corner);
-		plusBuilder.AddRoundRect(SKRect.Create(centerX - thickness / 2, centerY - extent / 2, thickness, extent), corner, corner);
-		return plusBuilder.Detach();
+		var plus = new SKPath { FillType = SKPathFillType.Winding };
+		plus.AddRoundRect(SKRect.Create(centerX - extent / 2, centerY - thickness / 2, extent, thickness), corner, corner);
+		plus.AddRoundRect(SKRect.Create(centerX - thickness / 2, centerY - extent / 2, thickness, extent), corner, corner);
+		return plus;
 	}
 
 	private static SKPath ParsePath(string svgPathData)

--- a/Source/LibationWinForms/LibationWinForms.csproj
+++ b/Source/LibationWinForms/LibationWinForms.csproj
@@ -42,7 +42,7 @@
 
 	<ItemGroup>
 		<PackageReference Include="Dinah.Core.WindowsDesktop" Version="11.0.0.1" />
-		<PackageReference Include="Microsoft.Web.WebView2" Version="1.0.3912.50" />
+		<PackageReference Include="Microsoft.Web.WebView2" Version="1.0.4191.47" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/Source/LoadByOS/WindowsConfigApp/FolderIcon.cs
+++ b/Source/LoadByOS/WindowsConfigApp/FolderIcon.cs
@@ -1,15 +1,15 @@
-﻿using SixLabors.ImageSharp;
-using System.IO;
+﻿using System.IO;
+using SkiaSharp;
 
 namespace WindowsConfigApp;
 
 internal static partial class FolderIcon
 {
 	static readonly IcoEncoder IcoEncoder = new();
-	public static byte[] ToIcon(this Image img)
+	public static byte[] ToIcon(this SKBitmap img)
 	{
 		using var ms = new MemoryStream();
-		img.Save(ms, IcoEncoder);
+		IcoEncoder.Encode(img, ms);
 		return ms.ToArray();
 	}
 

--- a/Source/LoadByOS/WindowsConfigApp/IcoEncoder.cs
+++ b/Source/LoadByOS/WindowsConfigApp/IcoEncoder.cs
@@ -1,18 +1,12 @@
-﻿using SixLabors.ImageSharp;
-using SixLabors.ImageSharp.Formats;
-using SixLabors.ImageSharp.PixelFormats;
-using SixLabors.ImageSharp.Processing;
+﻿using SkiaSharp;
 using System;
 using System.Collections.ObjectModel;
 using System.IO;
-using System.Threading;
-using System.Threading.Tasks;
 
 namespace WindowsConfigApp;
 
-public class IcoEncoder : IImageEncoder
+public class IcoEncoder
 {
-	public bool SkipMetadata { get; init; } = true;
 	public ReadOnlyCollection<int> ExportSizes { get; }
 	public IcoEncoder() : this(512, 256, 128, 96, 64, 48, 32, 24) { }
 	public IcoEncoder(params int[] icoSizes)
@@ -21,20 +15,23 @@ public class IcoEncoder : IImageEncoder
 		ExportSizes = new(icoSizes);
 	}
 
-	public void Encode<TPixel>(Image<TPixel> image, Stream stream) where TPixel : unmanaged, IPixel<TPixel>
+	public void Encode(SKBitmap image, Stream stream)
 	{
 		// https://stackoverflow.com/a/21389253
 
 		//Knowing the image size ahead of time removes the
 		//requirement of the output stream to support seeking.
 		byte[][] iconPngs = new byte[ExportSizes.Count][];
+		var samplingOptions = new SKSamplingOptions(SKCubicResampler.CatmullRom);
+
 		for (int i = 0; i < ExportSizes.Count; i++)
 		{
 			int size = ExportSizes[i];
-			using var resized = image.Clone(x => x.Resize(size, size, KnownResamplers.Lanczos2));
-			using var pngMs = new MemoryStream();
-			resized.SaveAsPng(pngMs);
-			iconPngs[i] = pngMs.ToArray();
+			var imageInfo = new SKImageInfo(size, size);
+			using var resized = image.Resize(imageInfo, samplingOptions);
+			using var skImage = SKImage.FromBitmap(resized);
+			using var data = skImage.Encode(SKEncodedImageFormat.Png, 100);			
+			iconPngs[i] = data.ToArray();
 		}
 
 		//Disposing of the BinaryWriter disposes the soutput stream. Let the caller clean up.
@@ -65,7 +62,4 @@ public class IcoEncoder : IImageEncoder
 		for (int i = 0; i < ExportSizes.Count; i++)
 			bw.Write(iconPngs[i]);
 	}
-
-	public Task EncodeAsync<TPixel>(Image<TPixel> image, Stream stream, CancellationToken cancellationToken) where TPixel : unmanaged, IPixel<TPixel>
-		=> throw new NotImplementedException();
 }

--- a/Source/LoadByOS/WindowsConfigApp/WinInterop.cs
+++ b/Source/LoadByOS/WindowsConfigApp/WinInterop.cs
@@ -1,6 +1,5 @@
 ﻿using Dinah.Core;
 using LibationFileManager;
-using SixLabors.ImageSharp;
 using System;
 using System.Diagnostics;
 using System.IO;
@@ -14,15 +13,15 @@ internal class WinInterop : IInteropFunctions
 	public WinInterop(params object[] values) { }
 	public void SetFolderIcon(string image, string directory)
 	{
-		using var img = Image.Load(image);
-		var icon = img.ToIcon();
+		using var bmp = SkiaSharp.SKBitmap.Decode(image);
+		var icon = bmp.ToIcon();
 		new DirectoryInfo(directory)?.SetIcon(icon, "Music");
 	}
 
 	public void SetFolderIcon(byte[] imageJpegBytes, string directory)
 	{
-		using var img = Image.Load(new MemoryStream(imageJpegBytes, writable: false));
-		var icon = img.ToIcon();
+		using var bmp = SkiaSharp.SKBitmap.Decode(imageJpegBytes);
+		var icon = bmp.ToIcon();
 		new DirectoryInfo(directory)?.SetIcon(icon, "Music");
 	}
 

--- a/Source/LoadByOS/WindowsConfigApp/WindowsConfigApp.csproj
+++ b/Source/LoadByOS/WindowsConfigApp/WindowsConfigApp.csproj
@@ -26,7 +26,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="SixLabors.ImageSharp" Version="3.1.12" />
+    <PackageReference Include="SixLabors.ImageSharp" Version="4.1.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Source/LoadByOS/WindowsConfigApp/WindowsConfigApp.csproj
+++ b/Source/LoadByOS/WindowsConfigApp/WindowsConfigApp.csproj
@@ -26,10 +26,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="SixLabors.ImageSharp" Version="4.1.1" />
-  </ItemGroup>
-
-  <ItemGroup>
     <ProjectReference Include="..\..\LibationUiBase\LibationUiBase.csproj" />
   </ItemGroup>
 

--- a/Source/_Tests/ApplicationServices.Tests/ApplicationServices.Tests.csproj
+++ b/Source/_Tests/ApplicationServices.Tests/ApplicationServices.Tests.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="MSTest" Version="4.3.3" />
+    <PackageReference Include="MSTest" Version="4.4.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Source/_Tests/AssertionHelper/AssertionHelper.csproj
+++ b/Source/_Tests/AssertionHelper/AssertionHelper.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="MSTest.TestFramework" Version="4.3.3" />
+    <PackageReference Include="MSTest.TestFramework" Version="4.4.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Source/_Tests/AudibleUtilities.Tests/AudibleUtilities.Tests.csproj
+++ b/Source/_Tests/AudibleUtilities.Tests/AudibleUtilities.Tests.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="MSTest" Version="4.3.3" />
+    <PackageReference Include="MSTest" Version="4.4.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Source/_Tests/FileLiberator.Tests/FileLiberator.Tests.csproj
+++ b/Source/_Tests/FileLiberator.Tests/FileLiberator.Tests.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="MSTest" Version="4.3.3" />
+    <PackageReference Include="MSTest" Version="4.4.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Source/_Tests/FileManager.Tests/FileManager.Tests.csproj
+++ b/Source/_Tests/FileManager.Tests/FileManager.Tests.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="MSTest" Version="4.3.3" />
+    <PackageReference Include="MSTest" Version="4.4.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Source/_Tests/LibationCli.Tests/LibationCli.Tests.csproj
+++ b/Source/_Tests/LibationCli.Tests/LibationCli.Tests.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="MSTest" Version="4.3.3" />
+    <PackageReference Include="MSTest" Version="4.4.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Source/_Tests/LibationCli.Tests/LoginExternalOptionsTests.cs
+++ b/Source/_Tests/LibationCli.Tests/LoginExternalOptionsTests.cs
@@ -22,7 +22,7 @@ public class LoginExternalOptionsTests
 
 		Assert.IsTrue(options.TryResolveRegistrationProfile(out var profile, out var error));
 		Assert.AreEqual("", error);
-		Assert.AreEqual(DeviceRegistrationKind.RetailAndroid, profile.Kind);
+		Assert.AreEqual(DeviceRegistrationKind.CurrentAndroid, profile.Kind);
 	}
 
 	[TestMethod]

--- a/Source/_Tests/LibationFileManager.Tests/DeviceRegistrationKindConfigurationTests.cs
+++ b/Source/_Tests/LibationFileManager.Tests/DeviceRegistrationKindConfigurationTests.cs
@@ -5,6 +5,7 @@ using LibationFileManager;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Newtonsoft.Json.Linq;
 using System;
+using System.Linq;
 
 namespace DeviceRegistrationKindConfigurationTests;
 
@@ -32,8 +33,8 @@ public class DeviceRegistrationKindConfigurationTests
 	public void Round_trips_each_kind()
 	{
 		var config = Configuration.CreateMockInstance();
-
-		foreach (var kind in Enum.GetValues<DeviceRegistrationKind>())
+		//Exclude RetailAndroid from this test because it is not a valid option for the setting
+		foreach (var kind in Enum.GetValues<DeviceRegistrationKind>().Where(p => p is not DeviceRegistrationKind.RetailAndroid))
 		{
 			config.DeviceRegistrationKind = kind;
 			Assert.AreEqual(kind, config.DeviceRegistrationKind);

--- a/Source/_Tests/LibationFileManager.Tests/LibationFileManager.Tests.csproj
+++ b/Source/_Tests/LibationFileManager.Tests/LibationFileManager.Tests.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="MSTest" Version="4.3.3" />
+    <PackageReference Include="MSTest" Version="4.4.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Source/_Tests/LibationSearchEngine.Tests/LibationSearchEngine.Tests.csproj
+++ b/Source/_Tests/LibationSearchEngine.Tests/LibationSearchEngine.Tests.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="MSTest" Version="4.3.3" />
+    <PackageReference Include="MSTest" Version="4.4.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Source/_Tests/LibationUiBase.Tests/DeviceRegistrationSettingsUiTests.cs
+++ b/Source/_Tests/LibationUiBase.Tests/DeviceRegistrationSettingsUiTests.cs
@@ -9,8 +9,9 @@ public class DeviceRegistrationSettingsUiTests
 	[TestMethod]
 	public void Options_cover_every_DeviceRegistrationKind()
 	{
-		var kinds = DeviceRegistrationSettingsUi.Options.Select(o => o.Value).ToHashSet();
-		CollectionAssert.AreEquivalent(Enum.GetValues<DeviceRegistrationKind>(), kinds.ToArray());
+		var kinds = DeviceRegistrationSettingsUi.Options.Select(o => o.Value).ToArray();
+		// RetailAndroid is not a valid option for the setting, so it is excluded from the assertion.
+		CollectionAssert.AreEquivalent(Enum.GetValues<DeviceRegistrationKind>().Where(p => p is not DeviceRegistrationKind.RetailAndroid).ToArray(), kinds);
 	}
 
 	[TestMethod]

--- a/Source/_Tests/LibationUiBase.Tests/LibationUiBase.Tests.csproj
+++ b/Source/_Tests/LibationUiBase.Tests/LibationUiBase.Tests.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="MSTest" Version="4.3.3" />
+    <PackageReference Include="MSTest" Version="4.4.0" />
     <!-- The Liberate icon tests rasterize with SkiaSharp, whose Linux native isn't
          brought in by the SkiaSharp package itself the way Windows' and macOS' are. -->
     <PackageReference Include="SkiaSharp.NativeAssets.Linux" Version="3.119.4" Condition="$([MSBuild]::IsOSPlatform('Linux'))" />

--- a/Source/_Tests/LibationUiBase.Tests/LibationUiBase.Tests.csproj
+++ b/Source/_Tests/LibationUiBase.Tests/LibationUiBase.Tests.csproj
@@ -10,9 +10,10 @@
 
   <ItemGroup>
     <PackageReference Include="MSTest" Version="4.4.0" />
+	<PackageReference Include="Google.Protobuf" Version="3.36.1" />
     <!-- The Liberate icon tests rasterize with SkiaSharp, whose Linux native isn't
          brought in by the SkiaSharp package itself the way Windows' and macOS' are. -->
-    <PackageReference Include="SkiaSharp.NativeAssets.Linux" Version="3.119.4" Condition="$([MSBuild]::IsOSPlatform('Linux'))" />
+    <PackageReference Include="SkiaSharp.NativeAssets.Linux" Version="4.151.2" Condition="$([MSBuild]::IsOSPlatform('Linux'))" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Source/_Tests/LibationUiBase.Tests/LibationUiBase.Tests.csproj
+++ b/Source/_Tests/LibationUiBase.Tests/LibationUiBase.Tests.csproj
@@ -13,7 +13,7 @@
 	<PackageReference Include="Google.Protobuf" Version="3.36.1" />
     <!-- The Liberate icon tests rasterize with SkiaSharp, whose Linux native isn't
          brought in by the SkiaSharp package itself the way Windows' and macOS' are. -->
-    <PackageReference Include="SkiaSharp.NativeAssets.Linux" Version="4.151.2" Condition="$([MSBuild]::IsOSPlatform('Linux'))" />
+    <PackageReference Include="SkiaSharp.NativeAssets.Linux" Version="3.119.4" Condition="$([MSBuild]::IsOSPlatform('Linux'))" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
- Update all project dependencies to current
- Fix errors and new warnings in updated libs
- Remove the SixLabors.ImageSharp dependency. We can use SkiaSharp (already a dependency) instead, and SixLabors has added mandatory licensing for everyone in recent versions.
