### PR TITLE
fix(abs): enhance error diagnostics for upload failures

### DIFF
--- a/Source/FileLiberator/UploadToAudiobookshelf.cs
+++ b/Source/FileLiberator/UploadToAudiobookshelf.cs
@@ -104,22 +104,63 @@ public class UploadToAudiobookshelf : Processable, IProcessable<UploadToAudioboo
 				OnStatusUpdate(message);
 				Serilog.Log.Logger.Error("Audiobookshelf upload failed for {Book}, but continuing as soft-failure", libraryBook.LogFriendly());
 				// Soft-fail: log the error but do not mark the book as failed
-				OnOutcomeDetermined(UploadOutcome.Failed, message + ". See log for details.");
+				OnOutcomeDetermined(UploadOutcome.Failed, message + $". See Libation log ({Path.Combine(Configuration.Instance.LibationFiles.Location, "Log.log")}) and Audiobookshelf server logs for details.");
 				return new StatusHandler();
 			}
 		}
 		catch (Exception ex)
 		{
 			Serilog.Log.Logger.Error(ex, "Error uploading {Book} to Audiobookshelf; continuing as soft-failure", libraryBook.LogFriendly());
-			OnStatusUpdate($"Audiobookshelf upload error: {ex.Message}");
+			var errorMessage = FormatUploadErrorMessage(ex);
+			OnStatusUpdate(errorMessage);
 			// Soft-fail: log the error but do not mark the book as failed
-			OnOutcomeDetermined(UploadOutcome.Failed, $"Audiobookshelf upload error: {ex.Message}");
+			OnOutcomeDetermined(UploadOutcome.Failed, errorMessage);
 			return new StatusHandler();
 		}
 		finally
 		{
 			OnCompleted(libraryBook);
 		}
+	}
+
+	internal static string FormatUploadErrorMessage(Exception ex)
+	{
+		var baseEx = ex.GetBaseException();
+		var baseMsg = baseEx?.Message?.Trim();
+		var logFile = Path.Combine(Configuration.Instance.LibationFiles.Location, "Log.log");
+
+		var isStreamCopyError = ex.Message.Contains("Error while copying content to a stream", StringComparison.OrdinalIgnoreCase)
+			|| (baseMsg?.Contains("forcibly closed", StringComparison.OrdinalIgnoreCase) == true)
+			|| (baseMsg?.Contains("connection reset", StringComparison.OrdinalIgnoreCase) == true)
+			|| (baseMsg?.Contains("broken pipe", StringComparison.OrdinalIgnoreCase) == true)
+			|| (baseMsg?.Contains("ended prematurely", StringComparison.OrdinalIgnoreCase) == true);
+
+		if (isStreamCopyError)
+		{
+			var reason = !string.IsNullOrWhiteSpace(baseMsg) && !string.Equals(baseMsg, ex.Message, StringComparison.OrdinalIgnoreCase)
+				? $" ({baseMsg})"
+				: "";
+
+			return $"Audiobookshelf upload error: Connection lost while sending audio files to the server{reason}.\n"
+				+ "  Possible causes:\n"
+				+ "  - Reverse proxy upload limit: if using Nginx/Cloudflare/Traefik, ensure 'client_max_body_size' (or equivalent proxy upload limit) is large enough for audiobook files (e.g. 1G or higher).\n"
+				+ "  - Reverse proxy or server timeout: the upload may have exceeded proxy timeout limits.\n"
+				+ "  - Server disk space or Audiobookshelf crash: verify the server has sufficient free storage.\n"
+				+ $"  Check Audiobookshelf server logs and the Libation log ({logFile}) for details.";
+		}
+
+		if (ex is TaskCanceledException or TimeoutException)
+		{
+			return $"Audiobookshelf upload timed out or was cancelled.\n"
+				+ $"  Check Audiobookshelf server logs and the Libation log ({logFile}) for details.";
+		}
+
+		var detail = !string.IsNullOrWhiteSpace(baseMsg) && !string.Equals(baseMsg, ex.Message, StringComparison.OrdinalIgnoreCase)
+			? $"{ex.Message} ({baseMsg})"
+			: ex.Message;
+
+		return $"Audiobookshelf upload error: {detail}\n"
+			+ $"  Check Audiobookshelf server logs and the Libation log ({logFile}) for details.";
 	}
 
 	/// <summary>

--- a/Source/_Tests/FileLiberator.Tests/UploadToAudiobookshelfTests.cs
+++ b/Source/_Tests/FileLiberator.Tests/UploadToAudiobookshelfTests.cs
@@ -6,6 +6,7 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
 using System.IO;
 using System.Linq;
+using System.Net.Http;
 using System.Threading.Tasks;
 
 namespace FileLiberator.Tests;
@@ -284,5 +285,44 @@ public class UploadToAudiobookshelfTests
 		{
 			Directory.Delete(booksDirectory, recursive: true);
 		}
+	}
+
+	[TestMethod]
+	public void FormatUploadErrorMessage_stream_copy_error_provides_actionable_diagnostics()
+	{
+		var inner = new IOException("An existing connection was forcibly closed by the remote host.");
+		var ex = new HttpRequestException("Error while copying content to a stream.", inner);
+
+		var message = UploadToAudiobookshelf.FormatUploadErrorMessage(ex);
+
+		StringAssert.Contains(message, "Connection lost while sending audio files to the server");
+		StringAssert.Contains(message, "An existing connection was forcibly closed by the remote host");
+		StringAssert.Contains(message, "client_max_body_size");
+		StringAssert.Contains(message, "Reverse proxy or server timeout");
+		StringAssert.Contains(message, "Log.log");
+	}
+
+	[TestMethod]
+	public void FormatUploadErrorMessage_timeout_error_provides_timeout_message()
+	{
+		var ex = new TaskCanceledException("The request was canceled due to the configured HttpClient.Timeout.");
+
+		var message = UploadToAudiobookshelf.FormatUploadErrorMessage(ex);
+
+		StringAssert.Contains(message, "timed out or was cancelled");
+		StringAssert.Contains(message, "Log.log");
+	}
+
+	[TestMethod]
+	public void FormatUploadErrorMessage_unwraps_base_exception()
+	{
+		var root = new InvalidOperationException("Root failure reason");
+		var middle = new Exception("Middle failure", root);
+		var top = new Exception("Top failure", middle);
+
+		var message = UploadToAudiobookshelf.FormatUploadErrorMessage(top);
+
+		StringAssert.Contains(message, "Top failure (Root failure reason)");
+		StringAssert.Contains(message, "Log.log");
 	}
 }


### PR DESCRIPTION
### Summary
Replaces opaque .NET `Error while copying content to a stream` exception messages with root cause analysis and actionable troubleshooting suggestions.

### Changes
- Unwraps `ex.GetBaseException()` to surface the underlying socket/I/O error (connection reset, broken pipe, etc.).
- Detects dropped connections and suggests checking reverse proxy `client_max_body_size` (Nginx default is 1MB), proxy timeouts, server disk space, and server logs.
- Displays the path to the local Libation `Log.log` file.
- Added unit tests verifying diagnostic messaging in `UploadToAudiobookshelfTests`.
