### PR TITLE
feat(abs): add --check-asin flag for Audiobookshelf duplicate checking

### DIFF
--- a/Source/ApplicationServices/AudiobookshelfApiService.cs
+++ b/Source/ApplicationServices/AudiobookshelfApiService.cs
@@ -297,12 +297,63 @@ public static class AudiobookshelfApiService
 		}
 	}
 
-	public static async Task<bool> BookExistsAsync(string serverUrl, string apiToken, string libraryId, string title, string? author = null)
+	public static async Task<bool> BookExistsAsync(
+		string serverUrl,
+		string apiToken,
+		string libraryId,
+		string title,
+		string? author = null,
+		string? asin = null)
 	{
 		apiToken = AudiobookshelfTokenStorage.DecryptToken(apiToken) ?? "";
 		using var client = CreateClient(serverUrl);
 		client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", apiToken);
 		client.Timeout = TimeSpan.FromSeconds(30);
+
+		if (!string.IsNullOrWhiteSpace(asin))
+		{
+			var normalizedAsin = asin.Trim().TrimStart('[').TrimEnd(']');
+			Serilog.Log.Logger.Debug("Audiobookshelf duplicate check: searching by ASIN '{Asin}' in library {LibraryId}", normalizedAsin, libraryId);
+			try
+			{
+				var asinCandidates = await SearchLibraryAsync(client, libraryId, normalizedAsin, 10);
+				foreach (var candidate in asinCandidates)
+				{
+					bool asinMatch = false;
+
+					// 1) Audiobookshelf metadata ASIN match
+					if (!string.IsNullOrWhiteSpace(candidate.Asin)
+						&& string.Equals(candidate.Asin, normalizedAsin, StringComparison.OrdinalIgnoreCase))
+					{
+						asinMatch = true;
+					}
+
+					// 2) Audio/library file name or folder path contains the ASIN
+					if (!asinMatch && candidate.FileNames.Any(fn => fn.Contains(normalizedAsin, StringComparison.OrdinalIgnoreCase)))
+					{
+						asinMatch = true;
+					}
+
+					// 3) Title contains the ASIN
+					if (!asinMatch && (candidate.Title.Contains(normalizedAsin, StringComparison.OrdinalIgnoreCase)
+						|| candidate.FullTitle.Contains(normalizedAsin, StringComparison.OrdinalIgnoreCase)))
+					{
+						asinMatch = true;
+					}
+
+					if (asinMatch)
+					{
+						Serilog.Log.Logger.Information("Audiobookshelf duplicate check: found match by ASIN '{Asin}' (item id={ItemId}, title='{CandidateTitle}')", normalizedAsin, candidate.Id, candidate.FullTitle);
+						return true;
+					}
+				}
+			}
+			catch (Exception ex)
+			{
+				Serilog.Log.Logger.Debug(ex, "Audiobookshelf duplicate check by ASIN failed for '{Asin}' in library {LibraryId}", normalizedAsin, libraryId);
+				// Fall through to title matching below
+			}
+		}
 
 		var normalizedTitle = NormalizeTitle(title);
 		var baseTitle = GetBaseTitle(normalizedTitle);
@@ -370,7 +421,7 @@ public static class AudiobookshelfApiService
 		}
 	}
 
-	private record SearchCandidate(string Id, string Title, string FullTitle, List<string> Authors);
+	private record SearchCandidate(string Id, string Title, string FullTitle, List<string> Authors, string? Asin, List<string> FileNames);
 
 	private static async Task<List<SearchCandidate>> SearchLibraryAsync(HttpClient client, string libraryId, string query, int limit)
 	{
@@ -393,6 +444,8 @@ public static class AudiobookshelfApiService
 			var id = item["id"]?.Value<string>() ?? entry["id"]?.Value<string>() ?? "";
 			var itemTitle = item["media"]?["metadata"]?["title"]?.Value<string>()?.Replace("\u00A0", " ").Trim();
 			var itemSubtitle = item["media"]?["metadata"]?["subtitle"]?.Value<string>()?.Replace("\u00A0", " ").Trim();
+			var asin = item["media"]?["metadata"]?["asin"]?.Value<string>()?.Trim();
+			var path = item["path"]?.Value<string>() ?? "";
 
 			var itemFullTitle = string.IsNullOrWhiteSpace(itemSubtitle)
 				? itemTitle
@@ -403,11 +456,36 @@ public static class AudiobookshelfApiService
 				.Where(n => !string.IsNullOrWhiteSpace(n))
 				.ToList() ?? [];
 
+			var fileNames = new List<string>();
+			if (!string.IsNullOrWhiteSpace(path))
+				fileNames.Add(path);
+
+			if (item["media"]?["audioFiles"] is JArray audioFiles)
+			{
+				foreach (var af in audioFiles)
+				{
+					var fn = af["metadata"]?["filename"]?.Value<string>() ?? af["ino"]?.Value<string>();
+					if (!string.IsNullOrWhiteSpace(fn))
+						fileNames.Add(fn);
+				}
+			}
+			if (item["media"]?["libraryFiles"] is JArray libFiles)
+			{
+				foreach (var lf in libFiles)
+				{
+					var fn = lf["metadata"]?["filename"]?.Value<string>();
+					if (!string.IsNullOrWhiteSpace(fn))
+						fileNames.Add(fn);
+				}
+			}
+
 			results.Add(new SearchCandidate(
 				id,
 				NormalizeTitle(itemTitle),
 				NormalizeTitle(itemFullTitle),
-				authorList));
+				authorList,
+				asin,
+				fileNames));
 		}
 
 		return results;
@@ -483,14 +561,15 @@ public static class AudiobookshelfApiService
 		string title,
 		string? author,
 		string? series,
-		IEnumerable<string> filePaths)
+		IEnumerable<string> filePaths,
+		string? asin = null)
 	{
 		apiToken = AudiobookshelfTokenStorage.DecryptToken(apiToken) ?? "";
 
 		// Pre-check for existing item
 		try
 		{
-			if (await BookExistsAsync(serverUrl, apiToken, libraryId, title, author))
+			if (await BookExistsAsync(serverUrl, apiToken, libraryId, title, author, asin))
 			{
 				Serilog.Log.Logger.Information("Skipping Audiobookshelf upload: book '{Title}' already exists in library {LibraryId}", title, libraryId);
 				return UploadResult.AlreadyExists;

--- a/Source/FileLiberator/UploadToAudiobookshelf.cs
+++ b/Source/FileLiberator/UploadToAudiobookshelf.cs
@@ -23,6 +23,8 @@ public class UploadToAudiobookshelf : Processable, IProcessable<UploadToAudioboo
 		public string Message { get; } = message;
 	}
 
+	public bool CheckAsin { get; set; }
+
 	/// <summary>
 	/// Raised exactly once per processed book, classifying what happened and why.
 	/// <para/>
@@ -81,7 +83,8 @@ public class UploadToAudiobookshelf : Processable, IProcessable<UploadToAudioboo
 				title,
 				author,
 				series,
-				files);
+				files,
+				asin: CheckAsin ? libraryBook.Book.AudibleProductId : null);
 
 			if (result == AudiobookshelfApiService.UploadResult.Success)
 			{

--- a/Source/LibationCli/Options/UploadOptions.cs
+++ b/Source/LibationCli/Options/UploadOptions.cs
@@ -13,6 +13,9 @@ namespace LibationCli;
 	+ "Books are never re-downloaded and local files are never deleted.")]
 public class AbsUploadOptions : ProcessableOptionsBase
 {
+	[Option("check-asin", Required = false, Default = false, HelpText = "Check for existing books on Audiobookshelf by Audible Product ID (ASIN) in metadata and file paths, in addition to title matching.")]
+	public bool CheckAsin { get; set; }
+
 	protected override async Task ProcessAsync()
 	{
 		if (AudibleFileStorage.BooksDirectory is null)
@@ -35,6 +38,7 @@ public class AbsUploadOptions : ProcessableOptionsBase
 		var outcomes = new Dictionary<UploadToAudiobookshelf.UploadOutcome, int>();
 
 		var uploader = CreateProcessable<UploadToAudiobookshelf>();
+		uploader.CheckAsin = CheckAsin;
 
 		// Failures arrive here rather than through StatusHandler: an upload problem must never mark
 		// the book as a bad book. See UploadToAudiobookshelf.OutcomeDetermined.


### PR DESCRIPTION
### Summary
Adds an opt-in `--check-asin` flag to `libationcli abs upload` to detect existing books by Audible Product ID (ASIN) in Audiobookshelf metadata and audio file paths.

### Context
When a book's title in Audiobookshelf includes localized qualifiers (e.g. `(French Edition)`), the exact title matching check can fail and trigger a duplicate upload even though the file is already on the server with matching ASIN `[<ASIN>]`.

### Changes
- Added `--check-asin` flag to `AbsUploadOptions`.
- Added ASIN query and candidate matching (metadata `asin`, folder path, and file names) to `AudiobookshelfApiService.BookExistsAsync`.
- Falls back to standard title/author matching if no ASIN match is found.
