### PR TITLE
feat(abs): add console progress bar during Audiobookshelf upload

### DIFF
--- a/Source/ApplicationServices/AudiobookshelfApiService.cs
+++ b/Source/ApplicationServices/AudiobookshelfApiService.cs
@@ -483,7 +483,8 @@ public static class AudiobookshelfApiService
 		string title,
 		string? author,
 		string? series,
-		IEnumerable<string> filePaths)
+		IEnumerable<string> filePaths,
+		IProgress<(long bytesSent, long totalBytes)>? progress = null)
 	{
 		apiToken = AudiobookshelfTokenStorage.DecryptToken(apiToken) ?? "";
 
@@ -517,15 +518,33 @@ public static class AudiobookshelfApiService
 		form.Add(new StringContent(libraryId), "library");
 		form.Add(new StringContent(folderId), "folder");
 
+		var existingFiles = filePaths.Where(File.Exists).ToList();
+		long totalBytes = 0;
+		foreach (var path in existingFiles)
+		{
+			try { totalBytes += new FileInfo(path).Length; } catch { }
+		}
+
+		progress?.Report((0, totalBytes));
+
+		long bytesSent = 0;
+		void OnBytesRead(int count)
+		{
+			var current = System.Threading.Interlocked.Add(ref bytesSent, count);
+			progress?.Report((current, totalBytes));
+		}
+
 		int fileIndex = 0;
 		var streams = new List<Stream>();
 		try
 		{
-			foreach (var path in filePaths.Where(File.Exists))
+			foreach (var path in existingFiles)
 			{
-				var stream = File.OpenRead(path);
-				streams.Add(stream);
-				var fileContent = new StreamContent(stream);
+				var fileStream = File.OpenRead(path);
+				streams.Add(fileStream);
+				var progressStream = new ProgressStream(fileStream, OnBytesRead);
+				streams.Add(progressStream);
+				var fileContent = new StreamContent(progressStream);
 				fileContent.Headers.ContentType = new MediaTypeHeaderValue("application/octet-stream");
 				form.Add(fileContent, fileIndex.ToString(), Path.GetFileName(path));
 				fileIndex++;
@@ -540,7 +559,10 @@ public static class AudiobookshelfApiService
 			var response = await client.PostAsync("api/upload", form);
 
 			if (response.IsSuccessStatusCode)
+			{
+				progress?.Report((totalBytes, totalBytes));
 				return UploadResult.Success;
+			}
 
 			var responseBody = await response.Content.ReadAsStringAsync();
 			Serilog.Log.Logger.Error("Audiobookshelf upload failed for '{Title}' with status {(int)response.StatusCode} ({StatusCode}). Response body: {ResponseBody}",

--- a/Source/ApplicationServices/ProgressStream.cs
+++ b/Source/ApplicationServices/ProgressStream.cs
@@ -1,0 +1,90 @@
+using System;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace ApplicationServices;
+
+/// <summary>
+/// A stream wrapper that reports the number of bytes read to a callback.
+/// Used to track upload streaming progress via HttpClient and MultipartFormDataContent.
+/// </summary>
+public sealed class ProgressStream : Stream
+{
+	private readonly Stream _inner;
+	private readonly Action<int> _onBytesRead;
+
+	public ProgressStream(Stream inner, Action<int> onBytesRead)
+	{
+		_inner = inner ?? throw new ArgumentNullException(nameof(inner));
+		_onBytesRead = onBytesRead ?? throw new ArgumentNullException(nameof(onBytesRead));
+	}
+
+	public override bool CanRead => _inner.CanRead;
+	public override bool CanSeek => _inner.CanSeek;
+	public override bool CanWrite => _inner.CanWrite;
+	public override long Length => _inner.Length;
+
+	public override long Position
+	{
+		get => _inner.Position;
+		set => _inner.Position = value;
+	}
+
+	public override void Flush() => _inner.Flush();
+	public override Task FlushAsync(CancellationToken cancellationToken) => _inner.FlushAsync(cancellationToken);
+
+	public override long Seek(long offset, SeekOrigin origin) => _inner.Seek(offset, origin);
+	public override void SetLength(long value) => _inner.SetLength(value);
+	public override void Write(byte[] buffer, int offset, int count) => _inner.Write(buffer, offset, count);
+	public override void Write(ReadOnlySpan<byte> buffer) => _inner.Write(buffer);
+	public override Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+		=> _inner.WriteAsync(buffer, offset, count, cancellationToken);
+	public override ValueTask WriteAsync(ReadOnlyMemory<byte> buffer, CancellationToken cancellationToken = default)
+		=> _inner.WriteAsync(buffer, cancellationToken);
+
+	public override int Read(byte[] buffer, int offset, int count)
+	{
+		var read = _inner.Read(buffer, offset, count);
+		if (read > 0)
+			_onBytesRead(read);
+		return read;
+	}
+
+	public override int Read(Span<byte> buffer)
+	{
+		var read = _inner.Read(buffer);
+		if (read > 0)
+			_onBytesRead(read);
+		return read;
+	}
+
+	public override async Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+	{
+		var read = await _inner.ReadAsync(buffer, offset, count, cancellationToken);
+		if (read > 0)
+			_onBytesRead(read);
+		return read;
+	}
+
+	public override async ValueTask<int> ReadAsync(Memory<byte> buffer, CancellationToken cancellationToken = default)
+	{
+		var read = await _inner.ReadAsync(buffer, cancellationToken);
+		if (read > 0)
+			_onBytesRead(read);
+		return read;
+	}
+
+	protected override void Dispose(bool disposing)
+	{
+		if (disposing)
+			_inner.Dispose();
+		base.Dispose(disposing);
+	}
+
+	public override async ValueTask DisposeAsync()
+	{
+		await _inner.DisposeAsync();
+		await base.DisposeAsync();
+	}
+}

--- a/Source/FileLiberator/UploadToAudiobookshelf.cs
+++ b/Source/FileLiberator/UploadToAudiobookshelf.cs
@@ -73,6 +73,31 @@ public class UploadToAudiobookshelf : Processable, IProcessable<UploadToAudioboo
 			var author = libraryBook.Book.AuthorNames;
 			var series = libraryBook.Book.SeriesNames();
 
+			var averageSpeed = new AaxDecrypter.AverageSpeed();
+			DateTime lastUpdate = DateTime.MinValue;
+
+			var progress = new Progress<(long bytesSent, long totalBytes)>(p =>
+			{
+				var now = DateTime.UtcNow;
+				if (p.bytesSent > 0 && p.bytesSent < p.totalBytes && (now - lastUpdate).TotalMilliseconds < 100)
+					return;
+				lastUpdate = now;
+
+				averageSpeed.AddPosition(p.bytesSent);
+				var remainingBytes = p.totalBytes - p.bytesSent;
+				var estTimeRemaining = remainingBytes / averageSpeed.Average;
+				if (double.IsNormal(estTimeRemaining))
+					OnStreamingTimeRemaining(TimeSpan.FromSeconds(estTimeRemaining));
+
+				var progressPercent = p.totalBytes > 0 ? (100.0 * p.bytesSent / p.totalBytes) : 100.0;
+				OnStreamingProgressChanged(new Dinah.Core.Net.Http.DownloadProgress
+				{
+					ProgressPercentage = progressPercent,
+					BytesReceived = p.bytesSent,
+					TotalBytesToReceive = p.totalBytes
+				});
+			});
+
 			var result = await AudiobookshelfApiService.UploadBookAsync(
 				Configuration.AudiobookshelfServerUrl!,
 				Configuration.AudiobookshelfApiToken!,
@@ -81,10 +106,12 @@ public class UploadToAudiobookshelf : Processable, IProcessable<UploadToAudioboo
 				title,
 				author,
 				series,
-				files);
+				files,
+				progress);
 
 			if (result == AudiobookshelfApiService.UploadResult.Success)
 			{
+				OnStreamingTimeRemaining(TimeSpan.Zero);
 				const string message = "Upload to Audiobookshelf completed successfully";
 				OnStatusUpdate(message);
 				OnOutcomeDetermined(UploadOutcome.Uploaded, message);

--- a/Source/LibationCli/ConsoleProgressBar.cs
+++ b/Source/LibationCli/ConsoleProgressBar.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.IO;
 
 namespace LibationCli;
@@ -58,18 +58,20 @@ internal class ConsoleProgressBar
 			? "ETA ∞"
 			: $"ETA {(int)RemainingTime.TotalMinutes}:{RemainingTime.Seconds:D2}";
 
-		Output.Write(new string('\b', m_LastWriteLength) + progressBar);
 		if (progressBar.Length < m_LastWriteLength)
-		{
-			var extra = m_LastWriteLength - progressBar.Length;
-			Output.Write(new string(' ', extra) + new string('\b', extra));
-		}
-		m_LastWriteLength = progressBar.Length;
+			Output.Write("\r" + progressBar.PadRight(m_LastWriteLength));
+		else
+			Output.Write("\r" + progressBar);
+
+		m_LastWriteLength = Math.Max(m_LastWriteLength, progressBar.Length);
 	}
 
 	public void Clear()
-		=> Output.Write(
-			new string('\b', m_LastWriteLength) +
-			new string(' ', m_LastWriteLength) +
-			new string('\b', m_LastWriteLength));
+	{
+		if (m_LastWriteLength > 0)
+		{
+			Output.Write("\r" + new string(' ', m_LastWriteLength) + "\r");
+			m_LastWriteLength = 0;
+		}
+	}
 }

--- a/Source/_Tests/ApplicationServices.Tests/ProgressStreamTests.cs
+++ b/Source/_Tests/ApplicationServices.Tests/ProgressStreamTests.cs
@@ -1,0 +1,94 @@
+using ApplicationServices;
+using AssertionHelper;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.IO;
+using System.Threading.Tasks;
+
+namespace ApplicationServices.Tests;
+
+[TestClass]
+public class ProgressStreamTests
+{
+	[TestMethod]
+	public void Read_reports_bytes_read_to_callback()
+	{
+		var data = new byte[] { 1, 2, 3, 4, 5, 6, 7, 8 };
+		using var inner = new MemoryStream(data);
+		long reportedBytes = 0;
+		using var sut = new ProgressStream(inner, count => reportedBytes += count);
+
+		var buffer = new byte[4];
+		var read = sut.Read(buffer, 0, 4);
+
+		read.Should().Be(4);
+		reportedBytes.Should().Be(4);
+
+		read = sut.Read(buffer, 0, 4);
+		read.Should().Be(4);
+		reportedBytes.Should().Be(8);
+	}
+
+	[TestMethod]
+	public async Task ReadAsync_reports_bytes_read_to_callback()
+	{
+		var data = new byte[] { 10, 20, 30, 40, 50 };
+		using var inner = new MemoryStream(data);
+		long reportedBytes = 0;
+		using var sut = new ProgressStream(inner, count => reportedBytes += count);
+
+		var buffer = new byte[3];
+		var read = await sut.ReadAsync(buffer, 0, 3);
+
+		read.Should().Be(3);
+		reportedBytes.Should().Be(3);
+
+		read = await sut.ReadAsync(buffer, 0, 3);
+		read.Should().Be(2);
+		reportedBytes.Should().Be(5);
+	}
+
+	[TestMethod]
+	public async Task CopyToAsync_reports_total_bytes_copied()
+	{
+		var data = new byte[1024];
+		Random.Shared.NextBytes(data);
+		using var inner = new MemoryStream(data);
+		long reportedBytes = 0;
+		using var sut = new ProgressStream(inner, count => reportedBytes += count);
+
+		using var destination = new MemoryStream();
+		await sut.CopyToAsync(destination);
+
+		destination.ToArray().Should().BeEquivalentTo(data);
+		reportedBytes.Should().Be(1024);
+	}
+
+	[TestMethod]
+	public void Properties_delegate_to_inner_stream()
+	{
+		var data = new byte[100];
+		using var inner = new MemoryStream(data);
+		using var sut = new ProgressStream(inner, _ => { });
+
+		sut.CanRead.Should().BeTrue();
+		sut.CanSeek.Should().BeTrue();
+		sut.CanWrite.Should().BeTrue();
+		sut.Length.Should().Be(100);
+		sut.Position.Should().Be(0);
+
+		sut.Position = 50;
+		inner.Position.Should().Be(50);
+	}
+
+	[TestMethod]
+	public void Dispose_disposes_inner_stream()
+	{
+		var inner = new MemoryStream(new byte[10]);
+		var sut = new ProgressStream(inner, _ => { });
+
+		sut.Dispose();
+
+		Assert.ThrowsExactly<ObjectDisposedException>(() => inner.ReadByte());
+	}
+}

--- a/Source/_Tests/LibationCli.Tests/ConsoleProgressBarTests.cs
+++ b/Source/_Tests/LibationCli.Tests/ConsoleProgressBarTests.cs
@@ -1,0 +1,52 @@
+using AssertionHelper;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.IO;
+
+namespace LibationCli.Tests;
+
+[TestClass]
+public class ConsoleProgressBarTests
+{
+	[TestMethod]
+	public void WriteProgress_starts_with_carriage_return_to_overwrite_line()
+	{
+		using var writer = new StringWriter();
+		var sut = new ConsoleProgressBar(writer, maxWidth: 40);
+
+		sut.Progress = 50;
+
+		var output = writer.ToString();
+		Assert.IsTrue(output.StartsWith("\r", StringComparison.Ordinal));
+		StringAssert.Contains(output, "[");
+		StringAssert.Contains(output, "]");
+		StringAssert.Contains(output, "ETA");
+	}
+
+	[TestMethod]
+	public void Successive_updates_start_with_carriage_return()
+	{
+		using var writer = new StringWriter();
+		var sut = new ConsoleProgressBar(writer, maxWidth: 40);
+
+		sut.Progress = 25;
+		sut.Progress = 50;
+
+		var output = writer.ToString();
+		var carriageReturns = output.Split('\r').Length - 1;
+		carriageReturns.Should().Be(2);
+	}
+
+	[TestMethod]
+	public void Clear_overwrites_line_with_spaces_and_resets_cursor()
+	{
+		using var writer = new StringWriter();
+		var sut = new ConsoleProgressBar(writer, maxWidth: 40);
+
+		sut.Progress = 50;
+		sut.Clear();
+
+		var output = writer.ToString();
+		Assert.IsTrue(output.EndsWith("\r", StringComparison.Ordinal));
+	}
+}


### PR DESCRIPTION
### Summary
Adds real-time upload progress and dynamic ETA in the console during Audiobookshelf uploads (`libationcli abs upload` and `libationcli liberate`).

### Changes
- Added `ProgressStream` wrapper in `ApplicationServices` to report bytes transferred without buffering files in memory.
- Added `progress` parameter to `AudiobookshelfApiService.UploadBookAsync`.
- Wired `AverageSpeed` moving speed and ETA calculation to `OnStreamingProgressChanged` and `OnStreamingTimeRemaining` in `UploadToAudiobookshelf`.
- Updated `ConsoleProgressBar` to use carriage return `\r` and space padding so the progress bar continuously overwrites in-place on a single line.
- Added unit tests for `ProgressStream` and `ConsoleProgressBar`.
